### PR TITLE
fix: resolve issues #212, #214, #216, #218

### DIFF
--- a/app/marketplace/[id]/page.tsx
+++ b/app/marketplace/[id]/page.tsx
@@ -50,6 +50,7 @@ import { validateRouteId, safeIpfsUrl, safeExternalUrl, safeStellarTxUrl } from 
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { env } from "@/lib/env";
 import Script from "next/script";
+import { PrintLayout, PrintButton } from "@/components/ui/print-layout";
 import {
   invoiceFinancialProductSchema,
   breadcrumbSchema,
@@ -275,17 +276,22 @@ Stellar Testnet Transaction Hash: ${txHash}`);
       }}
     />
     <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
-      {/* Back */}
-      <Link
-        href="/marketplace"
-        className="mb-6 inline-flex items-center gap-2 text-sm text-zinc-500 hover:text-zinc-300"
-      >
-        <ArrowLeft className="h-4 w-4" /> {t("backToMarketplace")}
-      </Link>
+      <div className="mb-6 flex items-center justify-between">
+        <Link
+          href="/marketplace"
+          className="inline-flex items-center gap-2 text-sm text-zinc-500 hover:text-zinc-300"
+        >
+          <ArrowLeft className="h-4 w-4" /> {t("backToMarketplace")}
+        </Link>
+        <PrintButton label="Print / Save PDF" />      </div>
 
       <div className="grid gap-8 lg:grid-cols-3">
         {/* ── Left: Invoice Details ─────────────────────────────────────── */}
-        <div className="space-y-6 lg:col-span-2">
+        <PrintLayout
+          title={metadata.invoiceNumber}
+          subtitle={`${metadata.debtorName} · ${metadata.issuerName}`}
+          className="space-y-6 lg:col-span-2"
+        >
           {/* Header card */}
           <motion.div layoutId={`invoice-card-${id}`} initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }}>
             <Card>
@@ -513,10 +519,10 @@ Stellar Testnet Transaction Hash: ${txHash}`);
             <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }}>
               <InvoiceMetadataViewer invoice={invoice} isFunded={isFunded} />
             </motion.div>
-        </div>
+        </PrintLayout>
 
         {/* ── Right: Fund Panel ─────────────────────────────────────────── */}
-        <div className="space-y-4">
+        <div className="space-y-4" data-print-hide>
           <motion.div initial={{ opacity: 0, x: 16 }} animate={{ opacity: 1, x: 0 }} transition={{ delay: 0.2 }}>
             <GlassCard className="p-6">
               <div className="mb-4 flex items-center gap-2">

--- a/components/invoice/InvoiceCard.tsx
+++ b/components/invoice/InvoiceCard.tsx
@@ -79,6 +79,15 @@ export function InvoiceCard({ invoice, index = 0, updatedAt }: InvoiceCardProps)
   const countdown = useCountdown(listingExpiry);
   const isExpired = countdown.isExpired || status === "cancelled";
 
+  // Maturity countdown — only shown when ≤ 7 days to repayment
+  const showMaturityTimer = days >= 0 && days <= 7;
+  // midnight of repayment date
+  const maturityMidnight = terms.repaymentDate + "T23:59:59";
+  const maturityCountdown = useCountdown(maturityMidnight);
+  const prefersReducedMotion = typeof window !== "undefined"
+    ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    : false;
+
   const handleMouseEnter = () => {
     queryClient.prefetchQuery({
       queryKey: queryKeys.invoices.detail(invoice.id),
@@ -183,6 +192,25 @@ export function InvoiceCard({ invoice, index = 0, updatedAt }: InvoiceCardProps)
               </p>
             </div>
           </div>
+
+          {/* Maturity countdown — only when ≤7 days remain */}
+          {showMaturityTimer && (
+            <div className="mt-3 flex items-center gap-2 rounded-md border border-destructive/20 bg-destructive/5 px-2.5 py-1.5">
+              <Clock className="h-3.5 w-3.5 shrink-0 text-destructive" />
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Matures in</span>
+              {prefersReducedMotion ? (
+                <span className={cn("text-xs font-semibold", maturityCountdown.isExpired ? "text-muted-foreground" : "text-destructive")}>
+                  {maturityCountdown.isExpired ? "Matured" : `${days} day${days !== 1 ? "s" : ""} remaining`}
+                </span>
+              ) : (
+                <CountdownTimer
+                  targetDate={maturityMidnight}
+                  compact
+                  className={cn("text-xs font-semibold", maturityCountdown.isExpired ? "text-muted-foreground" : "text-destructive")}
+                />
+              )}
+            </div>
+          )}
         </div>
 
         <div>

--- a/components/ui/apr-display.tsx
+++ b/components/ui/apr-display.tsx
@@ -1,112 +1,81 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import { Info } from "lucide-react";
 import {
   calculateAPR,
   calculateRiskAdjustedReturn,
   getAPRColor,
   formatApr,
+  formatCurrency,
 } from "@/lib/utils";
 import { cn } from "@/lib/utils";
+import { Tooltip } from "@/components/ui/tooltip";
 
 interface APRDisplayProps {
   discountRate: number; // As decimal, e.g., 0.05 for 5%
   daysToMaturity: number;
+  financingAmount?: number;
   riskTier?: string;
   showRiskAdjusted?: boolean;
   size?: "sm" | "md" | "lg";
   compact?: boolean;
 }
 
-interface TooltipState {
-  show: boolean;
-  x: number;
-  y: number;
-}
-
 /**
- * APRDisplay component shows effective APR with color coding and optional tooltip.
+ * APRDisplay component shows effective APR with color coding and tooltip explaining the calculation.
  * Used in InvoiceCard, marketplace detail, and dashboards.
  */
 export function APRDisplay({
   discountRate,
   daysToMaturity,
+  financingAmount,
   riskTier,
   showRiskAdjusted = false,
   size = "md",
-  compact = false,
 }: APRDisplayProps) {
-  const [tooltip, setTooltip] = useState<TooltipState>({ show: false, x: 0, y: 0 });
-
   const apr = calculateAPR(discountRate, daysToMaturity);
   const riskAdjustedApr = riskTier ? calculateRiskAdjustedReturn(apr, riskTier) : apr;
   const displayApr = showRiskAdjusted ? riskAdjustedApr : apr;
-
-  const handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    setTooltip({
-      show: true,
-      x: rect.left,
-      y: rect.bottom + 8,
-    });
-  };
-
-  const handleMouseLeave = () => {
-    setTooltip({ ...tooltip, show: false });
-  };
-
-  const sizeClasses = {
-    sm: "text-sm",
-    md: "text-base",
-    lg: "text-lg",
-  };
-
   const aprColor = getAPRColor(displayApr);
 
+  const discountAmt = financingAmount != null ? financingAmount * discountRate : null;
+
+  const sizeClasses = { sm: "text-sm", md: "text-base", lg: "text-lg" };
+
+  const tooltipContent = (
+    <div className="space-y-1.5">
+      <p className="font-semibold text-xs">APR Calculation</p>
+      <p className="text-[11px] text-muted-foreground font-mono">
+        APR = (discount / financing amount) × (365 / days to maturity) × 100
+      </p>
+      <div className="border-t border-border pt-1.5 text-[11px] space-y-0.5">
+        <div>Discount rate: <span className="font-semibold">{(discountRate * 100).toFixed(2)}%</span></div>
+        {discountAmt != null && (
+          <div>Discount amount: <span className="font-semibold">{formatCurrency(discountAmt, "USDC")}</span></div>
+        )}
+        {financingAmount != null && (
+          <div>Financing amount: <span className="font-semibold">{formatCurrency(financingAmount, "USDC")}</span></div>
+        )}
+        <div>Days to maturity: <span className="font-semibold">{daysToMaturity}</span></div>
+        <div className="pt-1 border-t border-border">
+          Result: <span className={cn("font-bold", aprColor)}>{formatApr(displayApr)}</span>
+        </div>
+        {riskTier && showRiskAdjusted && (
+          <div>Risk-adjusted ({riskTier}): <span className="font-bold">{formatApr(riskAdjustedApr)}</span></div>
+        )}
+      </div>
+    </div>
+  );
+
   return (
-    <div
-      className="relative"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      <div className="flex items-center gap-1">
+    <Tooltip content={tooltipContent} side="bottom" contentClassName="max-w-[220px]">
+      <div className="flex items-center gap-1 cursor-help">
         <span className={cn("font-semibold", sizeClasses[size], aprColor)}>
           {formatApr(displayApr)}
         </span>
-        <Info className="w-4 h-4 text-muted-foreground cursor-help" />
+        <Info className="w-4 h-4 text-muted-foreground" />
       </div>
-
-      {/* Tooltip */}
-      {tooltip.show && (
-        <div
-          className="fixed z-50 bg-slate-900 text-slate-50 px-3 py-2 rounded-md text-sm whitespace-nowrap shadow-lg border border-slate-700"
-          style={{
-            left: `${tooltip.x}px`,
-            top: `${tooltip.y}px`,
-          }}
-        >
-          <div className="font-semibold">APR Calculation Breakdown</div>
-          <div className="text-xs text-slate-300 mt-1">
-            <div>Discount Rate: {(discountRate * 100).toFixed(2)}%</div>
-            <div>Days to Maturity: {daysToMaturity}</div>
-            <div className="mt-1 border-t border-slate-700 pt-1">
-              <div>Base APR: {formatApr(apr)}</div>
-              {riskTier && showRiskAdjusted && (
-                <div>Risk Tier ({riskTier}): {formatApr(riskAdjustedApr)}</div>
-              )}
-            </div>
-          </div>
-          {/* Tooltip arrow */}
-          <div
-            className="absolute w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-slate-900"
-            style={{
-              left: "20px",
-              top: "-4px",
-            }}
-          />
-        </div>
-      )}
-    </div>
+    </Tooltip>
   );
 }

--- a/components/ui/print-layout.tsx
+++ b/components/ui/print-layout.tsx
@@ -3,6 +3,25 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
+// Inject print styles once on mount — hides navbar, wallet button, and funding panel
+const PRINT_STYLES = `
+@media print {
+  nav, header, [data-print-hide] { display: none !important; }
+  .print-layout { display: block !important; }
+}
+`;
+
+function usePrintStyles() {
+  React.useEffect(() => {
+    if (document.getElementById("kora-print-styles")) return;
+    const el = document.createElement("style");
+    el.id = "kora-print-styles";
+    el.textContent = PRINT_STYLES;
+    document.head.appendChild(el);
+    return () => el.remove();
+  }, []);
+}
+
 interface PrintLayoutProps {
   children: React.ReactNode;
   title?: string;
@@ -16,6 +35,7 @@ interface PrintLayoutProps {
  * Use alongside window.print() or the PDF export utility.
  */
 export function PrintLayout({ children, title, subtitle, className }: PrintLayoutProps) {
+  usePrintStyles();
   return (
     <div className={cn("print-layout", className)}>
       {(title || subtitle) && (

--- a/components/ui/progress.stories.tsx
+++ b/components/ui/progress.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { Progress } from './progress';
+import { Progress, InvoiceFundingProgress } from './progress';
 
 const meta: Meta<typeof Progress> = {
   title: 'UI/Progress',
@@ -50,5 +50,40 @@ export const Small: Story = {
   args: {
     value: 33,
     className: 'w-[200px] h-2',
+  },
+};
+
+// ─── InvoiceFundingProgress Stories ───────────────────────────────────────────
+
+const fundingMeta: Meta<typeof InvoiceFundingProgress> = {
+  title: 'UI/InvoiceFundingProgress',
+  component: InvoiceFundingProgress,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+
+type FundingStory = StoryObj<typeof InvoiceFundingProgress>;
+
+export const FundingEmpty: FundingStory = {
+  render: () => <InvoiceFundingProgress funded={0} target={100000} currency="USDC" />,
+};
+
+export const FundingPartial: FundingStory = {
+  render: () => <InvoiceFundingProgress funded={60000} target={100000} currency="USDC" />,
+};
+
+export const FundingFull: FundingStory = {
+  render: () => <InvoiceFundingProgress funded={100000} target={100000} currency="USDC" />,
+};
+
+export const FundingAnimated: FundingStory = {
+  name: 'Animated (0 → current on mount)',
+  render: () => <InvoiceFundingProgress funded={75000} target={100000} currency="USDC" />,
+  parameters: {
+    docs: {
+      description: {
+        story: 'Progress bar animates from 0 to 75% on mount using Framer Motion (600ms ease-out). Animation is skipped when prefers-reduced-motion is set.',
+      },
+    },
   },
 };

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -83,6 +83,11 @@ function InvoiceFundingProgress({
   const showInnerLabel = pct >= 30;
   const relativeTime = useRelativeTime(updatedAt);
 
+  // Respect prefers-reduced-motion
+  const prefersReduced = typeof window !== "undefined"
+    ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    : false;
+
   // Flash the bar when funded amount changes
   const prevFunded = React.useRef(funded);
   const [flash, setFlash] = React.useState(false);
@@ -104,9 +109,9 @@ function InvoiceFundingProgress({
           <motion.div
             className={cn("absolute inset-y-0 left-0 rounded-full", flash && "brightness-125")}
             style={{ backgroundColor: color }}
-            initial={{ width: 0 }}
+            initial={prefersReduced ? false : { width: 0 }}
             animate={{ width: `${pct}%` }}
-            transition={{ type: "spring", stiffness: 60, damping: 18 }}
+            transition={prefersReduced ? { duration: 0 } : { duration: 0.6, ease: "easeOut" }}
           >
             {showInnerLabel && (
               <span className="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold text-white">


### PR DESCRIPTION
- closes #216 (APRDisplay tooltip): Replace manual tooltip with Radix Tooltip; show formula 'APR = (discount / financing amount) × (365 / days) × 100' with actual numbers (discount rate, financing amount, days, result). Added financingAmount prop for full breakdown.

- closes #214 (Print invoice view): Add usePrintStyles() to PrintLayout that injects @media print CSS hiding nav/header/[data-print-hide] elements. Wire PrintButton + PrintLayout into marketplace/[id]/page.tsx; funding panel gets data-print-hide, left column wrapped in PrintLayout with invoice title/subtitle. Button hidden in print output via print:hidden.

- closes #218 (CountdownTimer on maturity): Show CountdownTimer on InvoiceCard when daysToMaturity <= 7. Respects prefers-reduced-motion by showing static 'X days remaining' text instead. Shows 'Matured' after due date.

- closes #212 (Animated progress bar): Add prefers-reduced-motion guard to InvoiceFundingProgress; animation is initial={false}/duration:0 when reduced. Normal animation changed to 600ms ease-out (was spring). Added InvoiceFundingProgress Storybook stories including animated story.