### PR TITLE
feat: SEO routes, feature flags, Docker setup, bundle size tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,9 @@ NEXT_PUBLIC_APP_NAME=Kora
 NEXT_PUBLIC_APP_DESCRIPTION="On-chain Invoice Financing Protocol"
 
 # ─── Feature Flags ────────────────────────────────────────────────────────────
+# See lib/featureFlags.ts for the full flag reference.
 NEXT_PUBLIC_ENABLE_MOCK_DATA=true
 NEXT_PUBLIC_ENABLE_DEVTOOLS=true
+NEXT_PUBLIC_ENABLE_COMPARISON=false
+NEXT_PUBLIC_ENABLE_ONBOARDING_TOUR=false
+NEXT_PUBLIC_ENABLE_BATCH_ACTIONS=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-check:
+    name: Build & Bundle Size
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_STELLAR_NETWORK: testnet
+          NEXT_PUBLIC_STELLAR_RPC_URL: https://soroban-testnet.stellar.org
+          NEXT_PUBLIC_STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+          NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+          NEXT_PUBLIC_INVOICE_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+          NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+          NEXT_PUBLIC_TOKEN_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+          NEXT_PUBLIC_IPFS_GATEWAY: https://gateway.pinata.cloud/ipfs
+          NEXT_PUBLIC_APP_URL: http://localhost:3000
+          NEXT_PUBLIC_ENABLE_MOCK_DATA: "false"
+          NEXT_PUBLIC_ENABLE_DEVTOOLS: "false"
+
+      - name: Check bundle size
+        run: npx bundlesize

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,14 @@ cp .env.example .env.local
 
 # 6. Start the dev server
 npm run dev
+
+# — or use Docker —
+docker compose up
 ```
+
+### Bundle Size Tracking
+
+We use `bundlesize` to prevent bundle regressions. The CI workflow runs `npx bundlesize` on every PR. If you need to update the size limits (e.g. after adding a justified new dependency), edit the `"bundlesize"` section in `package.json`.
 
 ---
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,12 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+# Install dependencies first (layer caching)
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Source is mounted as a volume for hot reload — no COPY of src needed
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
+### Docker (Alternative)
+
+If you prefer Docker, run:
+
+```bash
+cp .env.example .env.local
+# Edit .env.local with your values
+docker compose up
+```
+
+The app will be available at [http://localhost:3000](http://localhost:3000) with hot reload enabled.
+
 ### Quick Start with Mock Data
 
 The app ships with mock data enabled by default (`NEXT_PUBLIC_ENABLE_MOCK_DATA=true`). You can browse the marketplace, view invoice details, and explore dashboards without a live Soroban connection.

--- a/app/dashboard/sme/page.tsx
+++ b/app/dashboard/sme/page.tsx
@@ -11,10 +11,11 @@ import { Progress } from "@/components/ui/progress";
 import { RepaymentDialog } from "@/components/invoice/RepaymentDialog";
 import { DashboardSkeleton } from "@/components/ui/skeleton";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { 
-  BatchActionToolbar, 
-  BatchResultSummary 
+import {
+  BatchActionToolbar,
+  BatchResultSummary
 } from "@/components/dashboard/BatchActionToolbar";
+import { isEnabled } from "@/lib/featureFlags";
 import { 
   prepareCancelInvoice, 
   submitAndConfirm 
@@ -480,14 +481,16 @@ export default function SMEDashboardPage() {
         }
       />
 
-      <BatchActionToolbar
-        selectedCount={selectedIds.length}
-        onCancel={handleBatchCancel}
-        onExport={handleBatchExport}
-        isProcessing={isBatchProcessing}
-        progress={batchProgress}
-        processingLabel={`Cancelling ${selectedIds.length} invoices...`}
-      />
+      {isEnabled("batch-actions") && (
+        <BatchActionToolbar
+          selectedCount={selectedIds.length}
+          onCancel={handleBatchCancel}
+          onExport={handleBatchExport}
+          isProcessing={isBatchProcessing}
+          progress={batchProgress}
+          processingLabel={`Cancelling ${selectedIds.length} invoices...`}
+        />
+      )}
 
       <Dialog open={!!batchResults} onOpenChange={(open) => !open && setBatchResults(null)}>
         <DialogContent>

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -32,6 +32,7 @@ import { sanitizeQueryParam } from "@/lib/security";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { RangeSlider } from "@/components/ui/range-slider";
 import { ComparisonBar } from "@/components/marketplace/ComparisonBar";
+import { isEnabled } from "@/lib/featureFlags";
 import { useDebounce } from "@/hooks/useDebounce";
 import { BottomSheet } from "@/components/ui/bottom-sheet";
 
@@ -771,7 +772,7 @@ function MarketplaceContent() {
       </BottomSheet>
 
       {/* Fixed comparison bar — renders above the page when invoices are selected */}
-      <ComparisonBar />
+      {isEnabled("comparison") && <ComparisonBar />}
     </Container>
   );
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -35,6 +35,7 @@ import { ThemeProvider } from "@/components/layout/ThemeProvider";
 import { LocaleProvider } from "@/i18n/LocaleProvider";
 import { useUIStore } from "@/store/uiStore";
 import { env } from "@/lib/env";
+import { isEnabled } from "@/lib/featureFlags";
 
 // Pre-load both locale message files at the module level so they are
 // bundled and available synchronously on the client.
@@ -93,7 +94,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <LocaleProvider allMessages={ALL_MESSAGES}>
         <ThemeProvider>
           {children}
-          <OnboardingTour />
+          {isEnabled("onboarding-tour") && <OnboardingTour />}
           <WalletConnectModal />
           <InProgressOverlay />
           <InstallPrompt />
@@ -102,7 +103,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
           <CommandPalette />
           <ChangelogModal />
           <ThemedToaster />
-          {env.NEXT_PUBLIC_ENABLE_DEVTOOLS && (
+          {isEnabled("devtools") && (
             <ReactQueryDevtools initialIsOpen={false} />
           )}
         </ThemeProvider>

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,0 +1,23 @@
+/**
+ * robots.txt — Issue #305
+ *
+ * Allows all crawlers to index public pages while blocking
+ * /api/ and /dashboard/ routes from search engines.
+ */
+export function GET() {
+  const body = `# Kora Protocol — robots.txt
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /dashboard/
+
+Sitemap: ${process.env.NEXT_PUBLIC_APP_URL || "https://kora.finance"}/sitemap.xml
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain",
+      "Cache-Control": "public, max-age=86400, s-maxage=86400",
+    },
+  });
+}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,51 @@
+/**
+ * sitemap.xml — Issue #305
+ *
+ * Generates a sitemap with all public pages. Marketplace invoice URLs
+ * can be extended dynamically when a data source is available.
+ * Dashboard and API routes are excluded.
+ */
+
+const STATIC_PAGES = [
+  { path: "/", changefreq: "daily", priority: "1.0" },
+  { path: "/marketplace", changefreq: "hourly", priority: "0.9" },
+  { path: "/analytics", changefreq: "daily", priority: "0.6" },
+  { path: "/transactions", changefreq: "daily", priority: "0.5" },
+  { path: "/invoice/create", changefreq: "weekly", priority: "0.7" },
+];
+
+function escapeXml(str: string) {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export async function GET() {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL || "https://kora.finance";
+  const now = new Date().toISOString().split("T")[0];
+
+  // Build static page entries
+  const staticEntries = STATIC_PAGES.map(
+    (page) => `  <url>
+    <loc>${escapeXml(`${baseUrl}${page.path}`)}</loc>
+    <lastmod>${now}</lastmod>
+    <changefreq>${page.changefreq}</changefreq>
+    <priority>${page.priority}</priority>
+  </url>`
+  );
+
+  // TODO: When an invoice listing API is available, fetch invoice IDs
+  // and add dynamic entries:
+  //   /marketplace/[id] for each published invoice
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${staticEntries.join("\n")}
+</urlset>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.8"
+
+services:
+  kora-frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "3000:3000"
+    volumes:
+      # Mount source for hot reload
+      - .:/app
+      # Anonymous volume to preserve node_modules from the image
+      - /app/node_modules
+      # Mount env file (must exist locally — not committed)
+      - ./.env.local:/app/.env.local:ro
+    environment:
+      - NODE_ENV=development
+      - WATCHPACK_POLLING=true

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -1,0 +1,49 @@
+/**
+ * Feature Flags — Issue #308
+ *
+ * Centralised, type-safe feature flag system backed by env vars.
+ * All flags default to `false` in production. Set to `"true"` in
+ * `.env.local` to enable a flag during development.
+ *
+ * Usage:
+ *   import { isEnabled } from "@/lib/featureFlags";
+ *   if (isEnabled("comparison")) { ... }
+ */
+
+/**
+ * Every feature flag supported by the app. Add new flags here.
+ *
+ * | Flag              | Env var                               | Description                                    |
+ * |-------------------|---------------------------------------|------------------------------------------------|
+ * | mock-data         | NEXT_PUBLIC_ENABLE_MOCK_DATA           | Use mock data (no live Soroban)                |
+ * | devtools          | NEXT_PUBLIC_ENABLE_DEVTOOLS            | Show React Query devtools                      |
+ * | comparison        | NEXT_PUBLIC_ENABLE_COMPARISON          | Invoice comparison bar in marketplace          |
+ * | onboarding-tour   | NEXT_PUBLIC_ENABLE_ONBOARDING_TOUR     | Guided onboarding tour for new users           |
+ * | batch-actions     | NEXT_PUBLIC_ENABLE_BATCH_ACTIONS       | Batch cancel/repay in SME dashboard            |
+ */
+export type FeatureFlag =
+  | "mock-data"
+  | "devtools"
+  | "comparison"
+  | "onboarding-tour"
+  | "batch-actions";
+
+/** Maps each flag to its NEXT_PUBLIC_* env var name. */
+const FLAG_ENV_MAP: Record<FeatureFlag, string> = {
+  "mock-data": "NEXT_PUBLIC_ENABLE_MOCK_DATA",
+  devtools: "NEXT_PUBLIC_ENABLE_DEVTOOLS",
+  comparison: "NEXT_PUBLIC_ENABLE_COMPARISON",
+  "onboarding-tour": "NEXT_PUBLIC_ENABLE_ONBOARDING_TOUR",
+  "batch-actions": "NEXT_PUBLIC_ENABLE_BATCH_ACTIONS",
+};
+
+/**
+ * Returns `true` if the given feature flag is enabled.
+ *
+ * Reads the corresponding NEXT_PUBLIC_* env var at runtime.
+ * Only the string `"true"` (case-sensitive) enables a flag.
+ */
+export function isEnabled(flag: FeatureFlag): boolean {
+  const envVar = FLAG_ENV_MAP[flag];
+  return process.env[envVar] === "true";
+}

--- a/package.json
+++ b/package.json
@@ -90,6 +90,21 @@
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "11.0.6",
     "@semantic-release/npm": "13.1.5",
-    "semantic-release": "24.2.1"
-  }
+    "semantic-release": "24.2.1",
+    "bundlesize": "0.18.2"
+  },
+  "bundlesize": [
+    {
+      "path": ".next/static/chunks/main-*.js",
+      "maxSize": "250 kB"
+    },
+    {
+      "path": ".next/static/chunks/framework-*.js",
+      "maxSize": "500 kB"
+    },
+    {
+      "path": ".next/static/chunks/pages/**/*.js",
+      "maxSize": "300 kB"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- **Closes #305** — Add `robots.txt` and `sitemap.xml` route handlers for SEO crawlability
- **Closes #308** — Implement centralized feature flags system (`lib/featureFlags.ts`) with typed flags and env var mapping; gate `comparison`, `onboarding-tour`, and `batch-actions` features behind flags
- **Closes #301** — Add `Dockerfile.dev` and `docker-compose.yml` for one-command local development (`docker compose up`)
- **Closes #306** — Add `bundlesize` devDependency with size limits and a CI workflow (`.github/workflows/ci.yml`) that runs type-check, lint, build, and bundle size checks on every PR

## Changes

| File | What |
|------|------|
| `app/robots.txt/route.ts` | Route handler returning robots.txt (allows all, disallows `/api/` and `/dashboard/`) |
| `app/sitemap.xml/route.ts` | Route handler generating XML sitemap for static pages |
| `lib/featureFlags.ts` | Centralized `isEnabled(flag)` function with typed `FeatureFlag` union |
| `app/marketplace/page.tsx` | Gate `ComparisonBar` behind `comparison` flag |
| `app/providers.tsx` | Gate `OnboardingTour` and devtools behind flags |
| `app/dashboard/sme/page.tsx` | Gate `BatchActionToolbar` behind `batch-actions` flag |
| `Dockerfile.dev` | Dev Docker image (node:18-alpine) |
| `docker-compose.yml` | Docker compose with hot reload and env mounting |
| `.github/workflows/ci.yml` | CI pipeline with bundlesize check |
| `package.json` | Add `bundlesize` dep + config |
| `.env.example` | Add new feature flag env vars |
| `README.md` | Docker setup docs |
| `CONTRIBUTING.md` | Docker + bundle size docs |

## Test plan

- [ ] `npm run dev` — app starts, feature-flagged components hidden when flags are `false`
- [ ] Set `NEXT_PUBLIC_ENABLE_COMPARISON=true` — `ComparisonBar` appears on marketplace
- [ ] `curl localhost:3000/robots.txt` — returns valid robots.txt
- [ ] `curl localhost:3000/sitemap.xml` — returns valid XML sitemap
- [ ] `docker compose up` — app starts with hot reload
- [ ] `npm run build && npx bundlesize` — passes size limits
- [ ] CI workflow triggers on PR and passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)