### PR TITLE
feat: add environment variable validation on startup

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
+import { env } from "@/lib/env";
 
 const PINATA_BASE = "https://api.pinata.cloud";
-const PINATA_JWT = process.env.PINATA_JWT || "";
-const VIRUSTOTAL_API_KEY = process.env.VIRUSTOTAL_API_KEY || "";
+const PINATA_JWT = env.PINATA_JWT ?? "";
+const VIRUSTOTAL_API_KEY = env.VIRUSTOTAL_API_KEY ?? "";
 
 // In-memory rate limit store: walletAddress -> timestamps (ms)
 const RATE_LIMIT_WINDOW = 1000 * 60 * 60; // 1 hour

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Providers } from "./providers";
 import { Navbar } from "@/components/layout/Navbar";
 import { PageTransition } from "@/components/layout/PageTransition";
+import { env } from "@/lib/env";
 
 const geistSans = Inter({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = JetBrains_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
@@ -13,9 +14,7 @@ const geistMono = JetBrains_Mono({ variable: "--font-geist-mono", subsets: ["lat
 // The `template` ensures every page title follows "Page Name | Kora Protocol".
 export const metadata: Metadata = {
   // metadataBase is required for absolute URLs in openGraph/twitter images
-  metadataBase: new URL(
-    process.env.NEXT_PUBLIC_APP_URL ?? "https://kora-protocol.vercel.app"
-  ),
+  metadataBase: new URL(env.NEXT_PUBLIC_APP_URL),
 
   title: {
     default: "Kora Protocol — On-Chain Invoice Financing",

--- a/app/marketplace/[id]/page.tsx
+++ b/app/marketplace/[id]/page.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/lib/utils";
 import { validateRouteId, safeIpfsUrl, safeExternalUrl, safeStellarTxUrl } from "@/lib/security";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { env } from "@/lib/env";
 
 export default function InvoiceDetailPage() {
   const params = useParams<{ id: string }>();
@@ -129,7 +130,7 @@ Stellar Testnet Transaction Hash: ${txHash}`);
           };
 
           // 1. Update Memory array directly so the list pages show dynamic updates
-          if (process.env.NEXT_PUBLIC_ENABLE_MOCK_DATA === "true") {
+          if (env.NEXT_PUBLIC_ENABLE_MOCK_DATA) {
             const mockIdx = MOCK_INVOICES.findIndex((i) => i.id === id);
             if (mockIdx !== -1) {
               MOCK_INVOICES[mockIdx] = updatedInvoice;
@@ -328,7 +329,7 @@ Stellar Testnet Transaction Hash: ${txHash}`);
                 {metadata.documentHash ? (
                   <div className="overflow-hidden rounded-lg bg-zinc-900 border border-zinc-800 p-1">
                     <iframe
-                      src={safeIpfsUrl(metadata.documentHash, process.env.NEXT_PUBLIC_IPFS_GATEWAY) + "#toolbar=0&navpanes=0&scrollbar=0"}
+                      src={safeIpfsUrl(metadata.documentHash, env.NEXT_PUBLIC_IPFS_GATEWAY) + "#toolbar=0&navpanes=0&scrollbar=0"}
                       className="w-full h-[450px] rounded"
                       title="Invoice PDF Document"
                     />
@@ -338,7 +339,7 @@ Stellar Testnet Transaction Hash: ${txHash}`);
                         <code className="text-zinc-300 font-mono text-[10px] select-all">{metadata.documentHash}</code>
                       </div>
                       <a
-                        href={safeIpfsUrl(metadata.documentHash, process.env.NEXT_PUBLIC_IPFS_GATEWAY) || safeExternalUrl(metadata.documentUrl)}
+                        href={safeIpfsUrl(metadata.documentHash, env.NEXT_PUBLIC_IPFS_GATEWAY) || safeExternalUrl(metadata.documentUrl)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1.5 rounded-md bg-zinc-800 px-3 py-1.5 font-medium text-zinc-200 border border-zinc-700 hover:bg-zinc-700 hover:text-zinc-100 transition-colors"

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -11,6 +11,7 @@ const WalletConnectModal = dynamic(() => import("@/components/wallet/WalletConne
 });
 import { ThemeProvider } from "@/components/layout/ThemeProvider";
 import { useUIStore } from "@/store/uiStore";
+import { env } from "@/lib/env";
 
 function ThemedToaster() {
   const theme = useUIStore((s) => s.theme);
@@ -44,7 +45,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         {children}
         <WalletConnectModal />
         <ThemedToaster />
-        {process.env.NEXT_PUBLIC_ENABLE_DEVTOOLS === "true" && (
+        {env.NEXT_PUBLIC_ENABLE_DEVTOOLS && (
           <ReactQueryDevtools initialIsOpen={false} />
         )}
       </ThemeProvider>

--- a/hooks/useTransaction.ts
+++ b/hooks/useTransaction.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { useWallet } from "./useWallet";
 import { rpc, submitTransaction } from "@/lib/stellar/client";
+import { env } from "@/lib/env";
 import * as StellarSdk from "@stellar/stellar-sdk";
 
 export type TxLifecycleStatus =
@@ -81,7 +82,7 @@ export function useTransaction() {
           setStage("simulating");
           const tx = StellarSdk.TransactionBuilder.fromXDR(
             unsignedXdr,
-            process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE || StellarSdk.Networks.TESTNET
+            env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE
           );
           const sim = await rpc.simulateTransaction(tx);
           if (StellarSdk.rpc.Api.isSimulationError(sim)) {

--- a/hooks/useUsdcBalance.ts
+++ b/hooks/useUsdcBalance.ts
@@ -2,8 +2,9 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { getAccountBalances } from "@/lib/stellar/client";
+import { env } from "@/lib/env";
 
-const USE_MOCK = process.env.NEXT_PUBLIC_ENABLE_MOCK_DATA === "true";
+const USE_MOCK = env.NEXT_PUBLIC_ENABLE_MOCK_DATA;
 
 /**
  * Returns the wallet's USDC balance as a number.

--- a/hooks/useWallet.ts
+++ b/hooks/useWallet.ts
@@ -13,12 +13,13 @@ import {
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { useWalletStore } from "@/store";
 import { getAccountBalances } from "@/lib/stellar/client";
+import { env } from "@/lib/env";
 import type { WalletProvider } from "@/types";
 
 let kit: StellarWalletsKit | null = null;
 
 const WALLET_NETWORK =
-  process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet"
+  env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet"
     ? WalletNetwork.PUBLIC
     : WalletNetwork.TESTNET;
 
@@ -88,7 +89,7 @@ export function useWallet() {
   const signTransaction = useCallback(
     async (xdr: string): Promise<string> => {
       if (!isConnected) throw new Error("Wallet not connected");
-      if (process.env.NEXT_PUBLIC_ENABLE_MOCK_DATA === "true" || xdr.startsWith("mock_")) {
+      if (env.NEXT_PUBLIC_ENABLE_MOCK_DATA || xdr.startsWith("mock_")) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         return `${xdr}_signed`;
       }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+// ─── Client-safe (NEXT_PUBLIC_*) schema ──────────────────────────────────────
+const clientSchema = z.object({
+  NEXT_PUBLIC_STELLAR_NETWORK: z.enum(["testnet", "mainnet", "futurenet"]).default("testnet"),
+  NEXT_PUBLIC_STELLAR_RPC_URL: z.string().url(),
+  NEXT_PUBLIC_STELLAR_HORIZON_URL: z.string().url(),
+  NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE: z.string().min(1),
+  NEXT_PUBLIC_INVOICE_CONTRACT_ID: z.string().min(1),
+  NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID: z.string().min(1),
+  NEXT_PUBLIC_TOKEN_CONTRACT_ID: z.string().min(1),
+  NEXT_PUBLIC_IPFS_GATEWAY: z.string().url(),
+  NEXT_PUBLIC_APP_URL: z.string().url().default("http://localhost:3000"),
+  NEXT_PUBLIC_APP_NAME: z.string().default("Kora"),
+  NEXT_PUBLIC_APP_DESCRIPTION: z.string().default("On-chain Invoice Financing Protocol"),
+  NEXT_PUBLIC_ENABLE_MOCK_DATA: z
+    .string()
+    .transform((v) => v === "true")
+    .default("false"),
+  NEXT_PUBLIC_ENABLE_DEVTOOLS: z
+    .string()
+    .transform((v) => v === "true")
+    .default("false"),
+});
+
+// ─── Server-only schema ───────────────────────────────────────────────────────
+const serverSchema = z.object({
+  PINATA_JWT: z.string().min(1),
+  PINATA_API_KEY: z.string().optional(),
+  PINATA_SECRET_API_KEY: z.string().optional(),
+  VIRUSTOTAL_API_KEY: z.string().optional(),
+});
+
+// ─── Parse & validate ─────────────────────────────────────────────────────────
+function parseEnv() {
+  const isServer = typeof window === "undefined";
+  const isProd = process.env.NODE_ENV === "production";
+
+  const clientResult = clientSchema.safeParse(process.env);
+  if (!clientResult.success) {
+    const msg = clientResult.error.issues
+      .map((i) => `  ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    throw new Error(`❌ Invalid environment variables:\n${msg}`);
+  }
+
+  if (isServer) {
+    const serverResult = serverSchema.safeParse(process.env);
+    if (!serverResult.success) {
+      const issues = serverResult.error.issues;
+      const required = issues.filter((i) => i.code !== "z.ZodIssueCode.invalid_type" || i.received !== "undefined");
+      if (isProd && required.length > 0) {
+        const msg = required.map((i) => `  ${i.path.join(".")}: ${i.message}`).join("\n");
+        throw new Error(`❌ Missing required server environment variables:\n${msg}`);
+      } else if (!isProd) {
+        issues.forEach((i) => {
+          console.warn(`⚠️  Optional env var missing: ${i.path.join(".")}`);
+        });
+      }
+      return { ...clientResult.data, ...serverSchema.partial().parse(process.env) };
+    }
+    return { ...clientResult.data, ...serverResult.data };
+  }
+
+  return clientResult.data;
+}
+
+export const env = parseEnv();

--- a/lib/ipfs.ts
+++ b/lib/ipfs.ts
@@ -4,8 +4,9 @@
  */
 import type { InvoiceMetadata } from "@/types";
 import { withRetry } from "@/lib/utils";
+import { env } from "@/lib/env";
 
-const IPFS_GATEWAY = process.env.NEXT_PUBLIC_IPFS_GATEWAY || "https://gateway.pinata.cloud/ipfs";
+const IPFS_GATEWAY = env.NEXT_PUBLIC_IPFS_GATEWAY;
 
 // CID v0 (Qm...) or CID v1 (bafy...)
 const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|bafy[a-z2-7]{52,})$/;

--- a/lib/stellar/client.ts
+++ b/lib/stellar/client.ts
@@ -3,17 +3,11 @@
  * Reads network config from environment variables.
  */
 import * as StellarSdk from "@stellar/stellar-sdk";
+import { env } from "@/lib/env";
 
-const RPC_URL =
-  process.env.NEXT_PUBLIC_STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
-
-const NETWORK_PASSPHRASE =
-  process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ||
-  StellarSdk.Networks.TESTNET;
-
-const HORIZON_URL =
-  process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL ||
-  "https://horizon-testnet.stellar.org";
+const RPC_URL = env.NEXT_PUBLIC_STELLAR_RPC_URL;
+const NETWORK_PASSPHRASE = env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE;
+const HORIZON_URL = env.NEXT_PUBLIC_STELLAR_HORIZON_URL;
 
 // Soroban RPC client
 export const rpc = new StellarSdk.rpc.Server(RPC_URL, { allowHttp: false });

--- a/lib/stellar/contracts.ts
+++ b/lib/stellar/contracts.ts
@@ -5,6 +5,7 @@
  */
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { rpc, networkConfig } from "./client";
+import { env } from "@/lib/env";
 import type {
   MintInvoiceParams,
   FundInvoiceParams,
@@ -136,7 +137,7 @@ async function readCall<T>(
 
 // ─── Invoice Contract ─────────────────────────────────────────────────────────
 
-const INVOICE_CONTRACT_ID = process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID ?? "";
+const INVOICE_CONTRACT_ID = env.NEXT_PUBLIC_INVOICE_CONTRACT_ID;
 
 class InvoiceContractClient {
   readonly contractId = INVOICE_CONTRACT_ID;
@@ -199,8 +200,7 @@ class InvoiceContractClient {
 
 // ─── Marketplace Contract ─────────────────────────────────────────────────────
 
-const MARKETPLACE_CONTRACT_ID =
-  process.env.NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID ?? "";
+const MARKETPLACE_CONTRACT_ID = env.NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID;
 
 class MarketplaceContractClient {
   readonly contractId = MARKETPLACE_CONTRACT_ID;

--- a/services/invoiceService.ts
+++ b/services/invoiceService.ts
@@ -8,8 +8,9 @@ import { uploadFileToPinata, uploadInvoiceMetadata } from "@/lib/ipfs";
 import { invoiceContract, marketplaceContract } from "@/lib/stellar/contracts";
 import { submitTransaction, waitForTransaction } from "@/lib/stellar/client";
 import { sanitizeIpfsMetadata } from "@/lib/security";
+import { env } from "@/lib/env";
 
-const USE_MOCK = process.env.NEXT_PUBLIC_ENABLE_MOCK_DATA === "true";
+const USE_MOCK = env.NEXT_PUBLIC_ENABLE_MOCK_DATA;
 
 // ─── Read Operations ──────────────────────────────────────────────────────────
 
@@ -86,7 +87,7 @@ export async function fetchInvoiceById(id: string): Promise<Invoice | null> {
  * All fields from untrusted external sources are sanitized before use.
  */
 export async function fetchIpfsMetadata(cid: string): Promise<Record<string, unknown>> {
-  const gateway = process.env.NEXT_PUBLIC_IPFS_GATEWAY || "https://gateway.pinata.cloud/ipfs";
+  const gateway = env.NEXT_PUBLIC_IPFS_GATEWAY;
   // Validate CID before making the request
   if (!/^[a-zA-Z0-9+/=_-]{10,100}$/.test(cid)) {
     throw new Error("Invalid IPFS CID");
@@ -179,7 +180,7 @@ export async function prepareCreateInvoice(
     jurisdiction: formData.jurisdiction,
     category: formData.category,
     documentHash: docCid,
-    documentUrl: `${process.env.NEXT_PUBLIC_IPFS_GATEWAY || "https://gateway.pinata.cloud/ipfs"}/${docCid}`,
+    documentUrl: `${env.NEXT_PUBLIC_IPFS_GATEWAY}/${docCid}`,
   };
 
   const metadataCid = await uploadInvoiceMetadata(

--- a/store/walletStore.ts
+++ b/store/walletStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { env } from "@/lib/env";
 import type { WalletState, WalletProvider } from "@/types";
 
 interface WalletStore extends WalletState {
@@ -18,9 +19,7 @@ export const useWalletStore = create<WalletStore>()(
       publicKey: null,
       isConnected: false,
       provider: null,
-      network:
-        (process.env.NEXT_PUBLIC_STELLAR_NETWORK as WalletState["network"]) ||
-        "testnet",
+      network: (env.NEXT_PUBLIC_STELLAR_NETWORK as WalletState["network"]) || "testnet",
       balance: null,
       isVerified: false,
       verifiedAt: null,


### PR DESCRIPTION
closes #56 


- Add lib/env.ts with Zod schema for all env vars from .env.example
- Distinguish client-safe (NEXT_PUBLIC_*) vs server-only vars (PINATA_JWT, VIRUSTOTAL_API_KEY)
- Boolean feature flags transformed from string to boolean via Zod
- In development: warns on missing optional server vars; in production: hard fails
- Validation runs at module load time via layout.tsx import (server component)
- Replace all process.env.NEXT_PUBLIC_* usages with typed env.* across: lib/stellar/client.ts, lib/stellar/contracts.ts, lib/ipfs.ts, hooks/useWallet.ts, hooks/useUsdcBalance.ts, hooks/useTransaction.ts, store/walletStore.ts, services/invoiceService.ts, app/layout.tsx, app/providers.tsx, app/marketplace/[id]/page.tsx, app/api/upload/route.ts