### PR TITLE
feat: set up Playwright component testing for key UI primitives (#249)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,51 @@ jobs:
         run: |
           echo "Coverage thresholds enforced in vitest.config.ts"
           echo "Lines: 80%, Branches: 70%, Functions: 75%"
+
+  playwright-components:
+    name: Playwright — Component tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        # Only install Chromium — the component tests use the "components" project
+        # which targets Desktop Chrome exclusively.
+        run: npx playwright install --with-deps chromium
+
+      - name: Build Next.js application
+        # A production build is faster and more stable for CI than `npm run dev`.
+        run: npm run build
+        env:
+          # Disable telemetry in CI
+          NEXT_TELEMETRY_DISABLED: 1
+          # Ensure mock data is enabled so tests don't need a live Soroban RPC
+          NEXT_PUBLIC_ENABLE_MOCK_DATA: true
+
+      - name: Run Playwright component tests
+        run: npx playwright test --project=components
+        env:
+          CI: true
+          # Point Playwright at the production server started by webServer config
+          PLAYWRIGHT_BASE_URL: http://localhost:3000
+          NEXT_PUBLIC_ENABLE_MOCK_DATA: true
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-component-report
+          path: playwright-report/
+          retention-days: 30
+

--- a/app/test-components/page.tsx
+++ b/app/test-components/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * /test-components — Component test fixture page
+ *
+ * Mounts the three UI primitives that need browser-level Playwright testing
+ * in complete isolation.  Only available when NEXT_PUBLIC_ENABLE_MOCK_DATA is
+ * true (i.e. never reachable in production).
+ *
+ * This page is intentionally minimal — no auth, no wallet, no providers beyond
+ * what the components themselves need.  It exists solely to give the Playwright
+ * component tests a stable, predictable URL to navigate to.
+ *
+ * Sections (each has a data-testid for targeted locators):
+ *   #file-input-fixture   — FileInput component
+ *   #range-slider-fixture — RangeSlider component
+ *   #date-picker-fixture  — DatePicker component
+ */
+
+import * as React from "react";
+import { FileInput } from "@/components/ui/file-input";
+import { RangeSlider } from "@/components/ui/range-slider";
+import { DatePicker } from "@/components/ui/date-picker";
+
+// ── FileInput fixture ────────────────────────────────────────────────────────
+
+function FileInputFixture() {
+  const [file, setFile] = React.useState<File | null>(null);
+
+  return (
+    <section id="file-input-fixture" className="space-y-2">
+      <h2 className="text-sm font-semibold uppercase tracking-widest text-zinc-400">
+        FileInput
+      </h2>
+      <FileInput
+        label="Invoice Document"
+        maxSizeMB={5}
+        value={file}
+        onChange={(e) => {
+          const f = e.target.files?.[0] ?? null;
+          setFile(f);
+        }}
+      />
+      {file && (
+        <p data-testid="selected-file-name" className="text-xs text-zinc-400">
+          Selected: {file.name}
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ── RangeSlider fixture ──────────────────────────────────────────────────────
+
+function RangeSliderFixture() {
+  const [value, setValue] = React.useState<[number, number]>([0, 50]);
+
+  return (
+    <section id="range-slider-fixture" className="space-y-4">
+      <h2 className="text-sm font-semibold uppercase tracking-widest text-zinc-400">
+        RangeSlider
+      </h2>
+      <div data-testid="range-slider-output" className="text-xs text-zinc-300 font-mono">
+        {value[0]}% – {value[1]}%
+      </div>
+      <RangeSlider
+        min={0}
+        max={50}
+        step={1}
+        value={value}
+        onChange={setValue}
+        formatLabel={(v) => `${v}%`}
+      />
+    </section>
+  );
+}
+
+// ── DatePicker fixture ───────────────────────────────────────────────────────
+
+function DatePickerFixture() {
+  const today = new Date().toISOString().split("T")[0];
+  const [date, setDate] = React.useState<string>("");
+
+  return (
+    <section id="date-picker-fixture" className="space-y-2">
+      <h2 className="text-sm font-semibold uppercase tracking-widest text-zinc-400">
+        DatePicker
+      </h2>
+      <DatePicker
+        label="Select Date"
+        name="fixture-date"
+        min={today}
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        placeholder="Select date..."
+      />
+      {date && (
+        <p data-testid="selected-date-value" className="text-xs text-zinc-400 font-mono">
+          Value: {date}
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function TestComponentsPage() {
+  // Safety guard: only render in non-production environments
+  if (
+    process.env.NEXT_PUBLIC_ENABLE_MOCK_DATA !== "true" &&
+    process.env.NODE_ENV === "production"
+  ) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-zinc-500 text-sm">
+        Not available in production.
+      </div>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-zinc-950 p-8 space-y-12 max-w-lg mx-auto">
+      <h1 className="text-lg font-bold text-zinc-100">
+        Component Test Fixtures
+      </h1>
+      <FileInputFixture />
+      <RangeSliderFixture />
+      <DatePickerFixture />
+    </main>
+  );
+}

--- a/e2e/components/date-picker.spec.ts
+++ b/e2e/components/date-picker.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * Component tests — DatePicker
+ *
+ * These tests exercise the custom DatePicker UI primitive
+ * (components/ui/date-picker.tsx), which is built on Radix UI Popover and
+ * renders its calendar grid into a portal.  Portal-based rendering and the
+ * popover open/close lifecycle cannot be tested in jsdom.
+ *
+ * The tests run against the isolated fixture page at /test-components
+ * (app/test-components/page.tsx), which mounts DatePicker with:
+ *   label="Select Date", name="fixture-date", min=today
+ *
+ * Do NOT duplicate any Vitest / jsdom tests.  This file covers:
+ *  - Trigger button renders with placeholder text before selection
+ *  - Calendar popover is not visible before the trigger is clicked
+ *  - Clicking the trigger opens the calendar and shows the current month/year
+ *  - Day-of-week column headers (Su Mo Tu We Th Fr Sa) are visible
+ *  - Clicking a future day closes the calendar
+ *  - Selected date is written as YYYY-MM-DD into the hidden <input>
+ *  - Trigger button text updates to the formatted selected date
+ *  - "Next month" chevron advances the calendar header by one month
+ *  - "Prev month" chevron retreats the calendar header
+ *  - Navigating forward then back restores the original month header
+ *  - Days before the min date are rendered as disabled buttons
+ *  - Clicking a disabled date leaves the hidden input empty
+ *  - Pressing Escape closes the calendar
+ *  - Clicking outside the popover closes the calendar
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { format, addMonths } from "date-fns";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function gotoFixture(page: Page) {
+  await page.goto("/test-components");
+  await expect(page.locator("#date-picker-fixture")).toBeVisible();
+}
+
+/** The Radix Popover trigger button for the DatePicker */
+const getTrigger = (page: Page) =>
+  page
+    .locator("#date-picker-fixture")
+    .getByRole("button")
+    .first();
+
+/**
+ * The Radix Popover portal content.
+ * Radix renders the calendar outside #date-picker-fixture, so we locate it
+ * by the presence of numbered day buttons inside it.
+ */
+const getCalendar = (page: Page) =>
+  page
+    .locator('[data-radix-popper-content-wrapper]')
+    .filter({ has: page.locator("button", { hasText: /^\d+$/ }) })
+    .first();
+
+/** The "Next month" chevron button inside the calendar */
+const getNextMonthBtn = (page: Page) =>
+  getCalendar(page).getByRole("button").last();
+
+/** The "Prev month" chevron button inside the calendar */
+const getPrevMonthBtn = (page: Page) =>
+  getCalendar(page).getByRole("button").first();
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe("DatePicker component — date selection", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoFixture(page);
+  });
+
+  // ── Initial rendering ─────────────────────────────────────────────────────
+
+  test("trigger button renders with placeholder text before selection", async ({
+    page,
+  }) => {
+    await expect(
+      page.locator("#date-picker-fixture").getByText(/Select date/i)
+    ).toBeVisible();
+  });
+
+  test("calendar popover is not visible before the trigger is clicked", async ({
+    page,
+  }) => {
+    // The current month/year header only exists inside the open popover
+    const monthYear = format(new Date(), "MMMM yyyy");
+    await expect(
+      page.locator('[data-radix-popper-content-wrapper]').getByText(monthYear)
+    ).not.toBeVisible();
+  });
+
+  // ── Opening the calendar ──────────────────────────────────────────────────
+
+  test("clicking the trigger opens the calendar popover", async ({ page }) => {
+    await getTrigger(page).click();
+    const monthYear = format(new Date(), "MMMM yyyy");
+    await expect(
+      page.locator('[data-radix-popper-content-wrapper]').getByText(monthYear)
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("calendar header shows the current month and year", async ({ page }) => {
+    await getTrigger(page).click();
+    const cal = getCalendar(page);
+    await expect(cal.getByText(format(new Date(), "MMMM yyyy"))).toBeVisible();
+  });
+
+  test("calendar renders day-of-week column headers", async ({ page }) => {
+    await getTrigger(page).click();
+    const cal = getCalendar(page);
+    for (const day of ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]) {
+      await expect(cal.getByText(day).first()).toBeVisible();
+    }
+  });
+
+  // ── Selecting a date ──────────────────────────────────────────────────────
+
+  test("clicking a future day cell closes the calendar", async ({ page }) => {
+    await getTrigger(page).click();
+
+    // Navigate one month forward so no days are blocked by the min=today constraint
+    await getNextMonthBtn(page).click();
+
+    const cal = getCalendar(page);
+    await cal.getByRole("button", { name: "15" }).first().click();
+
+    // After selection the popover should close
+    await expect(getCalendar(page)).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test("selecting a date writes YYYY-MM-DD into the hidden input", async ({
+    page,
+  }) => {
+    await getTrigger(page).click();
+    const nextMonth = addMonths(new Date(), 1);
+    await getNextMonthBtn(page).click();
+
+    const cal = getCalendar(page);
+    await cal.getByRole("button", { name: "10" }).first().click();
+
+    const expectedValue = format(
+      new Date(nextMonth.getFullYear(), nextMonth.getMonth(), 10),
+      "yyyy-MM-dd"
+    );
+
+    // The fixture renders <p data-testid="selected-date-value">Value: {date}</p>
+    await expect(page.getByTestId("selected-date-value")).toContainText(
+      expectedValue,
+      { timeout: 3_000 }
+    );
+  });
+
+  test("trigger button text updates to the formatted selected date", async ({
+    page,
+  }) => {
+    const trigger = getTrigger(page);
+    await trigger.click();
+
+    const nextMonth = addMonths(new Date(), 1);
+    await getNextMonthBtn(page).click();
+
+    const cal = getCalendar(page);
+    await cal.getByRole("button", { name: "20" }).first().click();
+
+    const expectedLabel = format(
+      new Date(nextMonth.getFullYear(), nextMonth.getMonth(), 20),
+      "PPP"
+    );
+    await expect(trigger).toContainText(expectedLabel, { timeout: 3_000 });
+  });
+
+  // ── Month navigation ───────────────────────────────────────────────────────
+
+  test("next-month chevron advances the calendar header by one month", async ({
+    page,
+  }) => {
+    await getTrigger(page).click();
+    await getNextMonthBtn(page).click();
+    const nextHeader = format(addMonths(new Date(), 1), "MMMM yyyy");
+    await expect(getCalendar(page).getByText(nextHeader)).toBeVisible();
+  });
+
+  test("prev-month chevron retreats the calendar header", async ({ page }) => {
+    await getTrigger(page).click();
+
+    // Go forward two months first so prev-month isn't blocked by min=today
+    await getNextMonthBtn(page).click();
+    await getNextMonthBtn(page).click();
+
+    await getPrevMonthBtn(page).click();
+
+    const expectedHeader = format(addMonths(new Date(), 1), "MMMM yyyy");
+    await expect(getCalendar(page).getByText(expectedHeader)).toBeVisible();
+  });
+
+  test("navigating forward then back restores the original month header", async ({
+    page,
+  }) => {
+    const originalHeader = format(new Date(), "MMMM yyyy");
+    await getTrigger(page).click();
+    await getNextMonthBtn(page).click();
+    await getPrevMonthBtn(page).click();
+    await expect(getCalendar(page).getByText(originalHeader)).toBeVisible();
+  });
+
+  // ── Disabled dates ─────────────────────────────────────────────────────────
+
+  test("days before the min date are rendered as disabled buttons", async ({
+    page,
+  }) => {
+    await getTrigger(page).click();
+
+    // Navigate one month back — all days there are before today (min=today)
+    await getPrevMonthBtn(page).click();
+
+    const cal = getCalendar(page);
+    const disabledDays = cal.locator("button[disabled]");
+    await expect(disabledDays.first()).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("clicking a disabled date leaves the hidden input empty", async ({
+    page,
+  }) => {
+    await getTrigger(page).click();
+    await getPrevMonthBtn(page).click();
+
+    const cal = getCalendar(page);
+    const disabledDay = cal.locator("button[disabled]").first();
+
+    if (await disabledDay.isVisible()) {
+      await disabledDay.click({ force: true });
+    }
+
+    // No date value should have been written
+    await expect(page.getByTestId("selected-date-value")).not.toBeVisible();
+  });
+
+  // ── Dismissal ─────────────────────────────────────────────────────────────
+
+  test("pressing Escape closes the calendar", async ({ page }) => {
+    await getTrigger(page).click();
+    await expect(getCalendar(page)).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await expect(getCalendar(page)).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test("clicking outside the popover closes the calendar", async ({ page }) => {
+    await getTrigger(page).click();
+    await expect(getCalendar(page)).toBeVisible();
+
+    // Click the page heading — always outside the popover
+    await page
+      .locator("h1", { hasText: /Component Test Fixtures/i })
+      .click();
+
+    await expect(getCalendar(page)).not.toBeVisible({ timeout: 3_000 });
+  });
+});

--- a/e2e/components/file-input.spec.ts
+++ b/e2e/components/file-input.spec.ts
@@ -1,0 +1,267 @@
+/**
+ * Component tests — FileInput
+ *
+ * These tests exercise browser-specific interactions that cannot be reliably
+ * reproduced in jsdom.  react-dropzone uses native DataTransfer and
+ * URL.createObjectURL, both of which require a real browser context.
+ *
+ * They run against the isolated fixture page at /test-components
+ * (app/test-components/page.tsx), which mounts FileInput in a clean state
+ * with no surrounding form logic.
+ *
+ * Do NOT duplicate any Vitest / jsdom tests.  This file covers:
+ *  - Drop zone renders with correct placeholder copy
+ *  - The hidden file <input> only accepts application/pdf
+ *  - Selecting a valid PDF: name shown, size shown, prompt hidden, remove button shown
+ *  - Remove button: clears selection and restores empty state
+ *  - Selecting a non-PDF: "Only PDF files are accepted" error appears
+ *  - Selecting an oversized PDF: "File is too large" error appears
+ *  - dragenter / dragover: isDragActive highlight class applied to drop zone
+ *  - Programmatic drop of a valid PDF: file name shown
+ *  - Programmatic drop of a non-PDF: type-error message shown
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function gotoFixture(page: Page) {
+  await page.goto("/test-components");
+  // Wait for the FileInput section to be mounted
+  await expect(page.locator("#file-input-fixture")).toBeVisible();
+}
+
+/** The dashed drop zone div */
+const getDropzone = (page: Page) =>
+  page.locator("#file-input-fixture [class*='border-dashed']").first();
+
+/** The hidden <input type="file"> inside the dropzone */
+const getFileInput = (page: Page) =>
+  page.locator('#file-input-fixture input[type="file"]').first();
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe("FileInput component — browser interactions", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoFixture(page);
+  });
+
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  test("renders the drop zone with correct placeholder copy", async ({
+    page,
+  }) => {
+    await expect(
+      page.getByText(/Drag & drop your invoice PDF here/i)
+    ).toBeVisible();
+    await expect(page.getByText(/Only PDF up to/i)).toBeVisible();
+  });
+
+  test("renders browse link inside the drop zone", async ({ page }) => {
+    await expect(
+      page.locator("#file-input-fixture").getByText(/browse/i)
+    ).toBeVisible();
+  });
+
+  test("file input only accepts PDF files", async ({ page }) => {
+    const accept = await getFileInput(page).getAttribute("accept");
+    expect(accept).toContain("pdf");
+  });
+
+  // ── Successful file selection ──────────────────────────────────────────────
+
+  test("selecting a valid PDF shows the file name", async ({ page }) => {
+    await getFileInput(page).setInputFiles({
+      name: "invoice-test.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 test content"),
+    });
+
+    await expect(page.getByText("invoice-test.pdf")).toBeVisible();
+  });
+
+  test("selecting a valid PDF shows the file size", async ({ page }) => {
+    await getFileInput(page).setInputFiles({
+      name: "invoice-test.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 test content"),
+    });
+
+    // FileInput calls formatBytes which returns e.g. "21 Bytes", "2.5 KB" etc.
+    await expect(page.getByText(/\d+(\.\d+)?\s*(bytes|kb|mb)/i)).toBeVisible();
+  });
+
+  test("selecting a valid PDF hides the empty-state prompt", async ({
+    page,
+  }) => {
+    await getFileInput(page).setInputFiles({
+      name: "invoice-test.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 test"),
+    });
+
+    await expect(
+      page.getByText(/Drag & drop your invoice PDF here/i)
+    ).not.toBeVisible();
+  });
+
+  test("selecting a valid PDF shows the remove button", async ({ page }) => {
+    await getFileInput(page).setInputFiles({
+      name: "invoice-test.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 test"),
+    });
+
+    await expect(
+      page
+        .locator("#file-input-fixture")
+        .getByRole("button", { name: /remove file/i })
+    ).toBeVisible();
+  });
+
+  // ── Remove file ───────────────────────────────────────────────────────────
+
+  test("clicking the remove button clears the file selection", async ({
+    page,
+  }) => {
+    await getFileInput(page).setInputFiles({
+      name: "invoice-test.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 test"),
+    });
+    await expect(page.getByText("invoice-test.pdf")).toBeVisible();
+
+    await page
+      .locator("#file-input-fixture")
+      .getByRole("button", { name: /remove file/i })
+      .click();
+
+    await expect(
+      page.getByText(/Drag & drop your invoice PDF here/i)
+    ).toBeVisible();
+  });
+
+  test("clicking the remove button hides the file name", async ({ page }) => {
+    await getFileInput(page).setInputFiles({
+      name: "invoice-test.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("%PDF-1.4 test"),
+    });
+
+    await page
+      .locator("#file-input-fixture")
+      .getByRole("button", { name: /remove file/i })
+      .click();
+
+    await expect(page.getByText("invoice-test.pdf")).not.toBeVisible();
+  });
+
+  // ── Validation errors ─────────────────────────────────────────────────────
+
+  test("selecting a non-PDF file shows 'Only PDF files' error", async ({
+    page,
+  }) => {
+    await getFileInput(page).setInputFiles({
+      name: "document.docx",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      buffer: Buffer.from("PK fake docx"),
+    });
+
+    await expect(page.getByText(/only pdf files are accepted/i)).toBeVisible();
+  });
+
+  test("selecting an oversized PDF shows a size-limit error", async ({
+    page,
+  }) => {
+    // 6 MB — over the 5 MB limit configured in FileInputFixture
+    const oversized = Buffer.alloc(6 * 1024 * 1024, 0);
+    await getFileInput(page).setInputFiles({
+      name: "too-big.pdf",
+      mimeType: "application/pdf",
+      buffer: oversized,
+    });
+
+    await expect(page.getByText(/file is too large/i)).toBeVisible();
+  });
+
+  // ── Drag-and-drop ─────────────────────────────────────────────────────────
+
+  test("dragenter + dragover applies the active-highlight to the drop zone", async ({
+    page,
+  }) => {
+    const dropzone = getDropzone(page);
+
+    // Fire synthetic DragEvents with a PDF DataTransfer into the dropzone
+    await page.evaluate(() => {
+      const zone = document.querySelector<HTMLElement>(
+        "#file-input-fixture [class*='border-dashed']"
+      );
+      if (!zone) return;
+
+      const dt = new DataTransfer();
+      dt.items.add(
+        new File(["content"], "test.pdf", { type: "application/pdf" })
+      );
+
+      zone.dispatchEvent(
+        new DragEvent("dragenter", { bubbles: true, dataTransfer: dt })
+      );
+      zone.dispatchEvent(
+        new DragEvent("dragover", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        })
+      );
+    });
+
+    // react-dropzone sets isDragActive → adds border-primary / bg-primary/5
+    await expect(dropzone).toHaveClass(/border-primary|bg-primary/);
+  });
+
+  test("dropping a valid PDF onto the drop zone shows the file name", async ({
+    page,
+  }) => {
+    const dropzone = getDropzone(page);
+
+    await dropzone.dispatchEvent("drop", {
+      dataTransfer: {
+        files: [
+          {
+            name: "dropped-invoice.pdf",
+            mimeType: "application/pdf",
+            buffer: Buffer.from("%PDF-1.4 dropped"),
+          },
+        ],
+      },
+    });
+
+    await expect(page.getByText("dropped-invoice.pdf")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("dropping a non-PDF file onto the drop zone shows a type error", async ({
+    page,
+  }) => {
+    const dropzone = getDropzone(page);
+
+    await dropzone.dispatchEvent("drop", {
+      dataTransfer: {
+        files: [
+          {
+            name: "spreadsheet.xlsx",
+            mimeType:
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            buffer: Buffer.from("PK fake xlsx"),
+          },
+        ],
+      },
+    });
+
+    await expect(page.getByText(/only pdf files are accepted/i)).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+});

--- a/e2e/components/range-slider.spec.ts
+++ b/e2e/components/range-slider.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * Component tests — RangeSlider
+ *
+ * These tests exercise keyboard interactions on the dual-thumb RangeSlider
+ * component (components/ui/range-slider.tsx).
+ *
+ * jsdom cannot reliably fire native keyboard events on <input type="range">
+ * and observe value changes, making this a browser-only concern.
+ *
+ * The tests run against the isolated fixture page at /test-components
+ * (app/test-components/page.tsx), which mounts RangeSlider with:
+ *   min=0, max=50, step=1, initial value=[0, 50]
+ *   formatLabel={(v) => `${v}%`}
+ *
+ * The component (range-slider.tsx) uses:
+ *   aria-label={`Minimum value: ${formatLabel(minVal)}`}  → "Minimum value: 0%"
+ *   aria-label={`Maximum value: ${formatLabel(maxVal)}`}  → "Maximum value: 50%"
+ *
+ * Do NOT duplicate any Vitest / jsdom tests.  This file covers:
+ *  - Both range thumbs are present and keyboard-focusable
+ *  - Aria-labels correctly identify min and max thumbs
+ *  - Live output label reflects current state
+ *  - Min thumb: ArrowRight / ArrowUp increase value
+ *  - Min thumb: ArrowLeft / ArrowDown decrease value
+ *  - Min thumb: Home key jumps to minimum bound (0)
+ *  - Min thumb: End key clamps strictly below max thumb
+ *  - Max thumb: ArrowLeft decreases value
+ *  - Max thumb: ArrowRight increases value
+ *  - Max thumb: End key jumps to maximum bound (50)
+ *  - Max thumb: Home key clamps strictly above min thumb
+ *  - Min thumb clamped: cannot exceed max under repeated ArrowRight
+ *  - Max thumb clamped: cannot go below min under repeated ArrowLeft
+ *  - Endpoint labels (0% / 50%) visible below the slider track
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function gotoFixture(page: Page) {
+  await page.goto("/test-components");
+  await expect(page.locator("#range-slider-fixture")).toBeVisible();
+}
+
+/** The min-thumb: first <input type="range"> inside the fixture section */
+const getMinThumb = (page: Page) =>
+  page.locator('#range-slider-fixture input[type="range"]').nth(0);
+
+/** The max-thumb: second <input type="range"> inside the fixture section */
+const getMaxThumb = (page: Page) =>
+  page.locator('#range-slider-fixture input[type="range"]').nth(1);
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe("RangeSlider component — keyboard interactions", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoFixture(page);
+  });
+
+  // ── Presence and accessibility ─────────────────────────────────────────────
+
+  test("both range thumbs are present inside the fixture", async ({ page }) => {
+    await expect(getMinThumb(page)).toBeVisible();
+    await expect(getMaxThumb(page)).toBeVisible();
+  });
+
+  test("min thumb aria-label contains 'Minimum value'", async ({ page }) => {
+    const label = await getMinThumb(page).getAttribute("aria-label");
+    expect(label).toMatch(/minimum value/i);
+  });
+
+  test("max thumb aria-label contains 'Maximum value'", async ({ page }) => {
+    const label = await getMaxThumb(page).getAttribute("aria-label");
+    expect(label).toMatch(/maximum value/i);
+  });
+
+  test("both thumbs are keyboard-focusable (tabIndex is not -1)", async ({
+    page,
+  }) => {
+    const minTab = await getMinThumb(page).evaluate(
+      (el: HTMLInputElement) => el.tabIndex
+    );
+    const maxTab = await getMaxThumb(page).evaluate(
+      (el: HTMLInputElement) => el.tabIndex
+    );
+    expect(minTab).not.toBe(-1);
+    expect(maxTab).not.toBe(-1);
+  });
+
+  // ── Min thumb keyboard navigation ─────────────────────────────────────────
+
+  test("ArrowRight on min thumb increases its value by one step", async ({
+    page,
+  }) => {
+    const thumb = getMinThumb(page);
+    const before = Number(await thumb.inputValue());
+    await thumb.focus();
+    await thumb.press("ArrowRight");
+    const after = Number(await thumb.inputValue());
+    expect(after).toBeGreaterThan(before);
+  });
+
+  test("ArrowLeft on min thumb decreases its value by one step", async ({
+    page,
+  }) => {
+    const thumb = getMinThumb(page);
+    // Move right first so there is room to move left
+    await thumb.focus();
+    await thumb.press("ArrowRight");
+    await thumb.press("ArrowRight");
+    const before = Number(await thumb.inputValue());
+    await thumb.press("ArrowLeft");
+    const after = Number(await thumb.inputValue());
+    expect(after).toBeLessThan(before);
+  });
+
+  test("ArrowUp on min thumb increases its value (same as ArrowRight)", async ({
+    page,
+  }) => {
+    const thumb = getMinThumb(page);
+    const before = Number(await thumb.inputValue());
+    await thumb.focus();
+    await thumb.press("ArrowUp");
+    const after = Number(await thumb.inputValue());
+    expect(after).toBeGreaterThan(before);
+  });
+
+  test("ArrowDown on min thumb decreases its value (same as ArrowLeft)", async ({
+    page,
+  }) => {
+    const thumb = getMinThumb(page);
+    await thumb.focus();
+    await thumb.press("ArrowRight");
+    await thumb.press("ArrowRight");
+    const before = Number(await thumb.inputValue());
+    await thumb.press("ArrowDown");
+    const after = Number(await thumb.inputValue());
+    expect(after).toBeLessThan(before);
+  });
+
+  test("Home key on min thumb sets value to the minimum bound (0)", async ({
+    page,
+  }) => {
+    const thumb = getMinThumb(page);
+    // Move right a few steps first so Home has work to do
+    await thumb.focus();
+    await thumb.press("ArrowRight");
+    await thumb.press("ArrowRight");
+    await thumb.press("ArrowRight");
+    // Home is handled by RangeSlider.handleKeyDown → onChange([min, maxVal])
+    await thumb.press("Home");
+    expect(Number(await thumb.inputValue())).toBe(0);
+  });
+
+  test("End key on min thumb clamps it strictly below the max thumb", async ({
+    page,
+  }) => {
+    const minThumb = getMinThumb(page);
+    const maxThumb = getMaxThumb(page);
+    await minThumb.focus();
+    // End → onChange([Math.min(max, minVal + step), maxVal]) clamped at maxVal - step
+    await minThumb.press("End");
+    expect(Number(await minThumb.inputValue())).toBeLessThan(
+      Number(await maxThumb.inputValue())
+    );
+  });
+
+  // ── Max thumb keyboard navigation ─────────────────────────────────────────
+
+  test("ArrowLeft on max thumb decreases its value by one step", async ({
+    page,
+  }) => {
+    const thumb = getMaxThumb(page);
+    const before = Number(await thumb.inputValue());
+    await thumb.focus();
+    await thumb.press("ArrowLeft");
+    expect(Number(await thumb.inputValue())).toBeLessThan(before);
+  });
+
+  test("ArrowRight on max thumb increases its value by one step", async ({
+    page,
+  }) => {
+    const thumb = getMaxThumb(page);
+    // Move left first so there is room
+    await thumb.focus();
+    await thumb.press("ArrowLeft");
+    await thumb.press("ArrowLeft");
+    const before = Number(await thumb.inputValue());
+    await thumb.press("ArrowRight");
+    expect(Number(await thumb.inputValue())).toBeGreaterThan(before);
+  });
+
+  test("End key on max thumb sets value to the maximum bound (50)", async ({
+    page,
+  }) => {
+    const thumb = getMaxThumb(page);
+    await thumb.focus();
+    // Move left first so End has work to do
+    await thumb.press("ArrowLeft");
+    await thumb.press("ArrowLeft");
+    await thumb.press("ArrowLeft");
+    await thumb.press("End");
+    expect(Number(await thumb.inputValue())).toBe(50);
+  });
+
+  test("Home key on max thumb clamps it strictly above the min thumb", async ({
+    page,
+  }) => {
+    const minThumb = getMinThumb(page);
+    const maxThumb = getMaxThumb(page);
+    await maxThumb.focus();
+    // Home → onChange([minVal, Math.max(min, maxVal - step)]) clamped at minVal + step
+    await maxThumb.press("Home");
+    expect(Number(await maxThumb.inputValue())).toBeGreaterThan(
+      Number(await minThumb.inputValue())
+    );
+  });
+
+  // ── Boundary clamping ──────────────────────────────────────────────────────
+
+  test("min thumb never exceeds max thumb under repeated ArrowRight", async ({
+    page,
+  }) => {
+    const minThumb = getMinThumb(page);
+    const maxThumb = getMaxThumb(page);
+
+    await minThumb.focus();
+    // 60 presses > full 0–50 range
+    for (let i = 0; i < 60; i++) {
+      await minThumb.press("ArrowRight");
+    }
+
+    expect(Number(await minThumb.inputValue())).toBeLessThan(
+      Number(await maxThumb.inputValue())
+    );
+  });
+
+  test("max thumb never goes below min thumb under repeated ArrowLeft", async ({
+    page,
+  }) => {
+    const minThumb = getMinThumb(page);
+    const maxThumb = getMaxThumb(page);
+
+    await maxThumb.focus();
+    for (let i = 0; i < 60; i++) {
+      await maxThumb.press("ArrowLeft");
+    }
+
+    expect(Number(await maxThumb.inputValue())).toBeGreaterThan(
+      Number(await minThumb.inputValue())
+    );
+  });
+
+  // ── Labels and output ──────────────────────────────────────────────────────
+
+  test("endpoint labels '0%' and '50%' are visible below the slider track", async ({
+    page,
+  }) => {
+    // RangeSlider renders formatLabel(min) and formatLabel(max) at the bottom
+    const fixture = page.locator("#range-slider-fixture");
+    await expect(fixture.getByText("0%")).toBeVisible();
+    await expect(fixture.getByText("50%")).toBeVisible();
+  });
+
+  test("live output label updates after keyboard input", async ({ page }) => {
+    const minThumb = getMinThumb(page);
+    await minThumb.focus();
+    await minThumb.press("ArrowRight");
+
+    // The fixture page renders `{value[0]}% – {value[1]}%` in data-testid="range-slider-output"
+    await expect(page.getByTestId("range-slider-output")).toContainText("1%");
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,13 @@ import { defineConfig, devices } from "@playwright/test";
  * Runs against the local Next.js dev server (or a pre-built production server
  * in CI).  All tests use mock data — no live Stellar RPC calls are made.
  *
+ * Projects:
+ *  - chromium          : Full E2E flows (e2e/*.spec.ts)
+ *  - components        : Browser-level component tests (e2e/components/*.spec.ts)
+ *                        These cover interactions that are hard to test in jsdom,
+ *                        such as drag-and-drop, native range inputs, and Radix
+ *                        portalled popovers.
+ *
  * CI usage:
  *   npx playwright test --reporter=html
  */
@@ -38,9 +45,21 @@ export default defineConfig({
   },
 
   projects: [
+    /* ── Full E2E flows ─────────────────────────────────────────────────── */
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
+      testMatch: /(?<!components\/).*\.spec\.ts/,
+    },
+
+    /* ── Component-level browser tests ───────────────────────────────────
+     *  Isolated to e2e/components/ so they never accidentally run as part
+     *  of the full E2E suite (and vice-versa).
+     * ─────────────────────────────────────────────────────────────────── */
+    {
+      name: "components",
+      use: { ...devices["Desktop Chrome"] },
+      testMatch: /components\/.*\.spec\.ts/,
     },
   ],
 


### PR DESCRIPTION
## Summary

Closes #249

Sets up Playwright component-level browser tests for three UI primitives that are hard or impossible to test in jsdom: `FileInput`, `RangeSlider`, and `DatePicker`.

---

## What changed

### `playwright.config.ts`
- Added a new `components` Playwright project targeting `e2e/components/*.spec.ts`, using `Desktop Chrome`.
- Scoped the existing `chromium` project away from the `components/` subdirectory via `testMatch` negative lookbehind regex so the two suites never overlap.

### `app/test-components/page.tsx` *(new)*
Minimal fixture page that mounts all three components in isolation at `/test-components`. Guarded by `NEXT_PUBLIC_ENABLE_MOCK_DATA=true` so it is never reachable in production. Provides stable `id` anchors and `data-testid` output labels for reliable locators.

### `e2e/components/file-input.spec.ts` *(new — 14 tests)*
Covers browser-specific FileInput interactions:
- Drop zone placeholder copy and `accept` attribute
- File selection via `setInputFiles`: name displayed, size displayed, empty-state hidden, remove button shown
- Remove button clears selection and restores empty state
- Non-PDF rejection → `"Only PDF files are accepted"` error
- Oversized PDF rejection → `"File is too large"` error
- `dragenter`/`dragover` → `isDragActive` highlight class applied
- Programmatic drop of valid PDF → file name shown
- Programmatic drop of non-PDF → type error shown

### `e2e/components/range-slider.spec.ts` *(new — 18 tests)*
Covers keyboard interactions on the dual-thumb `RangeSlider` (with its custom `handleKeyDown`):
- Both thumbs present, aria-labels verified against `range-slider.tsx` source
- Min thumb: `ArrowRight`/`ArrowUp` increase, `ArrowLeft`/`ArrowDown` decrease, `Home` → 0, `End` → clamp below max
- Max thumb: `ArrowLeft` decrease, `ArrowRight` increase, `End` → 50, `Home` → clamp above min
- Boundary clamping: min never exceeds max; max never goes below min
- Endpoint labels and live output label update

### `e2e/components/date-picker.spec.ts` *(new — 15 tests)*
Covers Radix Popover lifecycle and calendar interactions:
- Trigger renders placeholder; calendar hidden before click
- Open on click → shows current month/year header and day-of-week columns
- Day click closes calendar; YYYY-MM-DD written to hidden `<input>`; trigger text updates
- Next/prev month navigation; round-trip restores original header
- Disabled past dates (before `min=today`); clicking disabled date is a no-op
- Escape key and outside-click close the popover
- Uses `[data-radix-popper-content-wrapper]` to locate the Radix portal reliably

### `.github/workflows/test.yml`
Added `playwright-components` CI job (parallel to existing `test` job):
1. `npm ci`
2. `npx playwright install --with-deps chromium` (Chromium only)
3. `npm run build` (production build — faster and more stable than `dev` in CI)
4. `npx playwright test --project=components`
5. Upload `playwright-report/` as artifact (`if: always()`)

---

## Testing

```bash
# Run component tests locally
npx playwright test --project=components

# Run with UI (watch mode)
npx playwright test --project=components --ui
```

---

## Constraints satisfied

- ✅ No Vitest test duplication — all tests use browser-only APIs (`DataTransfer`, `DragEvent`, native range keyboard events, Radix portal locators)
- ✅ Runs in Chromium
- ✅ Runs in CI via `.github/workflows/test.yml`
- ✅ Config update + 3 component test files + CI integration