### PR TITLE
[368] Replace contract event polling with streaming subscription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ NEXT_PUBLIC_ENABLE_DEVTOOLS=true
 NEXT_PUBLIC_ENABLE_COMPARISON=false
 NEXT_PUBLIC_ENABLE_ONBOARDING_TOUR=false
 NEXT_PUBLIC_ENABLE_BATCH_ACTIONS=false
+
+# ─── Event Streaming (optional) ───────────────────────────────────────────────
+# Indexer SSE/webhook URL for near-realtime contract events.
+# When unset, the client uses a ≤2s RPC stream loop and falls back to 5s polling.
+# NEXT_PUBLIC_EVENTS_STREAM_URL=https://indexer.example.com/events/stream

--- a/__tests__/contract-event-streaming.test.tsx
+++ b/__tests__/contract-event-streaming.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { invalidateCachesForEvent } from "@/hooks/useContractEvents";
+import {
+  EVENT_STREAM_INTERVAL_MS,
+  EVENT_POLL_FALLBACK_INTERVAL_MS,
+  EVENT_STREAM_FAILURE_THRESHOLD,
+  subscribeContractEvents,
+  rpc,
+  type ContractEvent,
+} from "@/lib/stellar/client";
+import { queryKeys } from "@/lib/queryKeys";
+
+const fundedEvent: ContractEvent = {
+  id: "evt-1",
+  ledger: 100,
+  ledgerClosedAt: new Date().toISOString(),
+  contractId: "CABC",
+  type: "invoice_funded",
+  tokenId: "42",
+  amount: 1000,
+  participantAddress: "GABC",
+  rawTopics: ["invoice_funded"],
+};
+
+describe("contract event streaming + invalidation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes stream cadence under 2s and 5s polling fallback", () => {
+    expect(EVENT_STREAM_INTERVAL_MS).toBeLessThanOrEqual(2_000);
+    expect(EVENT_POLL_FALLBACK_INTERVAL_MS).toBe(5_000);
+    expect(EVENT_STREAM_FAILURE_THRESHOLD).toBeGreaterThan(0);
+  });
+
+  it("invalidates invoice detail + list caches on invoice_funded", () => {
+    const queryClient = new QueryClient();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    invalidateCachesForEvent(fundedEvent, queryClient);
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: queryKeys.invoices.detail("42"),
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: queryKeys.invoices.all });
+  });
+
+  it("invalidates positions caches on invoice_repaid", () => {
+    const queryClient = new QueryClient();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    invalidateCachesForEvent(
+      { ...fundedEvent, type: "invoice_repaid", id: "evt-2" },
+      queryClient
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        predicate: expect.any(Function),
+      })
+    );
+  });
+
+  it("falls back to polling after repeated stream failures", async () => {
+    // Spy at the RPC boundary — same-module vi.mock of getContractEvents does not
+    // replace the binding used inside subscribeContractEvents.
+    vi.spyOn(rpc, "getEvents").mockRejectedValue(new Error("stream down"));
+
+    const modes: string[] = [];
+    const sub = subscribeContractEvents(
+      {
+        contractId: "CABC",
+        eventTypes: ["invoice_funded"],
+        startLedger: 0,
+        streamIntervalMs: 10,
+        pollIntervalMs: 20,
+      },
+      {
+        onEvents: () => undefined,
+        onModeChange: (m) => modes.push(m),
+        onError: () => undefined,
+      }
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(modes).toContain("polling");
+        expect(sub.getMode()).toBe("polling");
+      },
+      { timeout: 2_000, interval: 20 }
+    );
+
+    sub.unsubscribe();
+  });
+});

--- a/components/marketplace/ContractEventSubscriber.tsx
+++ b/components/marketplace/ContractEventSubscriber.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 /**
- * ContractEventSubscriber — mounts the Soroban event polling hook.
+ * ContractEventSubscriber — mounts the Soroban event streaming hook.
  *
- * This is a render-nothing component that activates the useContractEvents
- * hook for the marketplace and dashboard pages. It is intentionally kept
- * separate from the layout so it can be dynamically imported (ssr: false)
- * without affecting server-rendered metadata.
+ * Activates useContractEvents (stream + polling fallback) for marketplace and
+ * dashboard pages. Kept separate so it can be dynamically imported (ssr: false).
  */
 
 import { useContractEvents } from "@/hooks/useContractEvents";

--- a/hooks/useContractEvents.tsx
+++ b/hooks/useContractEvents.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 /**
- * useContractEvents — polls the Soroban RPC getEvents API every 5s
- * for invoice_funded, invoice_repaid, and invoice_cancelled events.
+ * useContractEvents — prefers Soroban/indexer event streaming with polling fallback.
  *
- * - Pauses when network is offline (uses useNetworkStatus)
- * - Uses useThrottle instead of raw setInterval
+ * - Streams via EventSource (NEXT_PUBLIC_EVENTS_STREAM_URL) or a ≤2s RPC stream loop
+ * - Falls back to 5s polling after repeated stream failures
+ * - Pauses when network is offline (useNetworkStatus)
+ * - Invalidates TanStack Query caches on each new event
  * - Stops on unmount
- * - Updates invoiceStore automatically on each new event
- * - Only triggers re-renders for events relevant to visible invoices
  */
 
 import { useEffect, useRef, useCallback, useState } from "react";
@@ -16,20 +15,21 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   getContractEvents,
+  subscribeContractEvents,
+  EVENT_POLL_FALLBACK_INTERVAL_MS,
+  EVENT_STREAM_INTERVAL_MS,
   type ContractEvent,
+  type EventSubscriptionMode,
   type KoraEventType,
 } from "@/lib/stellar/client";
 import { queryKeys } from "@/lib/queryKeys";
 import { useWalletStore } from "@/store/walletStore";
 import { useUIStore } from "@/store/uiStore";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
-import { useThrottle } from "@/hooks/useThrottle";
 import { env } from "@/lib/env";
-import { formatCurrency, truncateAddress } from "@/lib/utils";
+import { formatCurrency } from "@/lib/utils";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
-
-const POLL_INTERVAL_MS = 5_000;
 
 const EVENT_TYPES: KoraEventType[] = [
   "invoice_funded",
@@ -46,7 +46,6 @@ function showEventToast(event: ContractEvent, walletAddress: string) {
   if (!isRelevant) return;
 
   const amountStr = formatCurrency(event.amount, "USDC");
-  const shortAddr = truncateAddress(event.participantAddress, 4);
 
   switch (event.type) {
     case "invoice_funded":
@@ -89,7 +88,7 @@ function showEventToast(event: ContractEvent, walletAddress: string) {
 
 // ─── Cache invalidation ───────────────────────────────────────────────────────
 
-function invalidateCachesForEvent(
+export function invalidateCachesForEvent(
   event: ContractEvent,
   queryClient: ReturnType<typeof useQueryClient>
 ) {
@@ -129,7 +128,7 @@ let _mockLedger = 1000;
 
 function generateMockEvents(
   walletAddress: string,
-  startLedger: number
+  _startLedger: number
 ): { events: ContractEvent[]; latestLedger: number } {
   _mockLedger += 1;
 
@@ -159,23 +158,27 @@ function generateMockEvents(
 export interface UseContractEventsOptions {
   /** Override the contract ID to listen on (defaults to MARKETPLACE_CONTRACT_ID) */
   contractId?: string;
-  /** Override the poll interval in ms (defaults to 5_000) */
+  /** Override the stream interval in ms (defaults to 1_500) */
+  streamIntervalMs?: number;
+  /** Override the polling fallback interval in ms (defaults to 5_000) */
   pollIntervalMs?: number;
-  /** Disable polling entirely */
+  /** Force polling-only mode (disables streaming) */
+  forcePolling?: boolean;
+  /** Disable subscription entirely */
   disabled?: boolean;
 }
 
 /**
- * Subscribes to Soroban contract events via polling.
+ * Subscribes to Soroban contract events via streaming with polling fallback.
  *
- * Polls every 5 seconds for invoice_funded, invoice_repaid, invoice_cancelled.
  * Pauses automatically when the network is offline.
- * Uses useThrottle-based ticker instead of raw setInterval.
  */
 export function useContractEvents(options: UseContractEventsOptions = {}) {
   const {
     contractId = env.NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID,
-    pollIntervalMs = POLL_INTERVAL_MS,
+    streamIntervalMs = EVENT_STREAM_INTERVAL_MS,
+    pollIntervalMs = EVENT_POLL_FALLBACK_INTERVAL_MS,
+    forcePolling = false,
     disabled = false,
   } = options;
 
@@ -184,36 +187,16 @@ export function useContractEvents(options: UseContractEventsOptions = {}) {
   const notificationPreferences = useUIStore((s) => s.notificationPreferences);
   const { health } = useNetworkStatus();
 
-  // Derive offline state — pause polling when network is down
   const isOffline = health.overall === "down";
-
-  // Throttled tick counter — increments every pollIntervalMs when not paused
-  const [tick, setTick] = useState(0);
-  const throttledTick = useThrottle(tick, pollIntervalMs);
+  const [mode, setMode] = useState<EventSubscriptionMode>(
+    forcePolling ? "polling" : "stream"
+  );
 
   const lastLedgerRef = useRef<number>(0);
   const processedEventIds = useRef<Set<string>>(new Set());
 
-  const poll = useCallback(async () => {
-    if (typeof document !== "undefined" && document.visibilityState === "hidden") {
-      return;
-    }
-
-    try {
-      let result: { events: ContractEvent[]; latestLedger: number };
-
-      if (env.NEXT_PUBLIC_ENABLE_MOCK_DATA) {
-        result = generateMockEvents(walletAddress ?? "", lastLedgerRef.current);
-      } else {
-        result = await getContractEvents({
-          contractId,
-          eventTypes: EVENT_TYPES,
-          startLedger: lastLedgerRef.current,
-        });
-      }
-
-      const { events, latestLedger } = result;
-
+  const processEvents = useCallback(
+    (events: ContractEvent[], latestLedger: number) => {
       if (latestLedger > lastLedgerRef.current) {
         lastLedgerRef.current = latestLedger;
       }
@@ -235,42 +218,111 @@ export function useContractEvents(options: UseContractEventsOptions = {}) {
         const arr = Array.from(processedEventIds.current);
         processedEventIds.current = new Set(arr.slice(-250));
       }
+    },
+    [queryClient, walletAddress, notificationPreferences.invoiceFunded]
+  );
+
+  const fetchOnce = useCallback(async () => {
+    if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+      return;
+    }
+
+    try {
+      const result = env.NEXT_PUBLIC_ENABLE_MOCK_DATA
+        ? generateMockEvents(walletAddress ?? "", lastLedgerRef.current)
+        : await getContractEvents({
+            contractId,
+            eventTypes: EVENT_TYPES,
+            startLedger: lastLedgerRef.current,
+          });
+
+      processEvents(result.events, result.latestLedger);
     } catch (err) {
       if (process.env.NODE_ENV === "development") {
-        console.warn("[useContractEvents] Poll error:", err);
+        console.warn("[useContractEvents] Fetch error:", err);
       }
     }
-  }, [contractId, queryClient, walletAddress, notificationPreferences.invoiceFunded]);
+  }, [contractId, processEvents, walletAddress]);
 
-  // Advance the tick on a native interval — this is the only place setInterval
-  // is used; the actual poll is driven by useThrottle so poll rate is respected
+  // Streaming subscription (with automatic polling fallback inside subscribeContractEvents)
   useEffect(() => {
-    if (disabled || isOffline) return;
+    if (disabled || isOffline || forcePolling) return;
 
-    const id = setInterval(() => setTick((t) => t + 1), pollIntervalMs);
+    if (env.NEXT_PUBLIC_ENABLE_MOCK_DATA) {
+      // Mock mode: emulate stream cadence without touching RPC
+      setMode("stream");
+      void fetchOnce();
+      const id = setInterval(() => {
+        void fetchOnce();
+      }, streamIntervalMs);
+      return () => clearInterval(id);
+    }
+
+    const subscription = subscribeContractEvents(
+      {
+        contractId,
+        eventTypes: EVENT_TYPES,
+        startLedger: lastLedgerRef.current,
+        streamIntervalMs,
+        pollIntervalMs,
+      },
+      {
+        onEvents: ({ events, latestLedger }) => {
+          processEvents(events, latestLedger);
+        },
+        onModeChange: setMode,
+        onError: (err) => {
+          if (process.env.NODE_ENV === "development") {
+            console.warn("[useContractEvents] Stream error:", err);
+          }
+        },
+      }
+    );
+
+    setMode(subscription.getMode());
+
+    return () => subscription.unsubscribe();
+  }, [
+    disabled,
+    isOffline,
+    forcePolling,
+    contractId,
+    streamIntervalMs,
+    pollIntervalMs,
+    processEvents,
+    fetchOnce,
+  ]);
+
+  // Explicit polling fallback path (forced or when offline resumes into forcePolling)
+  useEffect(() => {
+    if (disabled || isOffline || !forcePolling) return;
+
+    setMode("polling");
+    void fetchOnce();
+    const id = setInterval(() => {
+      void fetchOnce();
+    }, pollIntervalMs);
     return () => clearInterval(id);
-  }, [disabled, isOffline, pollIntervalMs]);
+  }, [disabled, isOffline, forcePolling, pollIntervalMs, fetchOnce]);
 
-  // Execute poll whenever the throttled tick advances
-  useEffect(() => {
-    if (disabled || isOffline) return;
-    poll();
-  }, [throttledTick, disabled, isOffline, poll]);
-
-  // Re-poll immediately when coming back online
+  // Re-fetch immediately when coming back online
   useEffect(() => {
     if (!isOffline && !disabled) {
-      poll();
+      void fetchOnce();
     }
-  }, [isOffline, disabled, poll]);
+  }, [isOffline, disabled, fetchOnce]);
 
-  // Re-poll when tab becomes visible again
+  // Re-fetch when tab becomes visible again
   useEffect(() => {
     if (disabled) return;
     const handleVisibility = () => {
-      if (document.visibilityState === "visible" && !isOffline) poll();
+      if (document.visibilityState === "visible" && !isOffline) {
+        void fetchOnce();
+      }
     };
     document.addEventListener("visibilitychange", handleVisibility);
     return () => document.removeEventListener("visibilitychange", handleVisibility);
-  }, [disabled, isOffline, poll]);
+  }, [disabled, isOffline, fetchOnce]);
+
+  return { mode, isOffline };
 }

--- a/lib/stellar/client.ts
+++ b/lib/stellar/client.ts
@@ -544,6 +544,189 @@ export async function getContractEvents(
   return { events, latestLedger };
 }
 
+// ─── Contract event streaming ─────────────────────────────────────────────────
+
+/** Preferred near-realtime cadence when using the stream loop (≤2s). */
+export const EVENT_STREAM_INTERVAL_MS = 1_500;
+/** Fallback polling cadence after stream failure. */
+export const EVENT_POLL_FALLBACK_INTERVAL_MS = 5_000;
+/** Consecutive stream failures before switching to polling fallback. */
+export const EVENT_STREAM_FAILURE_THRESHOLD = 3;
+
+export type EventSubscriptionMode = "stream" | "polling";
+
+export interface SubscribeContractEventsParams extends GetContractEventsParams {
+  /** Optional indexer/SSE endpoint. When set, EventSource is preferred. */
+  streamUrl?: string;
+  /** Interval for the RPC stream loop (default 1500ms). */
+  streamIntervalMs?: number;
+  /** Interval for polling fallback (default 5000ms). */
+  pollIntervalMs?: number;
+}
+
+export interface ContractEventSubscription {
+  /** Tear down SSE / timers. */
+  unsubscribe: () => void;
+  /** Current transport mode. */
+  getMode: () => EventSubscriptionMode;
+}
+
+export interface ContractEventSubscriptionHandlers {
+  onEvents: (result: GetContractEventsResult) => void;
+  onModeChange?: (mode: EventSubscriptionMode) => void;
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Subscribe to contract events via indexer SSE when available, otherwise a
+ * near-realtime RPC stream loop. Falls back to slower polling after repeated
+ * stream failures so marketplace funding progress stays resilient.
+ */
+export function subscribeContractEvents(
+  params: SubscribeContractEventsParams,
+  handlers: ContractEventSubscriptionHandlers
+): ContractEventSubscription {
+  const {
+    streamUrl = typeof process !== "undefined"
+      ? process.env.NEXT_PUBLIC_EVENTS_STREAM_URL
+      : undefined,
+    streamIntervalMs = EVENT_STREAM_INTERVAL_MS,
+    pollIntervalMs = EVENT_POLL_FALLBACK_INTERVAL_MS,
+  } = params;
+
+  let mode: EventSubscriptionMode = "stream";
+  let stopped = false;
+  let startLedger = params.startLedger;
+  let failureCount = 0;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let eventSource: EventSource | null = null;
+
+  const setMode = (next: EventSubscriptionMode) => {
+    if (mode === next) return;
+    mode = next;
+    handlers.onModeChange?.(next);
+  };
+
+  const clearTimer = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+
+  const closeEventSource = () => {
+    if (eventSource) {
+      eventSource.close();
+      eventSource = null;
+    }
+  };
+
+  const handleResult = (result: GetContractEventsResult) => {
+    if (result.latestLedger > startLedger) {
+      startLedger = result.latestLedger;
+    }
+    failureCount = 0;
+    handlers.onEvents(result);
+  };
+
+  const pollOnce = async () => {
+    if (stopped) return;
+    try {
+      const result = await getContractEvents({
+        contractId: params.contractId,
+        eventTypes: params.eventTypes,
+        startLedger,
+      });
+      handleResult(result);
+    } catch (err) {
+      failureCount += 1;
+      handlers.onError?.(err);
+      if (mode === "stream" && failureCount >= EVENT_STREAM_FAILURE_THRESHOLD) {
+        startPollingFallback();
+      }
+    }
+  };
+
+  const startPollingFallback = () => {
+    if (stopped) return;
+    closeEventSource();
+    clearTimer();
+    setMode("polling");
+    failureCount = 0;
+    void pollOnce();
+    timer = setInterval(() => {
+      void pollOnce();
+    }, pollIntervalMs);
+  };
+
+  const startRpcStreamLoop = () => {
+    if (stopped) return;
+    closeEventSource();
+    clearTimer();
+    setMode("stream");
+    void pollOnce();
+    timer = setInterval(() => {
+      void pollOnce();
+    }, streamIntervalMs);
+  };
+
+  const startSse = (url: string) => {
+    if (typeof EventSource === "undefined") {
+      startRpcStreamLoop();
+      return;
+    }
+
+    try {
+      const qs = new URL(url);
+      qs.searchParams.set("contractId", params.contractId);
+      qs.searchParams.set("eventTypes", params.eventTypes.join(","));
+      if (startLedger > 0) qs.searchParams.set("startLedger", String(startLedger));
+
+      eventSource = new EventSource(qs.toString());
+      setMode("stream");
+
+      eventSource.onmessage = (msg) => {
+        try {
+          const parsed = JSON.parse(msg.data) as GetContractEventsResult;
+          handleResult(parsed);
+        } catch (err) {
+          failureCount += 1;
+          handlers.onError?.(err);
+          if (failureCount >= EVENT_STREAM_FAILURE_THRESHOLD) {
+            startPollingFallback();
+          }
+        }
+      };
+
+      eventSource.onerror = (err) => {
+        failureCount += 1;
+        handlers.onError?.(err);
+        if (failureCount >= EVENT_STREAM_FAILURE_THRESHOLD) {
+          startPollingFallback();
+        }
+      };
+    } catch (err) {
+      handlers.onError?.(err);
+      startRpcStreamLoop();
+    }
+  };
+
+  if (streamUrl) {
+    startSse(streamUrl);
+  } else {
+    startRpcStreamLoop();
+  }
+
+  return {
+    unsubscribe: () => {
+      stopped = true;
+      clearTimer();
+      closeEventSource();
+    },
+    getMode: () => mode,
+  };
+}
+
 // ─── Transaction submission ───────────────────────────────────────────────────
 
 /** Error thrown when the network rejects a transaction due to a bad sequence number. */


### PR DESCRIPTION
## Summary
- Replace 5s contract event polling with a streaming subscription (indexer SSE when configured, otherwise a ≤2s RPC stream loop).
- Fall back to 5s polling after repeated stream failures so marketplace funding progress stays resilient.
- Wire `useContractEvents` / `ContractEventSubscriber` to the new subscriber and document `NEXT_PUBLIC_EVENTS_STREAM_URL` in `.env.example`.

## Test plan
- [ ] Run `npx vitest run __tests__/contract-event-streaming.test.tsx` — all 4 tests pass
- [ ] Confirm stream cadence constants: stream ≤2s, poll fallback 5s
- [ ] With stream URL unset, verify RPC stream loop delivers events and invalidates invoice caches
- [ ] Simulate repeated stream failures and confirm mode switches to polling
- [ ] Smoke-test marketplace/dashboard with `ContractEventSubscriber` mounted

Closes #368