### PR TITLE
feat: feedback widget and global keyboard shortcuts

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface FeedbackPayload {
+  type: "bug" | "feature" | "other";
+  title: string;
+  description: string;
+  screenshot?: string | null; // base64 data URL
+  context: {
+    url: string;
+    walletAddress?: string | null;
+    userAgent: string;
+    timestamp: string;
+  };
+}
+
+/**
+ * POST /api/feedback
+ * Accepts a feedback submission, logs it to the console, and optionally
+ * forwards it to the GitHub Issues API when GITHUB_FEEDBACK_TOKEN and
+ * GITHUB_FEEDBACK_REPO are set in the environment.
+ *
+ * GITHUB_FEEDBACK_REPO format: "owner/repo"
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    const body = (await req.json()) as FeedbackPayload;
+
+    // ── Basic validation ──────────────────────────────────────────────────────
+    if (!body.type || !body.title?.trim() || !body.description?.trim()) {
+      return NextResponse.json(
+        { error: "type, title, and description are required" },
+        { status: 400 }
+      );
+    }
+
+    const allowed = ["bug", "feature", "other"];
+    if (!allowed.includes(body.type)) {
+      return NextResponse.json({ error: "Invalid feedback type" }, { status: 400 });
+    }
+
+    // ── Console log (always) ──────────────────────────────────────────────────
+    console.log("[feedback]", {
+      type: body.type,
+      title: body.title,
+      description: body.description,
+      context: body.context,
+      hasScreenshot: Boolean(body.screenshot),
+      ts: new Date().toISOString(),
+    });
+
+    // ── Optional: GitHub Issues API ───────────────────────────────────────────
+    const ghToken = process.env.GITHUB_FEEDBACK_TOKEN;
+    const ghRepo = process.env.GITHUB_FEEDBACK_REPO; // e.g. "org/kora-frontend"
+
+    if (ghToken && ghRepo) {
+      const labelMap: Record<FeedbackPayload["type"], string> = {
+        bug: "bug",
+        feature: "enhancement",
+        other: "feedback",
+      };
+
+      const issueBody = [
+        `**Type:** ${body.type}`,
+        `**URL:** ${body.context.url}`,
+        `**Wallet:** ${body.context.walletAddress ?? "not connected"}`,
+        `**Browser:** ${body.context.userAgent}`,
+        `**Submitted:** ${body.context.timestamp}`,
+        "",
+        "## Description",
+        body.description,
+        body.screenshot
+          ? "\n> _Screenshot attached (base64 omitted from issue body)_"
+          : "",
+      ]
+        .filter((l) => l !== undefined)
+        .join("\n");
+
+      const ghRes = await fetch(`https://api.github.com/repos/${ghRepo}/issues`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${ghToken}`,
+          "Content-Type": "application/json",
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        body: JSON.stringify({
+          title: `[${body.type.toUpperCase()}] ${body.title}`,
+          body: issueBody,
+          labels: [labelMap[body.type]],
+        }),
+      });
+
+      if (!ghRes.ok) {
+        const err = await ghRes.text();
+        console.error("[feedback] GitHub Issues API error:", err);
+        // Don't fail the user request — log and continue
+      } else {
+        const issue = await ghRes.json();
+        console.log("[feedback] GitHub issue created:", issue.html_url);
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[feedback] error", (err as Error).message);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -5,6 +5,10 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { Toaster } from "sonner";
 import { useState } from "react";
 import dynamic from "next/dynamic";
+import { ThemeProvider } from "@/components/layout/ThemeProvider";
+import { useUIStore } from "@/store/uiStore";
+import { env } from "@/lib/env";
+
 const WalletConnectModal = dynamic(
   () => import("@/components/wallet/WalletConnectModal").then((m) => m.WalletConnectModal),
   { ssr: false, loading: () => null }
@@ -13,12 +17,21 @@ const InstallPrompt = dynamic(
   () => import("@/components/pwa/InstallPrompt").then((m) => m.InstallPrompt),
   { ssr: false, loading: () => null }
 );
-import { ThemeProvider } from "@/components/layout/ThemeProvider";
-import { useUIStore } from "@/store/uiStore";
-import { env } from "@/lib/env";
-import dynamic from "next/dynamic";
-
-const OnboardingTour = dynamic(() => import("@/components/onboarding/OnboardingTour").then((m) => m.default), { ssr: false, loading: () => null });
+const OnboardingTour = dynamic(
+  () => import("@/components/onboarding/OnboardingTour").then((m) => m.default),
+  { ssr: false, loading: () => null }
+);
+const FeedbackWidget = dynamic(
+  () => import("@/components/feedback/FeedbackWidget").then((m) => m.FeedbackWidget),
+  { ssr: false, loading: () => null }
+);
+const KeyboardShortcutsProvider = dynamic(
+  () =>
+    import("@/components/keyboard/KeyboardShortcutsProvider").then(
+      (m) => m.KeyboardShortcutsProvider
+    ),
+  { ssr: false, loading: () => null }
+);
 
 function ThemedToaster() {
   const theme = useUIStore((s) => s.theme);
@@ -55,6 +68,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
         <OnboardingTour />
         <WalletConnectModal />
         <InstallPrompt />
+        <FeedbackWidget />
+        <KeyboardShortcutsProvider />
         <ThemedToaster />
         {env.NEXT_PUBLIC_ENABLE_DEVTOOLS && (
           <ReactQueryDevtools initialIsOpen={false} />

--- a/components/feedback/FeedbackWidget.tsx
+++ b/components/feedback/FeedbackWidget.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { MessageSquarePlus, X, Bug, Lightbulb, MessageCircle, Paperclip, Loader2 } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { useWalletStore } from "@/store/walletStore";
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+const feedbackSchema = z.object({
+  type: z.enum(["bug", "feature", "other"]),
+  title: z.string().min(3, "Title must be at least 3 characters").max(120),
+  description: z.string().min(10, "Please provide more detail").max(2000),
+});
+
+type FeedbackFormValues = z.infer<typeof feedbackSchema>;
+
+// ── Type selector config ──────────────────────────────────────────────────────
+const FEEDBACK_TYPES = [
+  { value: "bug" as const, label: "Bug Report", icon: Bug, color: "text-destructive" },
+  { value: "feature" as const, label: "Feature Request", icon: Lightbulb, color: "text-amber-400" },
+  { value: "other" as const, label: "Other", icon: MessageCircle, color: "text-primary" },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function getBrowserInfo(): string {
+  if (typeof navigator === "undefined") return "unknown";
+  return navigator.userAgent;
+}
+
+async function captureScreenshot(): Promise<string | null> {
+  try {
+    // Dynamically import html2canvas to keep it out of the initial bundle
+    const html2canvas = (await import("html2canvas")).default;
+    const canvas = await html2canvas(document.body, {
+      useCORS: true,
+      allowTaint: false,
+      scale: 0.5, // reduce size
+      logging: false,
+    });
+    return canvas.toDataURL("image/jpeg", 0.6);
+  } catch {
+    return null;
+  }
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+export function FeedbackWidget() {
+  const [open, setOpen] = useState(false);
+  const [screenshot, setScreenshot] = useState<string | null>(null);
+  const [capturingScreen, setCapturingScreen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const walletAddress = useWalletStore((s) => s.address);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<FeedbackFormValues>({
+    resolver: zodResolver(feedbackSchema),
+    defaultValues: { type: "bug" },
+  });
+
+  const selectedType = watch("type");
+
+  // ── Screenshot capture ────────────────────────────────────────────────────
+  const handleCaptureScreen = useCallback(async () => {
+    setCapturingScreen(true);
+    // Brief delay so the widget can close/minimise before capture
+    setOpen(false);
+    await new Promise((r) => setTimeout(r, 300));
+    const dataUrl = await captureScreenshot();
+    setScreenshot(dataUrl);
+    setOpen(true);
+    setCapturingScreen(false);
+  }, []);
+
+  const handleFileUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      toast.error("Please upload an image file");
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error("Screenshot must be under 5 MB");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (ev) => setScreenshot(ev.target?.result as string);
+    reader.readAsDataURL(file);
+  }, []);
+
+  // ── Submit ────────────────────────────────────────────────────────────────
+  const onSubmit = useCallback(
+    async (values: FeedbackFormValues) => {
+      setSubmitting(true);
+      try {
+        const payload = {
+          ...values,
+          screenshot,
+          context: {
+            url: window.location.href,
+            walletAddress,
+            userAgent: getBrowserInfo(),
+            timestamp: new Date().toISOString(),
+          },
+        };
+
+        const res = await fetch("/api/feedback", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.error ?? "Submission failed");
+        }
+
+        toast.success("Feedback submitted — thanks for helping improve Kora!");
+        reset();
+        setScreenshot(null);
+        setOpen(false);
+      } catch (err) {
+        toast.error("Failed to submit feedback", {
+          description: (err as Error).message,
+        });
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [screenshot, walletAddress, reset]
+  );
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    reset();
+    setScreenshot(null);
+  }, [reset]);
+
+  return (
+    <>
+      {/* ── Floating trigger button ─────────────────────────────────────────── */}
+      <div className="fixed bottom-6 right-6 z-[9000] flex flex-col items-end gap-3">
+        <AnimatePresence>
+          {open && (
+            <motion.div
+              key="feedback-panel"
+              initial={{ opacity: 0, y: 16, scale: 0.95 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 16, scale: 0.95 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+              className="w-[340px] sm:w-[380px] rounded-2xl border border-border bg-background shadow-token-lg"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Feedback form"
+            >
+              {/* Header */}
+              <div className="flex items-center justify-between border-b border-border px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <MessageSquarePlus className="h-4 w-4 text-primary" aria-hidden="true" />
+                  <span className="text-sm font-semibold text-foreground">Send Feedback</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="rounded-lg p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  aria-label="Close feedback form"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              {/* Form */}
+              <form onSubmit={handleSubmit(onSubmit)} className="p-4 space-y-4" noValidate>
+                {/* Type selector */}
+                <div>
+                  <p className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Type
+                  </p>
+                  <div className="grid grid-cols-3 gap-2">
+                    {FEEDBACK_TYPES.map(({ value, label, icon: Icon, color }) => (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => setValue("type", value)}
+                        className={cn(
+                          "flex flex-col items-center gap-1.5 rounded-xl border px-2 py-2.5 text-xs font-medium transition-all",
+                          selectedType === value
+                            ? "border-primary bg-primary/10 text-foreground"
+                            : "border-border bg-card text-muted-foreground hover:border-border/80 hover:bg-muted"
+                        )}
+                        aria-pressed={selectedType === value}
+                      >
+                        <Icon className={cn("h-4 w-4", selectedType === value ? color : "")} aria-hidden="true" />
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Title */}
+                <div>
+                  <label htmlFor="fb-title" className="mb-1.5 block text-xs font-medium text-foreground">
+                    Title <span className="text-destructive">*</span>
+                  </label>
+                  <input
+                    id="fb-title"
+                    {...register("title")}
+                    placeholder="Brief summary…"
+                    className={cn(
+                      "w-full rounded-lg border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground",
+                      "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
+                      errors.title ? "border-destructive" : "border-border"
+                    )}
+                  />
+                  {errors.title && (
+                    <p className="mt-1 text-xs text-destructive" role="alert">
+                      {errors.title.message}
+                    </p>
+                  )}
+                </div>
+
+                {/* Description */}
+                <div>
+                  <label htmlFor="fb-description" className="mb-1.5 block text-xs font-medium text-foreground">
+                    Description <span className="text-destructive">*</span>
+                  </label>
+                  <textarea
+                    id="fb-description"
+                    {...register("description")}
+                    rows={4}
+                    placeholder="Describe the issue or idea in detail…"
+                    className={cn(
+                      "w-full resize-none rounded-lg border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground",
+                      "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
+                      errors.description ? "border-destructive" : "border-border"
+                    )}
+                  />
+                  {errors.description && (
+                    <p className="mt-1 text-xs text-destructive" role="alert">
+                      {errors.description.message}
+                    </p>
+                  )}
+                </div>
+
+                {/* Screenshot section */}
+                <div>
+                  <p className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Screenshot (optional)
+                  </p>
+                  {screenshot ? (
+                    <div className="relative rounded-lg overflow-hidden border border-border">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={screenshot}
+                        alt="Attached screenshot preview"
+                        className="w-full max-h-32 object-cover"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setScreenshot(null)}
+                        className="absolute right-1.5 top-1.5 rounded-full bg-background/80 p-1 text-muted-foreground hover:text-foreground backdrop-blur-sm"
+                        aria-label="Remove screenshot"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={handleCaptureScreen}
+                        disabled={capturingScreen}
+                        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-card px-3 py-2 text-xs text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground disabled:opacity-50"
+                      >
+                        {capturingScreen ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                        ) : (
+                          <MessageSquarePlus className="h-3.5 w-3.5" aria-hidden="true" />
+                        )}
+                        Capture screen
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-dashed border-border bg-card px-3 py-2 text-xs text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground"
+                      >
+                        <Paperclip className="h-3.5 w-3.5" aria-hidden="true" />
+                        Upload image
+                      </button>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/*"
+                        className="sr-only"
+                        aria-label="Upload screenshot"
+                        onChange={handleFileUpload}
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {/* Auto-captured context info */}
+                <p className="text-[11px] text-muted-foreground">
+                  Your current URL, browser info
+                  {walletAddress ? ", and wallet address" : ""} will be included automatically.
+                </p>
+
+                {/* Actions */}
+                <div className="flex gap-2 pt-1">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="flex-1"
+                    onClick={handleClose}
+                    disabled={submitting}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    size="sm"
+                    className="flex-1"
+                    isLoading={submitting}
+                  >
+                    Submit
+                  </Button>
+                </div>
+              </form>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Floating button */}
+        <motion.button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+          className={cn(
+            "flex items-center gap-2 rounded-full border border-border bg-background px-4 py-2.5 text-sm font-medium text-foreground shadow-token-md transition-colors hover:bg-muted",
+            "sm:px-4 sm:py-2.5",
+            // On mobile collapse to icon only
+            "max-sm:px-3 max-sm:py-3"
+          )}
+          aria-label={open ? "Close feedback" : "Open feedback form"}
+          aria-expanded={open}
+        >
+          {open ? (
+            <X className="h-4 w-4 shrink-0" aria-hidden="true" />
+          ) : (
+            <MessageSquarePlus className="h-4 w-4 shrink-0" aria-hidden="true" />
+          )}
+          <span className="hidden sm:inline">{open ? "Close" : "Feedback"}</span>
+        </motion.button>
+      </div>
+    </>
+  );
+}

--- a/components/keyboard/KeyboardShortcutsProvider.tsx
+++ b/components/keyboard/KeyboardShortcutsProvider.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { ShortcutReferenceModal } from "./ShortcutReferenceModal";
+
+/**
+ * KeyboardShortcutsProvider
+ *
+ * Mounts the global keyboard shortcut listener and renders the shortcut
+ * reference modal. Drop this inside <Providers> so it's available app-wide.
+ *
+ * Search (⌘K) is wired to a custom event so any search component can listen
+ * without tight coupling. The Navbar keyboard icon also dispatches
+ * "kora:open-shortcut-modal" which is handled here.
+ */
+export function KeyboardShortcutsProvider() {
+  const [shortcutModalOpen, setShortcutModalOpen] = useState(false);
+
+  const handleOpenSearch = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("kora:open-search"));
+  }, []);
+
+  const handleOpenShortcutModal = useCallback(() => {
+    setShortcutModalOpen(true);
+  }, []);
+
+  // Also listen for the custom event dispatched by the Navbar keyboard button
+  useEffect(() => {
+    function handleEvent() {
+      setShortcutModalOpen(true);
+    }
+    window.addEventListener("kora:open-shortcut-modal", handleEvent);
+    return () => window.removeEventListener("kora:open-shortcut-modal", handleEvent);
+  }, []);
+
+  useKeyboardShortcuts({
+    onOpenSearch: handleOpenSearch,
+    onOpenShortcutModal: handleOpenShortcutModal,
+  });
+
+  return (
+    <ShortcutReferenceModal
+      open={shortcutModalOpen}
+      onClose={() => setShortcutModalOpen(false)}
+    />
+  );
+}

--- a/components/keyboard/ShortcutReferenceModal.tsx
+++ b/components/keyboard/ShortcutReferenceModal.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Keyboard, X } from "lucide-react";
+import { SHORTCUT_DEFINITIONS } from "@/hooks/useKeyboardShortcuts";
+import { cn } from "@/lib/utils";
+
+interface ShortcutReferenceModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+// Group shortcuts by category
+const CATEGORIES = ["Navigation", "Actions", "Help"] as const;
+
+function groupShortcuts() {
+  const groups: Record<string, Array<{ key: string; label: string; description: string }>> = {};
+  for (const [key, def] of Object.entries(SHORTCUT_DEFINITIONS)) {
+    if (!groups[def.category]) groups[def.category] = [];
+    groups[def.category].push({ key, label: def.label, description: def.description });
+  }
+  return groups;
+}
+
+const GROUPED = groupShortcuts();
+
+// ── Keyboard badge ─────────────────────────────────────────────────────────────
+function KbdBadge({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="inline-flex items-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[11px] font-medium text-foreground shadow-sm">
+      {children}
+    </kbd>
+  );
+}
+
+export function ShortcutReferenceModal({ open, onClose }: ShortcutReferenceModalProps) {
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            key="shortcut-backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="fixed inset-0 z-[9100] bg-black/70 backdrop-blur-sm"
+            onClick={onClose}
+            aria-hidden="true"
+          />
+
+          {/* Panel */}
+          <motion.div
+            key="shortcut-panel"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Keyboard shortcuts reference"
+            initial={{ opacity: 0, scale: 0.96, y: -8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: -8 }}
+            transition={{ duration: 0.18, ease: "easeOut" }}
+            className="fixed left-1/2 top-1/2 z-[9200] w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-background p-6 shadow-token-lg"
+          >
+            {/* Header */}
+            <div className="mb-5 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Keyboard className="h-5 w-5 text-primary" aria-hidden="true" />
+                <h2 className="text-base font-semibold text-foreground">Keyboard Shortcuts</h2>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-lg p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                aria-label="Close shortcuts reference"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            {/* Shortcut table */}
+            <div className="space-y-5">
+              {CATEGORIES.map((category) => {
+                const items = GROUPED[category];
+                if (!items?.length) return null;
+                return (
+                  <section key={category} aria-labelledby={`shortcut-cat-${category}`}>
+                    <h3
+                      id={`shortcut-cat-${category}`}
+                      className="mb-2 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground"
+                    >
+                      {category}
+                    </h3>
+                    <div className="rounded-xl border border-border overflow-hidden">
+                      {items.map((item, idx) => (
+                        <div
+                          key={item.key}
+                          className={cn(
+                            "flex items-center justify-between px-4 py-2.5 text-sm",
+                            idx !== items.length - 1 && "border-b border-border"
+                          )}
+                        >
+                          <span className="text-foreground">{item.description}</span>
+                          <KbdBadge>{item.label}</KbdBadge>
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                );
+              })}
+            </div>
+
+            {/* Footer hint */}
+            <p className="mt-5 text-center text-xs text-muted-foreground">
+              Press <KbdBadge>?</KbdBadge> anytime to open this reference. Shortcuts can be disabled in{" "}
+              <span className="text-foreground">Notification Settings</span>.
+            </p>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ import {
   Sun,
   Moon,
   History,
+  Keyboard,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
@@ -20,14 +21,15 @@ const AddressBook = dynamic(() => import("@/components/wallet/AddressBook").then
 import { WalletButton } from "@/components/wallet/WalletButton";
 import { NetworkStatusIndicator } from "@/components/layout/NetworkStatusIndicator";
 import { useUIStore } from "@/store/uiStore";
+import { ShortcutBadge } from "@/components/ui/ShortcutBadge";
 import { cn } from "@/lib/utils";
 
 const NAV_LINKS = [
-  { href: "/marketplace", label: "Marketplace", icon: Store },
-  { href: "/dashboard/investor", label: "Invest", icon: BarChart3 },
-  { href: "/dashboard/sme", label: "My Invoices", icon: LayoutDashboard },
-  { href: "/invoice/create", label: "Create Invoice", icon: PlusCircle },
-  { href: "/transactions", label: "History", icon: History },
+  { href: "/marketplace", label: "Marketplace", icon: Store, shortcut: "G M" },
+  { href: "/dashboard/investor", label: "Invest", icon: BarChart3, shortcut: "G D" },
+  { href: "/dashboard/sme", label: "My Invoices", icon: LayoutDashboard, shortcut: null },
+  { href: "/invoice/create", label: "Create Invoice", icon: PlusCircle, shortcut: "G C" },
+  { href: "/transactions", label: "History", icon: History, shortcut: "G T" },
 ];
 
 const MENU_ID = "mobile-nav-menu";
@@ -37,6 +39,7 @@ export function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const theme = useUIStore((s) => s.theme);
   const toggleTheme = useUIStore((s) => s.toggleTheme);
+  const shortcutsEnabled = useUIStore((s) => s.shortcutsEnabled);
   const navRef = useRef<HTMLElement>(null);
   const [addressBookOpen, setAddressBookOpen] = useState(false);
 
@@ -86,7 +89,7 @@ export function Navbar() {
 
         {/* Desktop nav */}
         <nav className="hidden items-center gap-1 md:flex" aria-label="Main navigation">
-          {NAV_LINKS.map(({ href, label }) => {
+          {NAV_LINKS.map(({ href, label, shortcut }) => {
             const active = pathname.startsWith(href);
             return (
               <Link
@@ -94,7 +97,7 @@ export function Navbar() {
                 href={href}
                 aria-current={active ? "page" : undefined}
                 className={cn(
-                  "relative rounded-lg px-3 py-2 text-sm transition-colors",
+                  "relative flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm transition-colors",
                   active
                     ? "text-foreground"
                     : "text-muted-foreground hover:text-foreground/80"
@@ -108,6 +111,9 @@ export function Navbar() {
                   />
                 )}
                 <span className="relative">{label}</span>
+                {shortcut && shortcutsEnabled && (
+                  <ShortcutBadge keys={shortcut} className="relative" />
+                )}
               </Link>
             );
           })}
@@ -130,6 +136,19 @@ export function Navbar() {
               <Moon className="h-5 w-5" />
             )}
           </button>
+
+          {/* Keyboard shortcut hint — desktop only */}
+          {shortcutsEnabled && (
+            <button
+              type="button"
+              onClick={() => window.dispatchEvent(new CustomEvent("kora:open-shortcut-modal"))}
+              className="hidden rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground md:flex"
+              aria-label="Open keyboard shortcuts reference"
+              title="Keyboard shortcuts (?)"
+            >
+              <Keyboard className="h-4 w-4" />
+            </button>
+          )}
 
           <button onClick={() => setAddressBookOpen(true)} className="rounded-lg px-3 py-2 text-sm text-muted-foreground hover:text-foreground">Address Book</button>
           <WalletButton />

--- a/components/settings/NotificationSettings.tsx
+++ b/components/settings/NotificationSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { RotateCcw } from "lucide-react";
+import { Keyboard, RotateCcw } from "lucide-react";
 import { useUIStore } from "@/store/uiStore";
 import { Button } from "@/components/ui/button";
 import type { MaturityReminderDays, NotificationPreferences } from "@/store/uiStore";
@@ -67,6 +67,8 @@ export function NotificationSettings() {
   const preferences = useUIStore((s) => s.notificationPreferences);
   const setNotificationPreferences = useUIStore((s) => s.setNotificationPreferences);
   const resetNotificationPreferences = useUIStore((s) => s.resetNotificationPreferences);
+  const shortcutsEnabled = useUIStore((s) => s.shortcutsEnabled);
+  const setShortcutsEnabled = useUIStore((s) => s.setShortcutsEnabled);
 
   const updatePreference = (
     key: keyof Pick<NotificationPreferences, "txConfirmed" | "invoiceFunded" | "maturityReminder" | "yieldAvailable">,
@@ -129,6 +131,30 @@ export function NotificationSettings() {
       >
         Reset to defaults
       </Button>
+
+      {/* ── Keyboard shortcuts toggle ──────────────────────────────────────── */}
+      <div className="space-y-1 pt-2">
+        <h3 className="text-base font-semibold text-foreground">Keyboard Shortcuts</h3>
+        <p className="text-sm text-muted-foreground">
+          Enable global keyboard shortcuts for faster navigation.
+        </p>
+      </div>
+      <div className="flex items-start justify-between gap-4 rounded-lg border border-border bg-card p-3">
+        <div className="flex items-center gap-2">
+          <Keyboard className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          <div>
+            <p className="text-sm font-medium text-foreground">Enable shortcuts</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Press <kbd className="rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px]">?</kbd> to view all shortcuts.
+            </p>
+          </div>
+        </div>
+        <Toggle
+          checked={shortcutsEnabled}
+          onChange={setShortcutsEnabled}
+          ariaLabel="Toggle keyboard shortcuts"
+        />
+      </div>
     </div>
   );
 }

--- a/components/ui/ShortcutBadge.tsx
+++ b/components/ui/ShortcutBadge.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils";
+
+interface ShortcutBadgeProps {
+  keys: string;
+  className?: string;
+}
+
+/**
+ * ShortcutBadge
+ *
+ * Renders a small keyboard shortcut hint badge, e.g. "⌘K".
+ * Intended to be placed alongside buttons or nav items.
+ */
+export function ShortcutBadge({ keys, className }: ShortcutBadgeProps) {
+  return (
+    <kbd
+      aria-label={`Keyboard shortcut: ${keys}`}
+      className={cn(
+        "hidden items-center rounded border border-border bg-muted px-1 py-0.5 font-mono text-[10px] font-medium text-muted-foreground sm:inline-flex",
+        className
+      )}
+    >
+      {keys}
+    </kbd>
+  );
+}

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,198 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useUIStore } from "@/store/uiStore";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+export interface ShortcutDefinition {
+  /** Human-readable key sequence label, e.g. "⌘K" or "G M" */
+  label: string;
+  /** Short description shown in the reference modal */
+  description: string;
+  /** Category for grouping in the modal */
+  category: "Navigation" | "Actions" | "Help";
+}
+
+// ── Shortcut registry (exported for the modal) ────────────────────────────────
+export const SHORTCUT_DEFINITIONS: Record<string, ShortcutDefinition> = {
+  "cmd+k": {
+    label: "⌘K / Ctrl+K",
+    description: "Open search",
+    category: "Actions",
+  },
+  "cmd+w": {
+    label: "⌘W / Ctrl+W",
+    description: "Open wallet modal",
+    category: "Actions",
+  },
+  "g m": {
+    label: "G M",
+    description: "Go to Marketplace",
+    category: "Navigation",
+  },
+  "g d": {
+    label: "G D",
+    description: "Go to Dashboard",
+    category: "Navigation",
+  },
+  "g c": {
+    label: "G C",
+    description: "Go to Create Invoice",
+    category: "Navigation",
+  },
+  "g t": {
+    label: "G T",
+    description: "Go to Transaction History",
+    category: "Navigation",
+  },
+  "g a": {
+    label: "G A",
+    description: "Go to Analytics",
+    category: "Navigation",
+  },
+  "?": {
+    label: "?",
+    description: "Open shortcut reference",
+    category: "Help",
+  },
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Returns true when the event target is an interactive text input */
+function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = (el as HTMLElement).tagName.toLowerCase();
+  if (tag === "input" || tag === "textarea" || tag === "select") return true;
+  if ((el as HTMLElement).isContentEditable) return true;
+  return false;
+}
+
+/** Normalise a KeyboardEvent into a canonical key string */
+function eventToKey(e: KeyboardEvent): string {
+  const mod = e.metaKey || e.ctrlKey;
+  const key = e.key.toLowerCase();
+  if (mod) return `cmd+${key}`;
+  return key;
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+/**
+ * useKeyboardShortcuts
+ *
+ * Registers global keyboard shortcuts. Supports:
+ * - Single-key shortcuts (e.g. "?")
+ * - Modifier shortcuts (e.g. Cmd/Ctrl+K)
+ * - Two-key sequences (e.g. "G M" — press G then M within 1 500 ms)
+ *
+ * Shortcuts are disabled when the user is typing in an input field, or when
+ * `shortcutsEnabled` is false in the UI store.
+ */
+export function useKeyboardShortcuts({
+  onOpenSearch,
+  onOpenShortcutModal,
+}: {
+  onOpenSearch?: () => void;
+  onOpenShortcutModal?: () => void;
+}) {
+  const router = useRouter();
+  const setWalletModalOpen = useUIStore((s) => s.setWalletModalOpen);
+  const shortcutsEnabled = useUIStore((s) => s.shortcutsEnabled);
+
+  // Sequence buffer: stores the last key pressed for two-key sequences
+  const sequenceRef = useRef<string | null>(null);
+  const sequenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearSequence = useCallback(() => {
+    sequenceRef.current = null;
+    if (sequenceTimerRef.current) {
+      clearTimeout(sequenceTimerRef.current);
+      sequenceTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!shortcutsEnabled) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      // Never fire when user is typing
+      if (isInputFocused()) return;
+
+      const key = eventToKey(e);
+
+      // ── Modifier shortcuts (fire immediately) ──────────────────────────────
+      if (key === "cmd+k") {
+        e.preventDefault();
+        onOpenSearch?.();
+        clearSequence();
+        return;
+      }
+
+      if (key === "cmd+w") {
+        // Only intercept if not a browser tab-close scenario (no modifier ambiguity on Mac)
+        e.preventDefault();
+        setWalletModalOpen(true);
+        clearSequence();
+        return;
+      }
+
+      // ── Single-key shortcuts ───────────────────────────────────────────────
+      if (key === "?") {
+        e.preventDefault();
+        onOpenShortcutModal?.();
+        clearSequence();
+        return;
+      }
+
+      // ── Two-key sequences (G + letter) ─────────────────────────────────────
+      if (key === "g" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        clearSequence();
+        sequenceRef.current = "g";
+        // Auto-clear after 1.5 s if no second key
+        sequenceTimerRef.current = setTimeout(clearSequence, 1500);
+        return;
+      }
+
+      if (sequenceRef.current === "g") {
+        clearSequence();
+        switch (key) {
+          case "m":
+            e.preventDefault();
+            router.push("/marketplace");
+            break;
+          case "d":
+            e.preventDefault();
+            router.push("/dashboard/investor");
+            break;
+          case "c":
+            e.preventDefault();
+            router.push("/invoice/create");
+            break;
+          case "t":
+            e.preventDefault();
+            router.push("/transactions");
+            break;
+          case "a":
+            e.preventDefault();
+            router.push("/analytics");
+            break;
+          default:
+            break;
+        }
+        return;
+      }
+
+      // Any other key clears the sequence buffer
+      clearSequence();
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      clearSequence();
+    };
+  }, [shortcutsEnabled, router, setWalletModalOpen, onOpenSearch, onOpenShortcutModal, clearSequence]);
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "date-fns": "^4.1.0",
     "dompurify": "3.4.7",
     "framer-motion": "^11.5.4",
+    "html2canvas": "1.4.1",
     "lucide-react": "^0.441.0",
     "next": "15.0.0",
     "next-pwa": "5.6.0",

--- a/store/uiStore.ts
+++ b/store/uiStore.ts
@@ -22,6 +22,9 @@ export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
   maturityReminderDays: 3,
 };
 
+// ── Keyboard shortcuts ────────────────────────────────────────────────────────
+export const DEFAULT_SHORTCUTS_ENABLED = true;
+
 interface UIStore {
   walletModalOpen: boolean;
   setWalletModalOpen: (open: boolean) => void;
@@ -44,6 +47,10 @@ interface UIStore {
   notificationPreferences: NotificationPreferences;
   setNotificationPreferences: (prefs: Partial<NotificationPreferences>) => void;
   resetNotificationPreferences: () => void;
+
+  // Keyboard shortcuts
+  shortcutsEnabled: boolean;
+  setShortcutsEnabled: (enabled: boolean) => void;
 }
 
 export const useUIStore = create<UIStore>()(
@@ -81,12 +88,17 @@ export const useUIStore = create<UIStore>()(
         })),
       resetNotificationPreferences: () =>
         set({ notificationPreferences: DEFAULT_NOTIFICATION_PREFERENCES }),
+
+      // Keyboard shortcuts
+      shortcutsEnabled: DEFAULT_SHORTCUTS_ENABLED,
+      setShortcutsEnabled: (shortcutsEnabled) => set({ shortcutsEnabled }),
     }),
     {
       name: "kora-ui-store",
       partialize: (state) => ({
         theme: state.theme,
         notificationPreferences: state.notificationPreferences,
+        shortcutsEnabled: state.shortcutsEnabled,
       }),
     }
   )


### PR DESCRIPTION

closes #163 
closes #164 

Closes #115, Closes #116

- Add FeedbackWidget floating button (bottom-right) with bug/feature/other
  type selector, title, description, optional screenshot via html2canvas or
  file upload, and auto-captured context (URL, wallet, browser/OS)
- Add POST /api/feedback route that logs to console and optionally creates
  GitHub Issues when GITHUB_FEEDBACK_TOKEN + GITHUB_FEEDBACK_REPO are set
- Add useKeyboardShortcuts hook with modifier (Cmd+K, Cmd+W), single-key (?),
  and two-key sequence (G M/D/C/T/A) support; respects input focus
- Add ShortcutReferenceModal showing all shortcuts grouped by category
- Add KeyboardShortcutsProvider wired into app Providers
- Add ShortcutBadge UI component for inline shortcut hints
- Show shortcut badges on Navbar nav links; add keyboard icon button
- Add shortcuts enable/disable toggle in NotificationSettings
- Persist shortcutsEnabled preference in uiStore (localStorage)
- Fix duplicate import dynamic in providers.tsx
- Add html2canvas@1.4.1 dependency
