### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,57 @@
+---
+name: Bug report
+about: Report a reproducible problem in the Kora invoice financing app
+title: "[Bug]: "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+Describe the problem in one or two sentences.
+
+## Area
+
+- [ ] SME invoice creation
+- [ ] Investor marketplace
+- [ ] Invoice detail or funding flow
+- [ ] Portfolio positions
+- [ ] Wallet connection or signing
+- [ ] Smart contract or Soroban transaction flow
+- [ ] Other
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Result
+
+What should happen for the SME, investor, invoice, position, or wallet flow?
+
+## Actual Result
+
+What happened instead?
+
+## Wallet and Network
+
+- Wallet provider:
+- Wallet network or passphrase:
+- Public key type used, if relevant:
+- Transaction hash, if available:
+
+## Browser and Device
+
+- Browser:
+- Browser version:
+- Operating system:
+- Device or viewport:
+
+## Evidence
+
+Add screenshots, screen recordings, console logs, transaction hashes, or relevant invoice or position IDs.
+
+## Additional Context
+
+Anything else maintainers should know?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,46 @@
+---
+name: Feature request
+about: Propose an improvement for Kora SMEs, investors, invoices, or positions
+title: "[Feature]: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What user problem does this solve for SMEs, investors, or protocol operators?
+
+## Proposed Solution
+
+Describe the desired behavior.
+
+## User Flow
+
+1.
+2.
+3.
+
+## Affected Area
+
+- [ ] SME invoice upload or minting
+- [ ] Investor marketplace discovery
+- [ ] Invoice detail and funding
+- [ ] Portfolio positions and yield tracking
+- [ ] Wallet connection, signing, or network checks
+- [ ] Analytics or reporting
+- [ ] Accessibility, localization, or responsive UI
+- [ ] Developer experience
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Design or Copy Notes
+
+Include screenshots, wireframes, labels, empty states, or Kora-specific wording that should be used.
+
+## Risks and Edge Cases
+
+List any wallet, invoice, position, investor, SME, accessibility, or transaction edge cases.

--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,43 @@
+---
+name: Good first issue
+about: Define a scoped beginner-friendly task for Kora contributors
+title: "[Good First Issue]: "
+labels: good first issue
+assignees: ""
+---
+
+## Goal
+
+State the small, focused change that should be made.
+
+## Background
+
+Explain the Kora context. Mention the relevant invoice, SME, investor, wallet, or position flow.
+
+## Scope
+
+- [ ]
+- [ ]
+- [ ]
+
+## Out of Scope
+
+- [ ]
+
+## Files or Areas to Inspect
+
+- `path/to/file`
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Testing Guidance
+
+Describe the smallest useful checks, such as unit tests, component tests, accessibility checks, or manual wallet-flow verification.
+
+## Helpful Notes
+
+Add links to relevant docs, components, design-system tokens, or existing examples in the repository.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Summary
+
+- 
+
+## Linked Issue
+
+Closes #
+
+## What Changed
+
+- 
+- 
+
+## Testing Steps
+
+1.
+2.
+3.
+
+## Screenshots or Recordings
+
+Add before/after screenshots for UI changes, especially invoice, SME dashboard, investor marketplace, position, and wallet states.
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] Docs updated, if needed
+- [ ] Accessibility checked
+- [ ] Wallet and network behavior considered
+- [ ] SME, investor, invoice, or position terminology is accurate
+- [ ] No secrets, private keys, real wallet seed phrases, or live credentials added
+
+## Notes for Reviewers
+
+Call out any migration steps, mocked data, incomplete contract wiring, or areas that need focused review.


### PR DESCRIPTION
## Summary
- Adds bug report, feature request, and good first issue templates under `.github/ISSUE_TEMPLATE/`.
- Adds a repository pull request template requiring summary, linked issue, testing steps, screenshots for UI changes, and reviewer notes.
- Uses Kora-specific terminology such as invoice, position, SME, investor, wallet, and network flows.

Closes #298

## Testing
- [x] Verified all requested template files exist.
- [x] Checked templates include required prompts for reproduction steps, expected vs actual behavior, wallet/browser info, screenshots, linked issue, tests/docs/accessibility checklist, and Kora terminology.
