### PR TITLE
docs: add contributor quick-start guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,242 +1,268 @@
 # Contributing to Kora Protocol
 
-Thank you for your interest in contributing to Kora Protocol! This document explains how to get involved, what we expect from contributors, and how to submit high-quality work.
+Thank you for helping improve Kora Protocol. Kora is an on-chain invoice financing app on Stellar: SMEs tokenize invoices, investors fund invoice positions, and wallet flows connect the UI to Soroban and USDC activity.
 
----
+This guide is written for first-time contributors. Follow it from top to bottom when you set up the project, pick an issue, make a branch, test your work, and open a pull request.
 
-## Table of Contents
+## Contents
 
-- [Code of Conduct](#code-of-conduct)
-- [Ways to Contribute](#ways-to-contribute)
-- [Development Setup](#development-setup)
-- [Branch Strategy](#branch-strategy)
-- [Commit Convention](#commit-convention)
-- [Pull Request Process](#pull-request-process)
+- [Before You Start](#before-you-start)
+- [Fork and Clone](#fork-and-clone)
+- [Local Setup](#local-setup)
+- [Mock Data Mode](#mock-data-mode)
+- [Daily Development Commands](#daily-development-commands)
+- [Storybook](#storybook)
+- [Your First Issue](#your-first-issue)
+- [Branch Naming](#branch-naming)
+- [Commit Messages](#commit-messages)
+- [Testing Checklist](#testing-checklist)
+- [Pull Request Checklist](#pull-request-checklist)
 - [Code Style](#code-style)
-- [Testing](#testing)
-- [Issue Labels](#issue-labels)
 - [Getting Help](#getting-help)
 
----
+## Before You Start
 
-## Code of Conduct
+Install these tools:
 
-This project follows the [Contributor Covenant](https://www.contributor-covenant.org/). By participating, you agree to uphold a welcoming, respectful, and harassment-free environment for everyone.
+- Node.js 18 or newer.
+- npm 9 or newer.
+- Git.
+- A GitHub account.
+- Freighter or another Stellar wallet extension if you are testing wallet flows.
 
----
+This repository uses npm. Use `npm install` for local setup so npm can reconcile `package.json` with the lockfile when dependencies change.
 
-## Ways to Contribute
+## Fork and Clone
 
-| Type | Description |
-|------|-------------|
-| 🐛 Bug reports | Open an issue with reproduction steps |
-| 💡 Feature requests | Open an issue with the `enhancement` label |
-| 📖 Documentation | Fix typos, improve clarity, add examples |
-| 🔧 Code | Fix bugs, implement features, improve performance |
-| 🎨 Design | Improve UI/UX, accessibility, responsiveness |
-| 🧪 Tests | Add unit, integration, or E2E tests |
-| 🌍 Translations | Help localise the interface |
-
----
-
-## Development Setup
-
-### Prerequisites
-
-- Node.js 18+
-- npm, yarn, or pnpm
-- Git
-- [Freighter wallet](https://freighter.app) (for testing wallet flows)
-
-### Steps
+1. Fork `OpenLedger-Foundation/Kora-Frontend` on GitHub.
+2. Clone your fork:
 
 ```bash
-# 1. Fork the repository on GitHub
-# 2. Clone your fork
-git clone https://github.com/<your-username>/kora-frontend.git
-cd kora-frontend
+git clone https://github.com/<your-github-user>/Kora-Frontend.git
+cd Kora-Frontend
+```
 
-# 3. Add the upstream remote
-git remote add upstream https://github.com/kora-protocol/kora-frontend.git
+3. Add the upstream repository:
 
-# 4. Install dependencies
+```bash
+git remote add upstream https://github.com/OpenLedger-Foundation/Kora-Frontend.git
+git fetch upstream
+```
+
+4. Start every new task from the latest upstream `main`:
+
+```bash
+git switch main
+git pull --ff-only upstream main
+```
+
+## Local Setup
+
+Install dependencies:
+
+```bash
 npm install
+```
 
-# 5. Copy environment variables
+Create a local environment file:
+
+```bash
 cp .env.example .env.local
-# Fill in values — mock data mode works without any real keys
+```
 
-# 6. Start the dev server
+The example file documents the variables the app expects. Do not commit `.env.local`; it is ignored by Git and may contain private values.
+
+Start the app:
+
+```bash
 npm run dev
 ```
 
----
+Open `http://localhost:3000`.
 
-## Branch Strategy
+## Mock Data Mode
 
-We use a simplified **GitHub Flow**:
+Mock data mode lets you work on marketplace pages, SME dashboards, investor views, invoice cards, filters, and many UI states without live Stellar contracts.
 
-| Branch | Purpose |
-|--------|---------|
-| `main` | Production-ready code. Protected. |
-| `develop` | Integration branch for features. |
-| `feat/<name>` | New features |
-| `fix/<name>` | Bug fixes |
-| `docs/<name>` | Documentation changes |
-| `chore/<name>` | Tooling, deps, config |
+Use mock data mode when:
 
-**Always branch from `develop`**, not `main`.
+- You are building UI.
+- You are adding tests for stores, components, filters, or formatting.
+- You do not need a real wallet signature or Soroban transaction.
+
+Check `.env.example` for the mock-data flag. If it is enabled in `.env.local`, you can browse the app without live contract IDs or Pinata credentials.
+
+Use a wallet only when the issue specifically touches wallet connection, transaction signing, funding, repayment, or network mismatch behavior. For wallet testing, use Stellar Testnet and never commit seed phrases, private keys, or real credentials.
+
+## Daily Development Commands
+
+Use these commands before you open a PR:
 
 ```bash
-git checkout develop
-git pull upstream develop
-git checkout -b feat/my-feature
+npm run lint
+npm run type-check
+npm run test
+npm run build
 ```
 
----
+Other useful commands:
 
-## Commit Convention
-
-We follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-```
-<type>(<scope>): <short description>
-
-[optional body]
-
-[optional footer]
+```bash
+npm run test:watch       # run Vitest in watch mode
+npm run test:coverage    # generate a coverage report
+npm run test:e2e         # run Playwright end-to-end tests
+npm run format:check     # check Prettier formatting
+npm run format           # format files with Prettier
 ```
 
-### Types
+If a command fails because of existing unrelated failures, mention that clearly in your PR description and include the exact command output that proves your changed area was tested.
 
-| Type | When to use |
-|------|-------------|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `docs` | Documentation only |
-| `style` | Formatting, no logic change |
-| `refactor` | Code restructure, no feature/fix |
-| `perf` | Performance improvement |
-| `test` | Adding or fixing tests |
-| `chore` | Build process, dependencies |
-| `ci` | CI/CD changes |
+## Storybook
 
-### Examples
+Storybook is available for isolated UI work:
 
-```
-feat(marketplace): add APR range filter
-fix(wallet): handle Freighter connection timeout
-docs(readme): update environment variable table
-chore(deps): upgrade stellar-sdk to 12.3.0
+```bash
+npm run storybook
 ```
 
----
+Open the local Storybook URL printed by the command, usually `http://localhost:6006`.
 
-## Pull Request Process
+Build Storybook before submitting changes that add or modify stories:
 
-1. **Keep PRs focused** — one feature or fix per PR. Large PRs are hard to review.
-
-2. **Fill in the PR template** — describe what changed, why, and how to test it.
-
-3. **Link related issues** — use `Closes #123` in the PR description.
-
-4. **Pass all checks** — CI must be green before review:
-   - `npm run type-check` — no TypeScript errors
-   - `npm run lint` — no ESLint errors
-   - `npm run build` — production build succeeds
-
-5. **Request review** — tag at least one maintainer.
-
-6. **Address feedback** — respond to all review comments. Mark resolved threads.
-
-7. **Squash on merge** — maintainers will squash commits when merging.
-
-### PR Title Format
-
-Follow the same convention as commits:
-
-```
-feat(analytics): add monthly yield breakdown chart
-fix(invoice-detail): correct expected return calculation
+```bash
+npm run build-storybook
 ```
 
----
+Use Storybook for components in `components/ui`, invoice cards, empty states, loading states, dialogs, drawers, and other reusable UI pieces.
+
+## Your First Issue
+
+Start with small issues that have clear files, acceptance criteria, and tests. The best search is:
+
+```text
+is:issue is:open label:"good first issue"
+```
+
+If the `good first issue` label has not been populated yet, use the same approach with small documentation, test, or accessibility issues under the `Stellar Wave` label. Good starter-style candidates are:
+
+- `#228` - active filter chips with individual clear buttons.
+- `#232` - unit tests for `lib/utils.ts`.
+- `#233` - integration tests for the `useWallet` hook.
+- `#235` - filter and sort tests for `invoiceStore`.
+- `#245` - IPFS upload and verification tests.
+- `#296` - contributor quick-start guide.
+
+Before starting, read the issue comments. Do not take an issue that has already been assigned or accepted for another contributor. If a maintainer asks contributors to apply first, comment on the issue and wait for assignment before expecting reward-program credit.
+
+## Branch Naming
+
+Use short, descriptive branch names:
+
+```bash
+git switch -c docs/contributing-quickstart
+git switch -c test/invoice-store-filters
+git switch -c fix/wallet-network-mismatch
+git switch -c feat/marketplace-filter-chips
+```
+
+Recommended prefixes:
+
+- `docs/` for documentation only.
+- `test/` for tests only.
+- `fix/` for bug fixes.
+- `feat/` for new user-facing behavior.
+- `chore/` for tooling, configuration, or maintenance.
+
+## Commit Messages
+
+Use Conventional Commits:
+
+```text
+docs(contributing): add contributor quick-start guide
+test(invoice-store): cover filter combinations
+fix(wallet): handle network mismatch reconnects
+feat(marketplace): add active filter chip removal
+```
+
+Keep commits focused. If a commit includes unrelated formatting, generated output, and feature code together, it is harder to review.
+
+## Testing Checklist
+
+Choose the smallest useful validation for your change:
+
+- Documentation only: run `npm run format:check` if Markdown formatting changed, and verify links/commands manually.
+- Utility functions: run `npm run test -- <test-file>`.
+- Components or hooks: run the relevant Vitest file and `npm run lint`.
+- UI flows: run Storybook or Playwright where the issue asks for browser behavior.
+- Shared behavior: run `npm run lint`, `npm run type-check`, `npm run test`, and `npm run build`.
+
+For coverage issues, run:
+
+```bash
+npm run test:coverage
+```
+
+Add the coverage summary or relevant excerpt to the PR description when the issue asks for it.
+
+## Pull Request Checklist
+
+Before opening a PR:
+
+- Rebase on the latest upstream `main`.
+- Keep the PR limited to the issue scope.
+- Link the issue with `Closes #123`.
+- Explain what changed and why.
+- List every command you ran.
+- Add screenshots or recordings for UI changes.
+- Mention known limitations or existing unrelated failures.
+- Confirm no secrets, private keys, wallet seed phrases, or `.env.local` values are included.
+
+Example PR body:
+
+```text
+## Summary
+
+- Added focused tests for invoice store category, APR, jurisdiction, and risk filters.
+- Added fixture coverage for empty-result sorting.
+
+Closes #235
+
+## Testing
+
+- [x] npm run test -- store/__tests__/invoiceStore.test.ts
+- [x] npm run lint
+```
 
 ## Code Style
 
 ### TypeScript
 
-- Strict mode is enabled. No `any` unless absolutely necessary — use `unknown` and narrow.
-- Prefer `interface` for object shapes, `type` for unions/intersections.
-- Export types from `types/` — don't define domain types inline in components.
+- Prefer typed inputs and outputs.
+- Avoid `any`; use `unknown` and narrow it.
+- Keep domain types in `types/` when they are shared.
 
 ### React
 
-- Use functional components and hooks only.
-- Keep components small and single-purpose. Extract logic into hooks.
-- Use `"use client"` only when necessary (interactivity, browser APIs).
-- Prefer server components for data-fetching pages where possible.
+- Use functional components and hooks.
+- Add `"use client"` only when the component needs browser APIs, state, effects, or event handlers.
+- Extract repeated logic into hooks only when it simplifies the caller.
 
 ### Styling
 
-- Use Tailwind utility classes. Avoid inline styles.
-- Use the `cn()` utility from `lib/utils.ts` for conditional classes.
-- Follow the existing dark-mode-first design system.
-- Don't introduce new colour values — use the `kora-*` and `zinc-*` palette.
+- Use Tailwind utility classes and existing design tokens.
+- Use `cn()` from `lib/utils.ts` for conditional classes.
+- Keep accessibility in mind: labels, focus states, keyboard navigation, and screen reader announcements matter.
 
-### File Naming
+### Security
 
-| Type | Convention | Example |
-|------|-----------|---------|
-| Pages | `page.tsx` | `app/marketplace/page.tsx` |
-| Components | PascalCase | `InvoiceCard.tsx` |
-| Hooks | camelCase with `use` prefix | `useWallet.ts` |
-| Utilities | camelCase | `utils.ts` |
-| Types | camelCase | `invoice.ts` |
-
----
-
-## Testing
-
-> Testing infrastructure is being set up. See [#42](https://github.com/kora-protocol/kora-frontend/issues/42).
-
-When tests are available:
-
-```bash
-npm run test          # unit tests
-npm run test:e2e      # end-to-end tests
-npm run test:coverage # coverage report
-```
-
-**What to test:**
-- Utility functions in `lib/utils.ts`
-- Zustand store actions
-- Service layer functions (with mocked fetch)
-- Critical UI flows (wallet connect, fund invoice)
-
----
-
-## Issue Labels
-
-| Label | Meaning |
-|-------|---------|
-| `bug` | Something is broken |
-| `enhancement` | New feature or improvement |
-| `good first issue` | Suitable for first-time contributors |
-| `help wanted` | Maintainers want community input |
-| `documentation` | Docs-only change |
-| `wontfix` | Out of scope or intentional |
-| `duplicate` | Already reported |
-| `blocked` | Waiting on external dependency |
-
----
+- Never commit private keys, seed phrases, API keys, JWTs, or real customer data.
+- Do not log signatures, wallet seeds, private invoices, or credentials.
+- Use `.env.local` for local secrets and `.env.example` only for safe placeholders.
 
 ## Getting Help
 
-- **Discord:** [discord.gg/kora-protocol](https://discord.gg/kora-protocol) *(coming soon)*
-- **GitHub Discussions:** Use the Discussions tab for questions
-- **Issues:** For bugs and feature requests only
+- Ask questions on the issue when the acceptance criteria are unclear.
+- Include file paths, screenshots, and command output when reporting setup problems.
+- Keep discussion on GitHub unless maintainers explicitly ask contributors to use another channel.
 
----
-
-Thank you for helping build the future of invoice financing on Stellar! 🚀
+Thanks for contributing to Kora Protocol.


### PR DESCRIPTION
## Summary
- Rewrites CONTRIBUTING.md as a first-time contributor quick-start for Kora.
- Covers fork/clone, local env setup, mock data mode, daily commands, Storybook, branch naming, commit convention, and PR checklist.
- Adds a "Your First Issue" section with the good-first-issue search query and current starter-style Kora issues to use while that label has no active results.

Closes #296

## Validation
- [x] npm install
- [x] npx prettier --check CONTRIBUTING.md --no-config
- [x] git diff --check
- [x] Verified CONTRIBUTING.md is 269 lines and ASCII-only.
- [x] Checked the repository currently has no open issues under label:"good first issue"; documented the search query plus fallback starter-style issues #228, #232, #233, #235, #245, and #296.

## Notes
- `npm ci` currently fails before this docs change because package.json and package-lock.json are not in sync around semantic-release dependencies, so the guide uses `npm install` for local setup.
- `npm run format:check -- CONTRIBUTING.md` is blocked by the repo's existing Prettier config referencing `prettier-plugin-tailwindcss`, which is not installed; Markdown was checked with Prettier using `--no-config`.
- `npm run type-check` currently fails on existing unrelated TypeScript errors outside this docs-only change.
