### PR TITLE
feat(perf): image optimization, asset pipeline, and wallet SVG logos

### DIFF
--- a/components/wallet/WalletConnectModal.tsx
+++ b/components/wallet/WalletConnectModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import { Wallet, ChevronRight, Loader2, CheckCircle2, AlertCircle, ExternalLink } from "lucide-react";
 import {
@@ -20,7 +21,7 @@ const WALLETS = [
     id: "freighter",
     name: "Freighter",
     description: "Browser extension by Stellar Development Foundation",
-    icon: "🔑",
+    icon: "/wallets/freighter.svg",
     popular: true,
     installUrl: "https://www.freighter.app/",
     isAvailable: () => typeof window !== "undefined" && !!(window as Window & { freighter?: unknown }).freighter,
@@ -29,7 +30,7 @@ const WALLETS = [
     id: "xbull",
     name: "xBull Wallet",
     description: "Feature-rich Stellar wallet",
-    icon: "🐂",
+    icon: "/wallets/xbull.svg",
     popular: false,
     installUrl: "https://xbull.app/",
     isAvailable: () => typeof window !== "undefined" && !!(window as Window & { xBullSDK?: unknown }).xBullSDK,
@@ -38,7 +39,7 @@ const WALLETS = [
     id: "lobstr",
     name: "LOBSTR",
     description: "Simple and secure Stellar wallet",
-    icon: "🦞",
+    icon: "/wallets/lobstr.svg",
     popular: false,
     installUrl: "https://lobstr.co/",
     isAvailable: () => typeof window !== "undefined" && !!(window as Window & { lobstr?: unknown }).lobstr,
@@ -47,10 +48,10 @@ const WALLETS = [
     id: "albedo",
     name: "Albedo",
     description: "Web-based Stellar signer — no extension needed",
-    icon: "✨",
+    icon: "/wallets/albedo.svg",
     popular: false,
     installUrl: "https://albedo.link/",
-    isAvailable: () => true, // web-based, always available
+    isAvailable: () => true,
   },
 ];
 
@@ -134,7 +135,13 @@ export function WalletConnectModal() {
                   isError && "border-destructive/40 bg-destructive/5",
                 )}
               >
-                <span className="text-2xl">{wallet.icon}</span>
+                <Image
+                  src={wallet.icon}
+                  alt={wallet.name}
+                  width={32}
+                  height={32}
+                  className="shrink-0 rounded-lg"
+                />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium text-foreground">{wallet.name}</span>

--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,13 @@ const CSP_DIRECTIVES = {
     "https://ipfs.io",
     "https://gateway.pinata.cloud",
     "https://cloudflare-ipfs.com",
+    "https://nftstorage.link",
+    "https://*.ipfs.dweb.link",
+    // Wallet provider icons
+    "https://assets.freighter.app",
+    "https://xbull.app",
+    "https://lobstr.co",
+    "https://albedo.link",
   ],
 
   // Fonts: self only (Google Fonts are loaded via next/font, served from self)
@@ -116,10 +123,26 @@ const nextConfig = {
   },
 
   images: {
+    // Serve modern formats — Next.js negotiates AVIF → WebP → original
+    formats: ["image/avif", "image/webp"],
+
+    // Standard responsive breakpoints
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256],
+
     remotePatterns: [
+      // IPFS gateways (invoice document thumbnails / metadata images)
       { protocol: "https", hostname: "ipfs.io" },
       { protocol: "https", hostname: "gateway.pinata.cloud" },
       { protocol: "https", hostname: "cloudflare-ipfs.com" },
+      { protocol: "https", hostname: "nftstorage.link" },
+      { protocol: "https", hostname: "*.ipfs.dweb.link" },
+
+      // Wallet provider icon CDNs
+      { protocol: "https", hostname: "assets.freighter.app" },
+      { protocol: "https", hostname: "xbull.app" },
+      { protocol: "https", hostname: "lobstr.co" },
+      { protocol: "https", hostname: "albedo.link" },
     ],
   },
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,10 +2,19 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
+    formats: ["image/avif", "image/webp"],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256],
     remotePatterns: [
       { protocol: "https", hostname: "ipfs.io" },
       { protocol: "https", hostname: "gateway.pinata.cloud" },
       { protocol: "https", hostname: "cloudflare-ipfs.com" },
+      { protocol: "https", hostname: "nftstorage.link" },
+      { protocol: "https", hostname: "*.ipfs.dweb.link" },
+      { protocol: "https", hostname: "assets.freighter.app" },
+      { protocol: "https", hostname: "xbull.app" },
+      { protocol: "https", hostname: "lobstr.co" },
+      { protocol: "https", hostname: "albedo.link" },
     ],
   },
   experimental: {

--- a/public/wallets/albedo.svg
+++ b/public/wallets/albedo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
+  <rect width="40" height="40" rx="10" fill="#8B5CF6"/>
+  <path d="M20 9l2.5 7.5H30l-6 4.5 2.5 7.5L20 24l-6.5 4.5 2.5-7.5-6-4.5h7.5L20 9z" fill="#fff"/>
+</svg>

--- a/public/wallets/freighter.svg
+++ b/public/wallets/freighter.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
+  <rect width="40" height="40" rx="10" fill="#6366F1"/>
+  <path d="M10 14h20v3H10zM10 20h14v3H10zM10 26h17v3H10z" fill="#fff"/>
+</svg>

--- a/public/wallets/lobstr.svg
+++ b/public/wallets/lobstr.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
+  <rect width="40" height="40" rx="10" fill="#14B8A6"/>
+  <path d="M20 8c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12S26.627 8 20 8zm0 4a8 8 0 110 16A8 8 0 0120 12zm0 3a5 5 0 100 10A5 5 0 0020 15z" fill="#fff"/>
+</svg>

--- a/public/wallets/xbull.svg
+++ b/public/wallets/xbull.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
+  <rect width="40" height="40" rx="10" fill="#0EA5E9"/>
+  <path d="M12 12l8 8-8 8h5l5.5-5.5L28 28h5l-8.5-8.5L33 12h-5l-5 5-5-5h-6z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
closes #55 


- Add AVIF/WebP formats, deviceSizes, imageSizes to next.config images
- Extend remotePatterns: nftstorage.link, *.ipfs.dweb.link, wallet CDNs (freighter, xbull, lobstr, albedo)
- Update CSP img-src to match new remote origins
- Add SVG logos for all four wallet providers (public/wallets/*.svg)
- Replace emoji icons in WalletConnectModal with next/image <Image> (32×32, explicit dimensions — no layout shift)
- Sync next.config.ts image settings with next.config.js