### PR TITLE
feat(api): add Pinata proxy route with rate limiting, PDF validation,…

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,157 @@
+import { NextResponse } from "next/server";
+
+const PINATA_BASE = "https://api.pinata.cloud";
+const PINATA_JWT = process.env.PINATA_JWT || "";
+const VIRUSTOTAL_API_KEY = process.env.VIRUSTOTAL_API_KEY || "";
+
+// In-memory rate limit store: walletAddress -> timestamps (ms)
+const RATE_LIMIT_WINDOW = 1000 * 60 * 60; // 1 hour
+const RATE_LIMIT_MAX = 10;
+const rateLimitMap = new Map<string, number[]>();
+
+async function virusScan(buffer: Buffer, filename: string) {
+  if (!VIRUSTOTAL_API_KEY) return { ok: true };
+
+  try {
+    const form = new FormData();
+    form.append("file", new Blob([buffer]), filename);
+
+    const uploadRes = await fetch("https://www.virustotal.com/api/v3/files", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${VIRUSTOTAL_API_KEY}` },
+      body: form as any,
+    });
+
+    if (!uploadRes.ok) return { ok: false, error: `VirusTotal upload failed: ${uploadRes.status}` };
+    const uploadJson = await uploadRes.json();
+    const analysisId = uploadJson.data?.id;
+    if (!analysisId) return { ok: false, error: "VirusTotal returned no analysis id" };
+
+    // Poll analysis result (short timeout)
+    const start = Date.now();
+    while (Date.now() - start < 15000) {
+      const analysisRes = await fetch(`https://www.virustotal.com/api/v3/analyses/${analysisId}`, {
+        headers: { Authorization: `Bearer ${VIRUSTOTAL_API_KEY}` },
+      });
+      if (!analysisRes.ok) break;
+      const analysisJson = await analysisRes.json();
+      const status = analysisJson.data?.attributes?.status;
+      if (status === "completed") {
+        const stats = analysisJson.data?.attributes?.stats || {};
+        const malicious = stats.malicious || 0;
+        const suspicious = stats.suspicious || 0;
+        const totalThreats = malicious + suspicious;
+        return { ok: totalThreats === 0, stats };
+      }
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+    return { ok: true, note: "Virus scan timed out — treated as clean" };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+function checkRateLimit(wallet: string) {
+  const now = Date.now();
+  const arr = rateLimitMap.get(wallet) || [];
+  const recent = arr.filter((t) => t > now - RATE_LIMIT_WINDOW);
+  if (recent.length >= RATE_LIMIT_MAX) return false;
+  recent.push(now);
+  rateLimitMap.set(wallet, recent);
+  return true;
+}
+
+export async function POST(req: Request) {
+  try {
+    if (!PINATA_JWT) {
+      return NextResponse.json({ error: "Pinata JWT not configured" }, { status: 500 });
+    }
+
+    const contentType = req.headers.get("content-type") || "";
+
+    // Handle multipart file upload
+    if (contentType.startsWith("multipart/form-data")) {
+      const form = await req.formData();
+      const file = form.get("file") as File | null;
+      const wallet = form.get("walletAddress")?.toString();
+
+      if (!file) return NextResponse.json({ error: "file is required" }, { status: 400 });
+      if (!wallet) return NextResponse.json({ error: "walletAddress is required" }, { status: 400 });
+
+      // Rate limit per wallet
+      if (!checkRateLimit(wallet)) {
+        return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
+      }
+
+      const arrayBuffer = await file.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+
+      // Size check
+      const MAX_BYTES = 10 * 1024 * 1024; // 10MB
+      if (buffer.length > MAX_BYTES) return NextResponse.json({ error: "File too large" }, { status: 400 });
+
+      // Magic byte validation for PDF: %PDF-
+      const magic = buffer.slice(0, 5).toString("utf8");
+      if (magic !== "%PDF-") return NextResponse.json({ error: "Invalid PDF file" }, { status: 400 });
+
+      // Virus scan (optional)
+      const scan = await virusScan(buffer, (file as any).name || "upload.pdf");
+      if (!scan.ok) return NextResponse.json({ error: `Virus scan failed: ${scan.error || JSON.stringify(scan.stats)}` }, { status: 400 });
+
+      // Forward to Pinata
+      const forwardForm = new FormData();
+      forwardForm.append("file", new Blob([buffer]), (file as any).name || "upload.pdf");
+      forwardForm.append("pinataMetadata", JSON.stringify({ name: (file as any).name || "upload.pdf" }));
+
+      const pinRes = await fetch(`${PINATA_BASE}/pinning/pinFileToIPFS`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${PINATA_JWT}` },
+        body: forwardForm as any,
+      });
+
+      const pinJson = await pinRes.json();
+      if (!pinRes.ok) {
+        return NextResponse.json({ error: `Pinata error: ${pinJson?.error || pinRes.status}` }, { status: 502 });
+      }
+
+      console.log("[pinata-proxy] upload", { wallet, ts: new Date().toISOString(), cid: pinJson.IpfsHash });
+      return NextResponse.json({ cid: pinJson.IpfsHash });
+    }
+
+    // Handle JSON metadata upload
+    if (contentType.includes("application/json")) {
+      const body = await req.json();
+      const wallet = body.walletAddress;
+      const metadata = body.metadata;
+      const name = body.name || "metadata";
+
+      if (!wallet || !metadata) return NextResponse.json({ error: "walletAddress and metadata are required" }, { status: 400 });
+
+      if (!checkRateLimit(wallet)) {
+        return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
+      }
+
+      // Optional: could run lightweight metadata checks here
+
+      const pinRes = await fetch(`${PINATA_BASE}/pinning/pinJSONToIPFS`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${PINATA_JWT}`,
+        },
+        body: JSON.stringify({ pinataMetadata: { name }, pinataContent: metadata }),
+      });
+
+      const pinJson = await pinRes.json();
+      if (!pinRes.ok) return NextResponse.json({ error: `Pinata error: ${pinJson?.error || pinRes.status}` }, { status: 502 });
+
+      console.log("[pinata-proxy] json", { wallet, ts: new Date().toISOString(), cid: pinJson.IpfsHash });
+      return NextResponse.json({ cid: pinJson.IpfsHash });
+    }
+
+    return NextResponse.json({ error: "Unsupported content type" }, { status: 415 });
+  } catch (err) {
+    console.error("[pinata-proxy] error", (err as Error).message);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/lib/ipfs.ts
+++ b/lib/ipfs.ts
@@ -5,10 +5,7 @@
 import type { InvoiceMetadata } from "@/types";
 import { withRetry } from "@/lib/utils";
 
-const PINATA_JWT = process.env.PINATA_JWT || "";
-const IPFS_GATEWAY =
-  process.env.NEXT_PUBLIC_IPFS_GATEWAY || "https://gateway.pinata.cloud/ipfs";
-const PINATA_BASE = "https://api.pinata.cloud";
+const IPFS_GATEWAY = process.env.NEXT_PUBLIC_IPFS_GATEWAY || "https://gateway.pinata.cloud/ipfs";
 
 // CID v0 (Qm...) or CID v1 (bafy...)
 const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|bafy[a-z2-7]{52,})$/;
@@ -28,7 +25,6 @@ function xhrUpload(
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open("POST", url);
-    xhr.setRequestHeader("Authorization", `Bearer ${PINATA_JWT}`);
 
     if (onProgress) {
       xhr.upload.onprogress = (e) => {
@@ -42,7 +38,7 @@ function xhrUpload(
       if (xhr.status >= 200 && xhr.status < 300) {
         resolve(JSON.parse(xhr.responseText));
       } else {
-        reject(new Error(`Pinata upload failed: ${xhr.status} ${xhr.statusText}`));
+        reject(new Error(`Upload failed: ${xhr.status} ${xhr.statusText}`));
       }
     };
 
@@ -57,19 +53,14 @@ function xhrUpload(
  */
 export async function uploadInvoicePDF(
   file: File,
+  walletAddress: string,
   onProgress?: (percent: number) => void
 ): Promise<string> {
   const form = new FormData();
   form.append("file", file);
-  form.append(
-    "pinataMetadata",
-    JSON.stringify({ name: `invoice-${file.name}` })
-  );
+  form.append("walletAddress", walletAddress);
 
-  const data = await withRetry(
-    () => xhrUpload(`${PINATA_BASE}/pinning/pinFileToIPFS`, form, onProgress),
-    3
-  );
+  const data = await withRetry(() => xhrUpload(`/api/upload`, form, onProgress), 3);
 
   validateCid(data.IpfsHash);
   return data.IpfsHash;
@@ -80,29 +71,24 @@ export async function uploadInvoicePDF(
  * Returns the validated CID.
  */
 export async function uploadInvoiceMetadata(
-  metadata: InvoiceMetadata
+  metadata: InvoiceMetadata,
+  walletAddress: string
 ): Promise<string> {
   const res = await withRetry(
     () =>
-      fetch(`${PINATA_BASE}/pinning/pinJSONToIPFS`, {
+      fetch(`/api/upload`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${PINATA_JWT}`,
-        },
-        body: JSON.stringify({
-          pinataMetadata: { name: `invoice-metadata-${metadata.invoiceNumber}` },
-          pinataContent: metadata,
-        }),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ walletAddress, metadata, name: `invoice-metadata-${metadata.invoiceNumber}` }),
       }).then(async (r) => {
-        if (!r.ok) throw new Error(`Pinata metadata upload failed: ${r.status}`);
-        return r.json() as Promise<{ IpfsHash: string }>;
+        if (!r.ok) throw new Error(`Metadata upload failed: ${r.status}`);
+        return r.json() as Promise<{ cid: string }>; // proxy returns { cid }
       }),
     3
   );
 
-  validateCid(res.IpfsHash);
-  return res.IpfsHash;
+  validateCid(res.cid);
+  return res.cid;
 }
 
 /**
@@ -111,14 +97,15 @@ export async function uploadInvoiceMetadata(
 export async function uploadInvoiceToIPFS(
   file: File,
   metadata: InvoiceMetadata,
+  walletAddress: string,
   onProgress?: (percent: number) => void
 ): Promise<{ pdfCid: string; metadataCid: string }> {
-  const pdfCid = await uploadInvoicePDF(file, onProgress);
+  const pdfCid = await uploadInvoicePDF(file, walletAddress, onProgress);
   const metadataCid = await uploadInvoiceMetadata({
     ...metadata,
     documentHash: pdfCid,
     documentUrl: ipfsUrl(pdfCid),
-  });
+  }, walletAddress);
   return { pdfCid, metadataCid };
 }
 
@@ -132,33 +119,30 @@ export function ipfsUrl(cid: string): string {
 export async function uploadFileToPinata(
   file: File,
   _name: string,
+  walletAddress?: string,
   onProgress?: (percent: number) => void
 ): Promise<string> {
-  return uploadInvoicePDF(file, onProgress);
+  // If walletAddress is provided, forward it; otherwise use empty string.
+  return uploadInvoicePDF(file, walletAddress || "", onProgress);
 }
 
 export async function uploadJsonToPinata(
   metadata: Record<string, unknown>,
   _name: string
 ): Promise<string> {
+  // Proxy JSON upload through our server; walletAddress is not available here
   const res = await withRetry(
     () =>
-      fetch(`${PINATA_BASE}/pinning/pinJSONToIPFS`, {
+      fetch(`/api/upload`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${PINATA_JWT}`,
-        },
-        body: JSON.stringify({
-          pinataMetadata: { name: _name },
-          pinataContent: metadata,
-        }),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ walletAddress: "", metadata, name: _name }),
       }).then(async (r) => {
-        if (!r.ok) throw new Error(`Pinata upload failed: ${r.status}`);
-        return r.json() as Promise<{ IpfsHash: string }>;
+        if (!r.ok) throw new Error(`Metadata upload failed: ${r.status}`);
+        return r.json() as Promise<{ cid: string }>;
       }),
     3
   );
-  validateCid(res.IpfsHash);
-  return res.IpfsHash;
+  validateCid(res.cid);
+  return res.cid;
 }

--- a/services/invoiceService.ts
+++ b/services/invoiceService.ts
@@ -4,7 +4,7 @@
  */
 import type { Invoice, CreateInvoiceFormData, PaginatedResponse, MarketplaceFilters, MarketplaceSort } from "@/types";
 import { MOCK_INVOICES } from "./mockData";
-import { uploadFileToPinata, uploadJsonToPinata } from "@/lib/ipfs";
+import { uploadFileToPinata, uploadInvoiceMetadata } from "@/lib/ipfs";
 import { invoiceContract, marketplaceContract } from "@/lib/stellar/contracts";
 import { submitTransaction, waitForTransaction } from "@/lib/stellar/client";
 
@@ -124,6 +124,7 @@ export async function prepareCreateInvoice(
   const docCid = await uploadFileToPinata(
     formData.document,
     `invoice-${formData.invoiceNumber}.pdf`,
+    ownerAddress,
     onProgress
   );
 
@@ -164,9 +165,9 @@ export async function prepareCreateInvoice(
     documentUrl: `${process.env.NEXT_PUBLIC_IPFS_GATEWAY || "https://gateway.pinata.cloud/ipfs"}/${docCid}`,
   };
 
-  const metadataCid = await uploadJsonToPinata(
+  const metadataCid = await uploadInvoiceMetadata(
     metadata,
-    `invoice-metadata-${formData.invoiceNumber}`
+    ownerAddress
   );
 
   // 3. Build mint transaction


### PR DESCRIPTION
closes #79 

Implemented a secure Next.js API proxy route for Pinata uploads using `app/api/upload/route.ts`. Moved `PINATA_JWT` to a server-only environment variable, added rate limiting (10 uploads per wallet/hour), validated uploads as PDF-only with 10MB max size and magic byte checking, integrated upload logging with wallet address + timestamp, and updated `lib/ipfs.ts` to upload through the API route without exposing the Pinata JWT to the client.
