### PR TITLE
feat: investor yield claim flow (#61) and debounce/throttle hooks (#68)

### DIFF
--- a/__tests__/hooks.test.ts
+++ b/__tests__/hooks.test.ts
@@ -1,0 +1,218 @@
+import { renderHook, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { useDebounce } from "../hooks/useDebounce";
+import { useThrottle } from "../hooks/useThrottle";
+import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
+import { useResizeObserver } from "../hooks/useResizeObserver";
+import { createRef } from "react";
+
+// ─── useDebounce ──────────────────────────────────────────────────────────────
+
+describe("useDebounce", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("returns initial value immediately", () => {
+    const { result } = renderHook(() => useDebounce("hello", 300));
+    expect(result.current).toBe("hello");
+  });
+
+  it("does not update before delay elapses", () => {
+    const { result, rerender } = renderHook(({ v }) => useDebounce(v, 300), {
+      initialProps: { v: "a" },
+    });
+    rerender({ v: "b" });
+    act(() => vi.advanceTimersByTime(200));
+    expect(result.current).toBe("a");
+  });
+
+  it("updates after delay elapses", () => {
+    const { result, rerender } = renderHook(({ v }) => useDebounce(v, 300), {
+      initialProps: { v: "a" },
+    });
+    rerender({ v: "b" });
+    act(() => vi.advanceTimersByTime(300));
+    expect(result.current).toBe("b");
+  });
+
+  it("resets timer on rapid changes", () => {
+    const { result, rerender } = renderHook(({ v }) => useDebounce(v, 300), {
+      initialProps: { v: "a" },
+    });
+    rerender({ v: "b" });
+    act(() => vi.advanceTimersByTime(200));
+    rerender({ v: "c" });
+    act(() => vi.advanceTimersByTime(200));
+    expect(result.current).toBe("a"); // still not updated
+    act(() => vi.advanceTimersByTime(100));
+    expect(result.current).toBe("c");
+  });
+
+  it("cancels pending update on unmount", () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ v }) => useDebounce(v, 300),
+      { initialProps: { v: "a" } }
+    );
+    rerender({ v: "b" });
+    unmount();
+    act(() => vi.advanceTimersByTime(300));
+    // No error thrown — timer was cleaned up
+    expect(result.current).toBe("a");
+  });
+});
+
+// ─── useThrottle ──────────────────────────────────────────────────────────────
+
+describe("useThrottle", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("returns initial value immediately", () => {
+    const { result } = renderHook(() => useThrottle("hello", 200));
+    expect(result.current).toBe("hello");
+  });
+
+  it("emits updated value after interval elapses", () => {
+    const { result, rerender } = renderHook(({ v }) => useThrottle(v, 200), {
+      initialProps: { v: "a" },
+    });
+    rerender({ v: "b" });
+    // Advance past the interval to trigger the trailing update
+    act(() => vi.advanceTimersByTime(200));
+    expect(result.current).toBe("b");
+  });
+
+  it("emits only the last value when updated rapidly", () => {
+    const { result, rerender } = renderHook(({ v }) => useThrottle(v, 200), {
+      initialProps: { v: "a" },
+    });
+    rerender({ v: "b" });
+    act(() => vi.advanceTimersByTime(50));
+    rerender({ v: "c" });
+    act(() => vi.advanceTimersByTime(50));
+    rerender({ v: "d" });
+    // Still within interval — not yet updated
+    expect(result.current).toBe("a");
+    // After interval, trailing edge fires with latest value
+    act(() => vi.advanceTimersByTime(200));
+    expect(result.current).toBe("d");
+  });
+});
+
+// ─── useDebouncedCallback ─────────────────────────────────────────────────────
+
+describe("useDebouncedCallback", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("does not call fn before delay", () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(fn, 300));
+    act(() => result.current("x"));
+    act(() => vi.advanceTimersByTime(200));
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("calls fn after delay with correct args", () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(fn, 300));
+    act(() => result.current("hello"));
+    act(() => vi.advanceTimersByTime(300));
+    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledWith("hello");
+  });
+
+  it("resets timer on rapid calls", () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(fn, 300));
+    act(() => result.current("a"));
+    act(() => vi.advanceTimersByTime(200));
+    act(() => result.current("b"));
+    act(() => vi.advanceTimersByTime(300));
+    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledWith("b");
+  });
+
+  it("cancel() prevents the pending call", () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedCallback(fn, 300));
+    act(() => result.current("x"));
+    act(() => result.current.cancel());
+    act(() => vi.advanceTimersByTime(300));
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("cancels on unmount", () => {
+    const fn = vi.fn();
+    const { result, unmount } = renderHook(() => useDebouncedCallback(fn, 300));
+    act(() => result.current("x"));
+    unmount();
+    act(() => vi.advanceTimersByTime(300));
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+// ─── useResizeObserver ────────────────────────────────────────────────────────
+
+describe("useResizeObserver", () => {
+  let observeMock: ReturnType<typeof vi.fn>;
+  let disconnectMock: ReturnType<typeof vi.fn>;
+  let observerCallback: ResizeObserverCallback;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    observeMock = vi.fn();
+    disconnectMock = vi.fn();
+
+    vi.stubGlobal(
+      "ResizeObserver",
+      vi.fn((cb: ResizeObserverCallback) => {
+        observerCallback = cb;
+        return { observe: observeMock, disconnect: disconnectMock };
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns {0,0} initially", () => {
+    const ref = createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useResizeObserver(ref));
+    expect(result.current).toEqual({ width: 0, height: 0 });
+  });
+
+  it("does not observe when ref is null", () => {
+    const ref = createRef<HTMLDivElement>();
+    renderHook(() => useResizeObserver(ref));
+    expect(observeMock).not.toHaveBeenCalled();
+  });
+
+  it("observes element and returns throttled size", () => {
+    const el = document.createElement("div");
+    const ref = { current: el };
+
+    const { result } = renderHook(() => useResizeObserver(ref));
+    expect(observeMock).toHaveBeenCalledWith(el);
+
+    act(() => {
+      observerCallback(
+        [{ contentRect: { width: 400, height: 200 } } as ResizeObserverEntry],
+        {} as ResizeObserver
+      );
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toEqual({ width: 400, height: 200 });
+  });
+
+  it("disconnects observer on unmount", () => {
+    const el = document.createElement("div");
+    const ref = { current: el };
+    const { unmount } = renderHook(() => useResizeObserver(ref));
+    unmount();
+    expect(disconnectMock).toHaveBeenCalled();
+  });
+});

--- a/app/dashboard/investor/page.tsx
+++ b/app/dashboard/investor/page.tsx
@@ -1,209 +1,156 @@
 "use client";
 
+import { useState, useMemo } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { Store, TrendingUp, DollarSign, BarChart3, Clock } from "lucide-react";
+import {
+  Store,
+  TrendingUp,
+  DollarSign,
+  BarChart3,
+  Clock,
+  CheckCircle2,
+  Loader2,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { StatCard } from "@/components/ui/stat-card";
 import { Progress } from "@/components/ui/progress";
 import dynamic from "next/dynamic";
-const DataTable = dynamic<any>(() => import("@/components/ui/data-table").then((m) => m.DataTable), {
-  ssr: false,
-  loading: () => <DashboardSkeleton statCount={4} tableRows={5} tableCols={9} />,
-});
+const DataTable = dynamic<any>(
+  () => import("@/components/ui/data-table").then((m) => m.DataTable),
+  {
+    ssr: false,
+    loading: () => (
+      <DashboardSkeleton statCount={4} tableRows={5} tableCols={9} />
+    ),
+  }
+);
 import { useWallet } from "@/hooks/useWallet";
 import { useUIStore } from "@/store";
 import { usePositions } from "@/hooks/usePositions";
 import { useTransaction } from "@/hooks/useTransaction";
 import { prepareClaimPosition } from "@/services/invoiceService";
-import { MOCK_INVOICES } from "@/services/mockData";
 import { RiskBadge } from "@/components/ui/badge";
 import { DashboardSkeleton } from "@/components/ui/skeleton";
-import {
-  formatCurrency,
-  formatDate,
-  formatApr,
-  RISK_TIER_COLORS,
-  cn,
-} from "@/lib/utils";
+import { formatCurrency, formatDate, formatApr, RISK_TIER_COLORS, cn } from "@/lib/utils";
 import type { ColumnDef } from "@/types/table";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 
+// ─── Types ────────────────────────────────────────────────────────────────────
+
 interface InvestorPosition {
   id: string;
-  invoice: (typeof MOCK_INVOICES)[number];
+  invoice: {
+    id: string;
+    metadata: { invoiceNumber: string; category: string; debtorName: string };
+    terms: { apr: number; repaymentDate: string; discountRate: number };
+    riskTier: string;
+  };
   investedAmount: number;
   expectedReturn: number;
+  yieldEarned: number;
   status: "active" | "repaid";
+  claimed: boolean;
 }
 
-// Keep a small mock fallback but prefer hook data
-const POSITIONS: InvestorPosition[] = MOCK_INVOICES.slice(0, 4).map((inv, i) => ({
-  id: inv.id,
-  invoice: inv,
-  investedAmount: [15000, 50000, 5000, 100000][i],
-  expectedReturn: [15000, 50000, 5000, 100000][i] * (1 + inv.terms.discountRate),
-  status: inv.status === "repaid" ? "repaid" : "active",
-}));
-
-const POSITION_COLUMNS: ColumnDef<InvestorPosition>[] = [
-  {
-    id: "invoice",
-    header: "Invoice",
-    accessor: (row) => row.invoice.metadata.invoiceNumber,
-    cell: (row) => (
-      <div>
-        <p className="font-medium text-foreground">{row.invoice.metadata.invoiceNumber}</p>
-        <p className="text-xs text-muted-foreground">{row.invoice.metadata.category}</p>
-      </div>
-    ),
-  },
-  {
-    id: "debtor",
-    header: "Debtor",
-    accessor: (row) => row.invoice.metadata.debtorName,
-    cell: (row) => <span className="text-muted-foreground">{row.invoice.metadata.debtorName}</span>,
-  },
-  {
-    id: "invested",
-    header: "Invested",
-    accessor: (row) => row.investedAmount,
-    cell: (row) => (
-      <span className="font-medium text-foreground">
-        {formatCurrency(row.investedAmount, "USDC", true)}
-      </span>
-    ),
-  },
-  {
-    id: "expected",
-    header: "Expected Return",
-    accessor: (row) => row.expectedReturn,
-    cell: (row) => (
-      <span className="font-medium text-success">
-        {formatCurrency(row.expectedReturn, "USDC", true)}
-      </span>
-    ),
-  },
-  {
-    id: "yield",
-    header: "Yield",
-    accessor: (row) => row.expectedReturn - row.investedAmount,
-    cell: (row) => (
-      <span className="text-primary">
-        +{formatCurrency(row.expectedReturn - row.investedAmount, "USDC", true)}
-      </span>
-    ),
-  },
-  {
-    id: "apr",
-    header: "APR",
-    accessor: (row) => row.invoice.terms.apr,
-    cell: (row) => (
-      <span className="font-medium text-primary">{formatApr(row.invoice.terms.apr)}</span>
-    ),
-  },
-  {
-    id: "risk",
-    header: "Risk",
-    accessor: (row) => row.invoice.riskTier,
-    cell: (row) => <RiskBadge tier={row.invoice.riskTier} />,
-  },
-  {
-    id: "due",
-    header: "Due Date",
-    accessor: (row) => row.invoice.terms.repaymentDate,
-    cell: (row) => (
-      <span className="text-xs text-muted-foreground">
-        {formatDate(row.invoice.terms.repaymentDate)}
-      </span>
-    ),
-  },
-  {
-    id: "actions",
-    header: "",
-    sortable: false,
-    cell: (row) => (
-      <Link
-        href={`/marketplace/${row.invoice.id}`}
-        className="text-xs text-primary hover:opacity-80"
-      >
-        View →
-      </Link>
-    ),
-  },
-];
-
-const totalInvested = POSITIONS.reduce((s, p) => s + p.investedAmount, 0);
-const totalExpected = POSITIONS.reduce((s, p) => s + p.expectedReturn, 0);
-const totalYield = totalExpected - totalInvested;
-
-const STATS = [
-  {
-    label: "Portfolio Value",
-    value: formatCurrency(totalInvested, "USDC", true),
-    change: "4 active positions",
-    changePositive: true,
-    icon: <DollarSign className="h-4 w-4" />,
-  },
-  {
-    label: "Expected Yield",
-    value: formatCurrency(totalYield, "USDC", true),
-    change: `${((totalYield / totalInvested) * 100).toFixed(1)}% return`,
-    changePositive: true,
-    icon: <TrendingUp className="h-4 w-4" />,
-  },
-  {
-    label: "Active Positions",
-    value: POSITIONS.length.toString(),
-    icon: <BarChart3 className="h-4 w-4" />,
-  },
-  {
-    label: "Avg. APR",
-    value: `${(POSITIONS.reduce((s, p) => s + p.invoice.terms.apr, 0) / POSITIONS.length).toFixed(1)}%`,
-    change: "Across all positions",
-    changePositive: true,
-    icon: <Clock className="h-4 w-4" />,
-  },
-];
+// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function InvestorDashboardPage() {
-  const { isConnected } = useWallet();
+  const { isConnected, address } = useWallet();
   const { setWalletModalOpen } = useUIStore();
-  const { address } = useWallet();
-  const positionsQuery = usePositions(address ?? undefined, { refetchInterval: 30_000 });
-  const { execute } = useTransaction();
+  const positionsQuery = usePositions(address ?? undefined, {
+    refetchInterval: 30_000,
+  });
+  const { execute, status: txStatus } = useTransaction();
 
-  if (!isConnected) {
-    return (
-      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 px-4 text-center">
-        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
-          <BarChart3 className="h-6 w-6 text-muted-foreground" />
-        </div>
-        <h2 className="text-xl font-semibold text-foreground">Connect your wallet</h2>
-        <p className="text-sm text-muted-foreground">Connect to view your investment portfolio</p>
-        <Button onClick={() => setWalletModalOpen(true)}>Connect Wallet</Button>
-      </div>
-    );
-  }
+  // Optimistic "claimed" set — tracks IDs claimed in this session
+  const [claimedIds, setClaimedIds] = useState<Set<string>>(new Set());
+  const [claimingId, setClaimingId] = useState<string | null>(null);
+  const [isClaimingAll, setIsClaimingAll] = useState(false);
+
+  // ─── Derived data ──────────────────────────────────────────────────────────
+
+  const rawPositions = positionsQuery.data ?? [];
+
+  const positions: InvestorPosition[] = useMemo(
+    () =>
+      rawPositions.map((p) => ({
+        id: p.invoiceId,
+        invoice: p.invoice as InvestorPosition["invoice"],
+        investedAmount: p.investedAmount,
+        expectedReturn: p.expectedReturn,
+        yieldEarned: p.yieldEarned ?? 0,
+        status: p.status as "active" | "repaid",
+        claimed: claimedIds.has(p.invoiceId),
+      })),
+    [rawPositions, claimedIds]
+  );
+
+  const claimablePositions = positions.filter(
+    (p) => p.status === "repaid" && !p.claimed
+  );
+
+  const totalInvested = positions.reduce((s, p) => s + p.investedAmount, 0);
+  const totalExpected = positions.reduce((s, p) => s + p.expectedReturn, 0);
+  const totalYield = totalExpected - totalInvested;
+  const totalClaimed = positions
+    .filter((p) => p.claimed)
+    .reduce((s, p) => s + p.yieldEarned, 0);
+  const avgApr =
+    positions.length > 0
+      ? positions.reduce((s, p) => s + p.invoice.terms.apr, 0) / positions.length
+      : 0;
+
+  // ─── Claim handlers ────────────────────────────────────────────────────────
 
   const handleClaim = async (pos: InvestorPosition) => {
-    if (!address) return;
+    if (!address || pos.claimed) return;
+    setClaimingId(pos.id);
     await execute(() => prepareClaimPosition(pos.id, address), {
-      successMessage: "Claim submitted",
-      onSuccess: () => positionsQuery.refetch(),
+      successMessage: `Claimed ${formatCurrency(pos.yieldEarned, "USDC", true)} yield`,
+      onSuccess: () => {
+        setClaimedIds((prev) => new Set(prev).add(pos.id));
+        positionsQuery.refetch();
+      },
     });
+    setClaimingId(null);
   };
 
-  const POSITION_COLUMNS: ColumnDef<InvestorPosition>[] = [
+  const handleClaimAll = async () => {
+    if (!address || claimablePositions.length === 0) return;
+    setIsClaimingAll(true);
+    for (const pos of claimablePositions) {
+      setClaimingId(pos.id);
+      // eslint-disable-next-line no-await-in-loop
+      const hash = await execute(() => prepareClaimPosition(pos.id, address), {
+        successMessage: `Claimed ${formatCurrency(pos.yieldEarned, "USDC", true)} from ${pos.invoice.metadata.invoiceNumber}`,
+        onSuccess: () => {
+          setClaimedIds((prev) => new Set(prev).add(pos.id));
+        },
+      });
+      if (!hash) break; // stop on first failure
+    }
+    setClaimingId(null);
+    setIsClaimingAll(false);
+    positionsQuery.refetch();
+  };
+
+  // ─── Table columns ─────────────────────────────────────────────────────────
+
+  const columns: ColumnDef<InvestorPosition>[] = [
     {
       id: "invoice",
       header: "Invoice",
       accessor: (row) => row.invoice.metadata.invoiceNumber,
       cell: (row) => (
         <div>
-          <p className="font-medium text-foreground">{row.invoice.metadata.invoiceNumber}</p>
-          <p className="text-xs text-muted-foreground">{row.invoice.metadata.category}</p>
+          <p className="font-medium text-foreground">
+            {row.invoice.metadata.invoiceNumber}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {row.invoice.metadata.category}
+          </p>
         </div>
       ),
     },
@@ -211,14 +158,20 @@ export default function InvestorDashboardPage() {
       id: "debtor",
       header: "Debtor",
       accessor: (row) => row.invoice.metadata.debtorName,
-      cell: (row) => <span className="text-muted-foreground">{row.invoice.metadata.debtorName}</span>,
+      cell: (row) => (
+        <span className="text-muted-foreground">
+          {row.invoice.metadata.debtorName}
+        </span>
+      ),
     },
     {
       id: "invested",
       header: "Invested",
       accessor: (row) => row.investedAmount,
       cell: (row) => (
-        <span className="font-medium text-foreground">{formatCurrency(row.investedAmount, "USDC", true)}</span>
+        <span className="font-medium text-foreground">
+          {formatCurrency(row.investedAmount, "USDC", true)}
+        </span>
       ),
     },
     {
@@ -226,27 +179,42 @@ export default function InvestorDashboardPage() {
       header: "Expected Return",
       accessor: (row) => row.expectedReturn,
       cell: (row) => (
-        <span className="font-medium text-success">{formatCurrency(row.expectedReturn, "USDC", true)}</span>
+        <span className="font-medium text-success">
+          {formatCurrency(row.expectedReturn, "USDC", true)}
+        </span>
       ),
     },
     {
       id: "yield",
       header: "Yield",
-      accessor: (row) => row.expectedReturn - row.investedAmount,
-      cell: (row) => <span className="text-primary">+{formatCurrency(row.expectedReturn - row.investedAmount, "USDC", true)}</span>,
+      accessor: (row) => row.yieldEarned,
+      cell: (row) => (
+        <span className="text-primary">
+          +{formatCurrency(row.yieldEarned || row.expectedReturn - row.investedAmount, "USDC", true)}
+        </span>
+      ),
     },
     {
       id: "apr",
       header: "APR",
       accessor: (row) => row.invoice.terms.apr,
-      cell: (row) => <span className="font-medium text-primary">{formatApr(row.invoice.terms.apr)}</span>,
+      cell: (row) => (
+        <span className="font-medium text-primary">
+          {formatApr(row.invoice.terms.apr)}
+        </span>
+      ),
     },
     {
       id: "risk",
       header: "Risk",
       accessor: (row) => row.invoice.riskTier,
       cell: (row) => (
-        <span className={cn("rounded-md border px-2 py-0.5 text-xs font-semibold", RISK_TIER_COLORS[row.invoice.riskTier])}>
+        <span
+          className={cn(
+            "rounded-md border px-2 py-0.5 text-xs font-semibold",
+            RISK_TIER_COLORS[row.invoice.riskTier as keyof typeof RISK_TIER_COLORS]
+          )}
+        >
           {row.invoice.riskTier}
         </span>
       ),
@@ -255,139 +223,253 @@ export default function InvestorDashboardPage() {
       id: "due",
       header: "Due Date",
       accessor: (row) => row.invoice.terms.repaymentDate,
-      cell: (row) => <span className="text-xs text-muted-foreground">{formatDate(row.invoice.terms.repaymentDate)}</span>,
+      cell: (row) => (
+        <span className="text-xs text-muted-foreground">
+          {formatDate(row.invoice.terms.repaymentDate)}
+        </span>
+      ),
     },
     {
       id: "actions",
       header: "",
       sortable: false,
-      cell: (row) => (
-        <div className="flex items-center gap-2">
-          {row.status === "repaid" ? (
-            <Button size="sm" onClick={() => handleClaim(row)}>
-              Claim
-            </Button>
-          ) : null}
-          <Link href={`/marketplace/${row.invoice.id}`} className="text-xs text-primary hover:opacity-80">
-            View →
-          </Link>
-        </div>
-      ),
+      cell: (row) => {
+        const isClaiming = claimingId === row.id;
+        return (
+          <div className="flex items-center gap-2">
+            {row.status === "repaid" && !row.claimed && (
+              <Button
+                size="sm"
+                onClick={() => handleClaim(row)}
+                disabled={isClaiming || isClaimingAll}
+              >
+                {isClaiming ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  "Claim"
+                )}
+              </Button>
+            )}
+            {row.claimed && (
+              <span className="flex items-center gap-1 text-xs text-success">
+                <CheckCircle2 className="h-3 w-3" /> Claimed
+              </span>
+            )}
+            <Link
+              href={`/marketplace/${row.invoice.id}`}
+              className="text-xs text-primary hover:opacity-80"
+            >
+              View →
+            </Link>
+          </div>
+        );
+      },
     },
   ];
 
-  const rawPositions = positionsQuery.data;
-  const positionsData: InvestorPosition[] = rawPositions
-    ? rawPositions.map((p) => ({
-        id: p.invoiceId,
-        invoice: p.invoice,
-        investedAmount: p.investedAmount,
-        expectedReturn: p.expectedReturn,
-        status: p.status as "active" | "repaid",
-      }))
-    : POSITIONS;
+  // ─── Not connected ─────────────────────────────────────────────────────────
+
+  if (!isConnected) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 px-4 text-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+          <BarChart3 className="h-6 w-6 text-muted-foreground" />
+        </div>
+        <h2 className="text-xl font-semibold text-foreground">
+          Connect your wallet
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Connect to view your investment portfolio
+        </p>
+        <Button onClick={() => setWalletModalOpen(true)}>Connect Wallet</Button>
+      </div>
+    );
+  }
+
+  // ─── Stats ─────────────────────────────────────────────────────────────────
+
+  const stats = [
+    {
+      label: "Portfolio Value",
+      value: formatCurrency(totalInvested, "USDC", true),
+      change: `${positions.length} position${positions.length !== 1 ? "s" : ""}`,
+      changePositive: true,
+      icon: <DollarSign className="h-4 w-4" />,
+    },
+    {
+      label: "Expected Yield",
+      value: formatCurrency(totalYield, "USDC", true),
+      change:
+        totalInvested > 0
+          ? `${((totalYield / totalInvested) * 100).toFixed(1)}% return`
+          : "—",
+      changePositive: true,
+      icon: <TrendingUp className="h-4 w-4" />,
+    },
+    {
+      label: "Total Claimed",
+      value: formatCurrency(totalClaimed, "USDC", true),
+      change:
+        claimablePositions.length > 0
+          ? `${claimablePositions.length} claimable`
+          : "All claimed",
+      changePositive: claimablePositions.length === 0,
+      icon: <CheckCircle2 className="h-4 w-4" />,
+    },
+    {
+      label: "Avg. APR",
+      value: `${avgApr.toFixed(1)}%`,
+      change: "Across all positions",
+      changePositive: true,
+      icon: <Clock className="h-4 w-4" />,
+    },
+  ];
+
+  // ─── Render ────────────────────────────────────────────────────────────────
 
   return (
     <ErrorBoundary>
       <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6">
-      <div className="mb-8 flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">Investor Dashboard</h1>
-          <p className="mt-1 text-sm text-muted-foreground">Track your invoice financing portfolio</p>
+        {/* Header */}
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">
+              Investor Dashboard
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Track your invoice financing portfolio
+            </p>
+          </div>
+          <Link href="/marketplace">
+            <Button variant="outline">
+              <Store className="h-4 w-4" /> Browse Marketplace
+            </Button>
+          </Link>
         </div>
-        <Link href="/marketplace">
-          <Button variant="outline">
-            <Store className="h-4 w-4" /> Browse Marketplace
-          </Button>
-        </Link>
-      </div>
 
-      <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {STATS.map((stat, i) => (
-          <motion.div
-            key={stat.label}
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: i * 0.07 }}
-          >
-            <StatCard {...stat} />
-          </motion.div>
-        ))}
-      </div>
+        {/* Stats */}
+        <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {stats.map((stat, i) => (
+            <motion.div
+              key={stat.label}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.07 }}
+            >
+              <StatCard {...stat} />
+            </motion.div>
+          ))}
+        </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Active Positions</CardTitle>
-        </CardHeader>
-        <CardContent className="p-4 sm:p-6">
-          <DataTable
-            data={positionsData}
-            columns={POSITION_COLUMNS}
-            pageSize={5}
-            emptyState={{
-              title: "No positions",
-              message: "Fund invoices on the marketplace to build your portfolio.",
-              illustration: <BarChart3 className="h-10 w-10 text-muted-foreground" />,
-            }}
-          />
-        </CardContent>
-      </Card>
-
-      <div className="mt-6 grid gap-4 sm:grid-cols-2">
+        {/* Positions table */}
         <Card>
-          <CardHeader>
-            <CardTitle>Allocation by Risk Tier</CardTitle>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>Positions</CardTitle>
+            {claimablePositions.length > 0 ? (
+              <Button
+                size="sm"
+                onClick={handleClaimAll}
+                disabled={isClaimingAll || txStatus === "signing"}
+              >
+                {isClaimingAll ? (
+                  <>
+                    <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                    Claiming…
+                  </>
+                ) : (
+                  `Claim All (${claimablePositions.length})`
+                )}
+              </Button>
+            ) : positions.length > 0 ? (
+              <span className="flex items-center gap-1 text-xs text-success">
+                <CheckCircle2 className="h-3 w-3" /> Nothing to claim
+              </span>
+            ) : null}
           </CardHeader>
-          <CardContent className="space-y-3">
-            {Object.entries(
-              POSITIONS.reduce<Record<string, number>>((acc, p) => {
-                acc[p.invoice.riskTier] = (acc[p.invoice.riskTier] || 0) + p.investedAmount;
-                return acc;
-              }, {})
-            ).map(([tier, amount]) => (
-              <div key={tier} className="space-y-1">
-                <div className="flex justify-between text-sm">
-                  <RiskBadge tier={tier as import("@/components/ui/badge").AnyRiskTier} />
-                  <span className="text-muted-foreground">
-                    {formatCurrency(amount, "USDC", true)}
-                  </span>
-                </div>
-                <Progress value={(amount / totalInvested) * 100} className="h-1.5" />
-              </div>
-            ))}
+          <CardContent className="p-4 sm:p-6">
+            <DataTable
+              data={positions}
+              columns={columns}
+              pageSize={5}
+              emptyState={{
+                title: "No positions",
+                message:
+                  "Fund invoices on the marketplace to build your portfolio.",
+                illustration: (
+                  <BarChart3 className="h-10 w-10 text-muted-foreground" />
+                ),
+              }}
+            />
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Allocation by Jurisdiction</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {Object.entries(
-              POSITIONS.reduce<Record<string, number>>((acc, p) => {
-                const j = p.invoice.metadata.jurisdiction;
-                acc[j] = (acc[j] || 0) + p.investedAmount;
-                return acc;
-              }, {})
-            ).map(([jurisdiction, amount]) => (
-              <div key={jurisdiction} className="space-y-1">
-                <div className="flex justify-between text-sm">
-                  <span className="text-foreground">{jurisdiction}</span>
-                  <span className="text-muted-foreground">
-                    {formatCurrency(amount, "USDC", true)}
-                  </span>
-                </div>
-                <Progress
-                  value={(amount / totalInvested) * 100}
-                  className="h-1.5"
-                  indicatorClassName="bg-info"
-                />
-              </div>
-            ))}
-          </CardContent>
-        </Card>
+        {/* Allocation charts */}
+        {positions.length > 0 && (
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Allocation by Risk Tier</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {Object.entries(
+                  positions.reduce<Record<string, number>>((acc, p) => {
+                    acc[p.invoice.riskTier] =
+                      (acc[p.invoice.riskTier] || 0) + p.investedAmount;
+                    return acc;
+                  }, {})
+                ).map(([tier, amount]) => (
+                  <div key={tier} className="space-y-1">
+                    <div className="flex justify-between text-sm">
+                      <RiskBadge
+                        tier={
+                          tier as import("@/components/ui/badge").AnyRiskTier
+                        }
+                      />
+                      <span className="text-muted-foreground">
+                        {formatCurrency(amount, "USDC", true)}
+                      </span>
+                    </div>
+                    <Progress
+                      value={totalInvested > 0 ? (amount / totalInvested) * 100 : 0}
+                      className="h-1.5"
+                    />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Allocation by Jurisdiction</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {Object.entries(
+                  positions.reduce<Record<string, number>>((acc, p) => {
+                    const j =
+                      (p.invoice as any).metadata?.jurisdiction ?? "OTHER";
+                    acc[j] = (acc[j] || 0) + p.investedAmount;
+                    return acc;
+                  }, {})
+                ).map(([jurisdiction, amount]) => (
+                  <div key={jurisdiction} className="space-y-1">
+                    <div className="flex justify-between text-sm">
+                      <span className="text-foreground">{jurisdiction}</span>
+                      <span className="text-muted-foreground">
+                        {formatCurrency(amount, "USDC", true)}
+                      </span>
+                    </div>
+                    <Progress
+                      value={totalInvested > 0 ? (amount / totalInvested) * 100 : 0}
+                      className="h-1.5"
+                      indicatorClassName="bg-info"
+                    />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+        )}
       </div>
-    </div>
     </ErrorBoundary>
   );
 }

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -28,6 +28,7 @@ import { useBreakpoint } from "@/components/layout/useBreakpoint";
 import { cn } from "@/lib/utils";
 import { sanitizeQueryParam } from "@/lib/security";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { useDebounce } from "@/hooks/useDebounce";
 
 // ─── Filter Options ──────────────────────────────────────────────────────────
 
@@ -369,22 +370,8 @@ function MarketplaceContent() {
   }, [searchParams, isUrlHydrated, setFilters, setSortBy, setSearchQuery]);
 
   // 2. Debouncing Changes to Prevent URL History Thrashing
-  const [debouncedFilters, setDebouncedFilters] = useState(filters);
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedFilters(filters);
-    }, 400); // 400ms delay debounces slider adjustments
-    return () => clearTimeout(handler);
-  }, [filters]);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedSearchQuery(searchQuery);
-    }, 300); // 300ms delay debounces search input queries
-    return () => clearTimeout(handler);
-  }, [searchQuery]);
+  const debouncedFilters = useDebounce(filters, 400);
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
 
   useEffect(() => {
     setPage(1);

--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delay` ms of
+ * inactivity. The pending update is cancelled on unmount.
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}
+
+export default useDebounce;

--- a/hooks/useDebouncedCallback.ts
+++ b/hooks/useDebouncedCallback.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export interface DebouncedCallback<T extends (...args: any[]) => any> {
+  (...args: Parameters<T>): void;
+  cancel: () => void;
+}
+
+/**
+ * Returns a debounced version of `fn` that fires after `delay` ms of
+ * inactivity. The returned function has a `.cancel()` method and the pending
+ * call is automatically cancelled on unmount.
+ */
+export function useDebouncedCallback<T extends (...args: any[]) => any>(
+  fn: T,
+  delay: number
+): DebouncedCallback<T> {
+  const fnRef = useRef(fn);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep fnRef current without re-creating the debounced wrapper
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Cancel on unmount
+  useEffect(() => cancel, [cancel]);
+
+  const debounced = useCallback(
+    (...args: Parameters<T>) => {
+      cancel();
+      timerRef.current = setTimeout(() => {
+        fnRef.current(...args);
+        timerRef.current = null;
+      }, delay);
+    },
+    [cancel, delay]
+  ) as DebouncedCallback<T>;
+
+  debounced.cancel = cancel;
+
+  return debounced;
+}
+
+export default useDebouncedCallback;

--- a/hooks/useResizeObserver.ts
+++ b/hooks/useResizeObserver.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect, useRef, RefObject } from "react";
+
+export interface ElementSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * Observes the dimensions of the element referenced by `ref`.
+ * Updates are throttled to 100 ms to avoid excessive re-renders.
+ * The observer is disconnected on unmount.
+ */
+export function useResizeObserver(ref: RefObject<Element | null>): ElementSize {
+  const [size, setSize] = useState<ElementSize>({ width: 0, height: 0 });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRef = useRef<ElementSize | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      pendingRef.current = { width, height };
+
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        if (pendingRef.current) setSize(pendingRef.current);
+        timerRef.current = null;
+      }, 100);
+    });
+
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [ref]);
+
+  return size;
+}
+
+export default useResizeObserver;

--- a/hooks/useThrottle.ts
+++ b/hooks/useThrottle.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect, useRef } from "react";
+
+/**
+ * Returns a throttled copy of `value` — updates at most once per `interval` ms.
+ * Uses a trailing-edge update so the final value is always emitted.
+ */
+export function useThrottle<T>(value: T, interval: number): T {
+  const [throttled, setThrottled] = useState<T>(value);
+  const lastUpdated = useRef<number>(-Infinity);
+  const trailingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const now = Date.now();
+    const remaining = interval - (now - lastUpdated.current);
+
+    if (remaining <= 0) {
+      if (trailingTimer.current) {
+        clearTimeout(trailingTimer.current);
+        trailingTimer.current = null;
+      }
+      lastUpdated.current = now;
+      setThrottled(value);
+    } else {
+      if (trailingTimer.current) clearTimeout(trailingTimer.current);
+      trailingTimer.current = setTimeout(() => {
+        lastUpdated.current = Date.now();
+        setThrottled(value);
+        trailingTimer.current = null;
+      }, remaining);
+    }
+
+    return () => {
+      if (trailingTimer.current) clearTimeout(trailingTimer.current);
+    };
+  }, [value, interval]);
+
+  return throttled;
+}
+
+export default useThrottle;

--- a/lib/stellar/contracts.ts
+++ b/lib/stellar/contracts.ts
@@ -10,6 +10,7 @@ import type {
   MintInvoiceParams,
   FundInvoiceParams,
   RepayInvoiceParams,
+  ClaimYieldParams,
   OnChainInvoice,
 } from "@/types/contract";
 
@@ -263,6 +264,22 @@ class MarketplaceContractClient {
       [scvAddress(investor)],
       sourcePublicKey,
       (val) => val
+    );
+  }
+
+  /**
+   * Investor claims yield from a repaid position.
+   * Returns unsigned XDR string.
+   */
+  async claimYield(
+    params: ClaimYieldParams,
+    sourcePublicKey: string
+  ): Promise<string> {
+    return buildCall(
+      this.contractId,
+      "claim_yield",
+      [scvU64(params.tokenId)],
+      sourcePublicKey
     );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,8 @@
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.4",
-        "@vitest/coverage-v8": "^4.1.7",
+        "@vitest/coverage-v8": "^2.1.9",
+        "@vitest/ui": "^2.1.9",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.0",
         "eslint-config-next": "15.0.0",
@@ -86,6 +87,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1680,14 +1695,11 @@
       }
     },
     "node_modules/@bcoe/v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT"
     },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.1",
@@ -2922,6 +2934,112 @@
         }
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3403,6 +3521,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
@@ -3418,6 +3547,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
@@ -5712,79 +5848,36 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
-      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.7",
-        "ast-v8-to-istanbul": "^1.0.0",
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.7",
-        "vitest": "4.1.7"
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
-      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
-      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -5883,6 +5976,28 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.1.9.tgz",
+      "integrity": "sha512-izzd2zmnk8Nl5ECYkW27328RbQ1nKvkm6Bb5DAaz1Gk59EbLkiCMa6OLT0NoaAYTjOFS6N+SMYW1nh4/9ljPiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.1",
+        "pathe": "^1.1.2",
+        "sirv": "^3.0.0",
+        "tinyglobby": "^0.2.10",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "2.1.9"
       }
     },
     "node_modules/@vitest/utils": {
@@ -6814,25 +6929,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.2.tgz",
-      "integrity": "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.31",
-        "estree-walker": "^3.0.3",
-        "js-tokens": "^10.0.0"
-      }
-    },
-    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8315,6 +8411,13 @@
         "stream-shift": "^1.0.2"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -9203,6 +9306,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9374,6 +9484,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -10645,6 +10772,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -10675,6 +10817,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jake": {
@@ -11209,15 +11367,15 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.3",
-        "@babel/types": "^7.29.0",
-        "source-map-js": "^1.2.1"
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-dir": {
@@ -11334,6 +11492,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/motion": {
       "version": "10.16.2",
       "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
@@ -11362,6 +11530,16 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
       "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -11910,17 +12088,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT"
-    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -12039,6 +12206,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12104,6 +12278,30 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -13832,6 +14030,21 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -14026,6 +14239,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -14159,6 +14395,20 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -14565,6 +14815,115 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -14753,6 +15112,16 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
@@ -16079,6 +16448,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report"
@@ -52,17 +51,6 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
-    "@testing-library/react": "^14.1.2",
-    "@testing-library/user-event": "^14.5.1",
-    "@types/node": "^22.5.5",
-    "@types/react": "^18.3.5",
-    "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.2.1",
-    "@vitest/ui": "^1.0.4",
-    "autoprefixer": "^10.4.20",
-    "eslint": "^8.57.0",
-    "eslint-config-next": "15.0.0",
-    "jsdom": "^23.0.1",
     "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.3.1",
@@ -71,7 +59,8 @@
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "^4.1.7",
+    "@vitest/coverage-v8": "^2.1.9",
+    "@vitest/ui": "^2.1.9",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.0",
     "eslint-config-next": "15.0.0",
@@ -82,7 +71,6 @@
     "prettier-plugin-tailwindcss": "^0.6.6",
     "tailwindcss": "^3.4.11",
     "typescript": "^5.6.2",
-    "vitest": "^1.0.4"
     "vitest": "^2.1.9"
   }
 }

--- a/services/invoiceService.ts
+++ b/services/invoiceService.ts
@@ -107,16 +107,22 @@ export async function fetchInvoicesByOwner(ownerAddress: string): Promise<Invoic
 
 export async function fetchPositions(investorAddress: string) {
   if (USE_MOCK) {
-    // Build mock positions from MOCK_INVOICES for the demo
-    const positions = MOCK_INVOICES.slice(0, 6).map((inv, i) => ({
-      invoiceId: inv.id,
-      invoice: inv,
-      investedAmount: [15000, 50000, 5000, 100000, 25000, 8000][i % 6],
-      expectedReturn: ([15000, 50000, 5000, 100000, 25000, 8000][i % 6]) * (1 + inv.terms.discountRate),
-      yieldEarned: 0,
-      investedAt: new Date().toISOString(),
-      status: inv.status === "repaid" ? "repaid" : "active",
-    }));
+    const amounts = [15000, 50000, 5000, 100000, 25000, 8000];
+    const positions = MOCK_INVOICES.slice(0, 6).map((inv, i) => {
+      const invested = amounts[i % 6];
+      const isRepaid = inv.status === "repaid" || i === 1; // force inv_002 as repaid
+      const yieldEarned = isRepaid ? Math.round(invested * inv.terms.discountRate) : 0;
+      return {
+        invoiceId: inv.id,
+        invoice: inv,
+        investedAmount: invested,
+        expectedReturn: invested * (1 + inv.terms.discountRate),
+        yieldEarned,
+        investedAt: new Date().toISOString(),
+        status: isRepaid ? ("repaid" as const) : ("active" as const),
+        claimed: false,
+      };
+    });
     return positions;
   }
   throw new Error("Live positions fetch not yet implemented");
@@ -282,8 +288,8 @@ export async function prepareClaimPosition(
   if (USE_MOCK) {
     return `mock_unsigned_xdr_claim_position_${positionId}_${investorAddress}`;
   }
-  return (marketplaceContract as any).claimPosition(
-    { positionId: BigInt(positionId) },
+  return marketplaceContract.claimYield(
+    { tokenId: BigInt(positionId) },
     investorAddress
   );
 }

--- a/types/contract.ts
+++ b/types/contract.ts
@@ -46,6 +46,10 @@ export interface RepayInvoiceParams {
   tokenId: bigint;
 }
 
+export interface ClaimYieldParams {
+  tokenId: bigint;
+}
+
 // ─── API Response Wrappers ────────────────────────────────────────────────────
 
 export interface ApiResponse<T> {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,21 +1,22 @@
 /**
- * Vitest setup file for integration tests
- * Configures jsdom environment, mocks, and global test utilities
+ * Vitest global setup — runs before every test file.
  */
-
-import { expect, afterEach, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { expect, afterEach, beforeAll, afterAll, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 
-// Cleanup after each test
+// ── Cleanup ───────────────────────────────────────────────────────────────────
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 
-// Mock window.matchMedia for responsive components
+// ── Browser API stubs ─────────────────────────────────────────────────────────
+
 Object.defineProperty(window, "matchMedia", {
   writable: true,
-  value: vi.fn().mockImplementation((query) => ({
+  value: vi.fn().mockImplementation((query: string) => ({
     matches: false,
     media: query,
     onchange: null,
@@ -27,62 +28,32 @@ Object.defineProperty(window, "matchMedia", {
   })),
 });
 
-// Mock IntersectionObserver
 global.IntersectionObserver = class IntersectionObserver {
   constructor() {}
   disconnect() {}
   observe() {}
-  takeRecords() {
-    return [];
-  }
+  takeRecords() { return []; }
   unobserve() {}
 } as any;
 
-// Mock next/image
+if (typeof URL.createObjectURL === "undefined") {
+  Object.defineProperty(URL, "createObjectURL", {
+    value: vi.fn(() => "blob:mock-url"),
+    writable: true,
+  });
+}
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+// next/image — use createElement to avoid JSX in .ts file
 vi.mock("next/image", () => ({
-  default: (props: any) => {
-    // eslint-disable-next-line jsx-a11y/alt-text
-    return <img {...props} />;
+  default: ({ src, alt, ...rest }: any) => {
+    const React = require("react");
+    return React.createElement("img", { src, alt, ...rest });
   },
 }));
 
-// Mock sonner toast by default
-vi.mock("sonner", () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-    loading: vi.fn(),
-    promise: vi.fn(),
-  },
-}));
-
-// Add custom matchers if needed
-expect.extend({});
-import "@testing-library/jest-dom";
-import { afterEach, beforeAll, afterAll, vi } from "vitest";
-import { cleanup } from "@testing-library/react";
-import { server } from "./app/invoice/__tests__/mocks/server";
-
-// Clean up after each test
-afterEach(() => {
-  cleanup();
-});
-
-// Start MSW server before all tests
-beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
-
-// ── Global browser API stubs ──────────────────────────────────────────────────
-
-// next/navigation
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
-  usePathname: () => "/invoice/create",
-  useSearchParams: () => new URLSearchParams(),
-}));
-
-// next/link — render as plain anchor (no JSX in .ts file; use createElement)
+// next/link
 vi.mock("next/link", () => ({
   default: ({ href, children, ...rest }: any) => {
     const React = require("react");
@@ -90,7 +61,15 @@ vi.mock("next/link", () => ({
   },
 }));
 
-// framer-motion — passthrough to avoid animation complexity in tests
+// next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+// framer-motion — passthrough without animations
 vi.mock("framer-motion", async () => {
   const actual = await vi.importActual<typeof import("framer-motion")>("framer-motion");
   const React = require("react");
@@ -114,13 +93,8 @@ vi.mock("sonner", () => ({
     loading: vi.fn(),
     success: vi.fn(),
     error: vi.fn(),
+    promise: vi.fn(),
   },
 }));
 
-// URL.createObjectURL — not available in jsdom
-if (typeof URL.createObjectURL === "undefined") {
-  Object.defineProperty(URL, "createObjectURL", {
-    value: vi.fn(() => "blob:mock-url"),
-    writable: true,
-  });
-}
+expect.extend({});


### PR DESCRIPTION
Closes #61 

Closes #68 

- Add ClaimYieldParams type and claimYield() to MarketplaceContractClient
- Fix prepareClaimPosition to use real claimYield contract method
- Update fetchPositions mock to include repaid positions with yieldEarned
- Implement useDebounce, useThrottle, useDebouncedCallback, useResizeObserver hooks
- Rewrite investor dashboard: Claim All button, per-row Claim, totalClaimed stat, optimistic claimed state, nothing-to-claim state, loading spinners
- Wire useDebounce to marketplace search and filter inputs (replaces inline useEffect)
- Fix vitest.config.ts duplicate import and vitest.setup.ts JSX/duplicate issues
- Fix package.json duplicate keys and align @vitest/ui version to 2.1.9
- Add unit tests for all four hooks (17 tests passing)

Closes #61
Closes #68