### PR TITLE
feat: search invoices in command palette by debtor, token ID, or amount

### DIFF
--- a/components/command/CommandPalette.tsx
+++ b/components/command/CommandPalette.tsx
@@ -18,10 +18,13 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCommandPalette } from "@/hooks/useCommandPalette";
+import { useDebounce } from "@/hooks/useDebounce";
 import { useInvoices } from "@/hooks/useInvoices";
 import { useWallet } from "@/hooks/useWallet";
 import { useUIStore } from "@/store/uiStore";
 import { formatCurrency } from "@/lib/utils";
+
+const SEARCH_DEBOUNCE_MS = 300;
 
 // ─── Highlight matching characters ───────────────────────────────────────────
 
@@ -73,18 +76,25 @@ export function CommandPalette() {
 
   const recent = React.useMemo(() => getRecent(), [open, getRecent]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Fuzzy-filter invoices by ID or debtor name
+  // Debounce the search query before filtering so fast typing doesn't
+  // re-filter the (potentially large) invoice list on every keystroke.
+  const debouncedQuery = useDebounce(query, SEARCH_DEBOUNCE_MS);
+
+  // Filter invoices by debtor name, invoice number, on-chain token ID, or face value.
   const filteredInvoices = React.useMemo(() => {
-    if (!query.trim()) return [];
-    const q = query.toLowerCase();
+    const trimmed = debouncedQuery.trim();
+    if (!trimmed) return [];
+    const q = trimmed.toLowerCase();
     return invoices
       .filter(
         (inv) =>
           inv.metadata.invoiceNumber.toLowerCase().includes(q) ||
-          inv.metadata.debtorName.toLowerCase().includes(q)
+          inv.metadata.debtorName.toLowerCase().includes(q) ||
+          inv.tokenId.toLowerCase().includes(q) ||
+          String(inv.metadata.amount).includes(q)
       )
       .slice(0, 6);
-  }, [invoices, query]);
+  }, [invoices, debouncedQuery]);
 
   function navigate(href: string, label: string, type: "page" | "invoice") {
     pushRecent({ id: href, label, href, type });
@@ -218,7 +228,7 @@ export function CommandPalette() {
                       key={inv.id}
                       icon={<FileText className="h-4 w-4" />}
                       label={inv.metadata.invoiceNumber}
-                      sublabel={`${inv.metadata.debtorName} · ${formatCurrency(inv.metadata.amount, inv.metadata.currency, true)}`}
+                      sublabel={`${inv.metadata.debtorName} · ${formatCurrency(inv.metadata.amount, inv.metadata.currency, true)} · ${Math.round(inv.funding.fundingProgress * 100)}% funded`}
                       query={query}
                       badge={inv.status}
                       onSelect={() =>

--- a/components/command/__tests__/CommandPalette.test.tsx
+++ b/components/command/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Tests for CommandPalette invoice search (issue #213).
+ *
+ * Covers:
+ *  - Filtering invoices by debtor name, invoice number, token ID, and face value
+ *  - 300ms debounce before the invoice list is filtered
+ *  - Status badge + funded % shown alongside each invoice result
+ *  - Selecting an invoice result navigates to /marketplace/[id]
+ *  - Keyboard navigation (arrow keys + Enter) selects a result
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CommandPalette } from "@/components/command/CommandPalette";
+import { createMockInvoice } from "@/__tests__/fixtures";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+let paletteOpen = true;
+const setOpenMock = vi.fn((v: boolean) => {
+  paletteOpen = v;
+});
+vi.mock("@/hooks/useCommandPalette", () => ({
+  useCommandPalette: () => ({
+    open: paletteOpen,
+    setOpen: setOpenMock,
+    getRecent: () => [],
+    pushRecent: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => ({ isConnected: true }),
+}));
+
+vi.mock("@/store/uiStore", () => ({
+  useUIStore: (selector: (s: { setWalletModalOpen: () => void }) => unknown) =>
+    selector({ setWalletModalOpen: vi.fn() }),
+}));
+
+const mockInvoices = [
+  createMockInvoice({
+    id: "inv-safaricom",
+    tokenId: "42",
+    metadata: {
+      invoiceNumber: "INV-2024-0891",
+      debtorName: "Safaricom PLC",
+      amount: 250000,
+    } as any,
+    funding: { totalRaised: 188000, targetAmount: 235000, fundingProgress: 0.8, investorCount: 14, remainingCapacity: 47000 },
+    status: "partially_funded",
+  }),
+  createMockInvoice({
+    id: "inv-shoprite",
+    tokenId: "77",
+    metadata: {
+      invoiceNumber: "INV-2024-0555",
+      debtorName: "Shoprite Holdings",
+      amount: 90000,
+    } as any,
+    funding: { totalRaised: 90000, targetAmount: 90000, fundingProgress: 1, investorCount: 3, remainingCapacity: 0 },
+    status: "fully_funded",
+  }),
+];
+
+vi.mock("@/hooks/useInvoices", () => ({
+  useInvoices: () => ({ data: { data: mockInvoices } }),
+}));
+
+// cmdk may call scrollIntoView when moving the highlighted item — not implemented in jsdom.
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  paletteOpen = true;
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function typeQuery(user: ReturnType<typeof userEvent.setup>, text: string) {
+  const input = screen.getByLabelText("Command palette search");
+  await user.type(input, text);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("CommandPalette — invoice search", () => {
+  it("filters invoices by debtor name after the debounce window", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CommandPalette />);
+
+    await typeQuery(user, "Safaricom");
+
+    // Not yet filtered — debounce hasn't elapsed
+    expect(screen.queryByText("INV-2024-0891")).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => expect(screen.getByText("INV-2024-0891")).toBeInTheDocument());
+    expect(screen.queryByText("INV-2024-0555")).not.toBeInTheDocument();
+  });
+
+  it("filters invoices by on-chain token ID", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CommandPalette />);
+
+    await typeQuery(user, "77");
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => expect(screen.getByText("INV-2024-0555")).toBeInTheDocument());
+    expect(screen.queryByText("INV-2024-0891")).not.toBeInTheDocument();
+  });
+
+  it("filters invoices by face value (amount)", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CommandPalette />);
+
+    await typeQuery(user, "250000");
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => expect(screen.getByText("INV-2024-0891")).toBeInTheDocument());
+    expect(screen.queryByText("INV-2024-0555")).not.toBeInTheDocument();
+  });
+
+  it("shows the status badge and funded % alongside the result", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CommandPalette />);
+
+    await typeQuery(user, "Safaricom");
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => expect(screen.getByText("INV-2024-0891")).toBeInTheDocument());
+    expect(screen.getByText("partially funded")).toBeInTheDocument();
+    expect(screen.getByText(/80% funded/)).toBeInTheDocument();
+  });
+
+  it("navigates to /marketplace/[id] and closes when an invoice result is selected", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CommandPalette />);
+
+    await typeQuery(user, "Safaricom");
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    const result = await screen.findByText("INV-2024-0891");
+    await user.click(result);
+
+    expect(pushMock).toHaveBeenCalledWith("/marketplace/inv-safaricom");
+    expect(setOpenMock).toHaveBeenCalledWith(false);
+  });
+
+  it("supports arrow-key navigation and Enter to select a result", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CommandPalette />);
+
+    await typeQuery(user, "Safaricom");
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    await screen.findByText("INV-2024-0891");
+
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/marketplace/inv-safaricom"));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix --max-warnings=0",
-      "tsc --noEmit --skipLibCheck"
+      "bash -c 'tsc --noEmit --skipLibCheck'"
     ],
     "*.{js,jsx,cjs,mjs}": [
       "eslint --fix --max-warnings=0"


### PR DESCRIPTION
## Summary
- Extends the Cmd+K command palette's invoice search to match on-chain token ID and face value (amount), alongside the existing debtor name / invoice number match.
- Debounces the search filter by 300ms so fast typing doesn't re-scan the invoice list on every keystroke.
- Shows funded % alongside the status badge on each invoice result.
- Keyboard navigation (↑↓ / Enter) was already provided by `cmdk`'s `Command.List` — verified still works with these changes.

## Test plan
- [x] `components/command/__tests__/CommandPalette.test.tsx` — 6 tests covering: debtor-name search, token-ID search, face-value search, debounce timing, funded %/status badge display, click-to-navigate, and arrow-key + Enter navigation.
- [x] `npm run type-check` — no new errors (pre-existing, unrelated `e2e/*.spec.ts` errors are untouched by this PR).
- [x] `eslint --max-warnings=0` on changed files — clean.

## Note
Includes an unrelated one-line fix to `package.json`'s `lint-staged` config: the `tsc --noEmit --skipLibCheck` command was receiving staged filenames as CLI args, which makes `tsc` ignore `tsconfig.json` entirely (breaks `paths`, `jsx`, `esModuleInterop`) — so the pre-commit hook failed on *every* `.ts`/`.tsx` file, not just these changes. Wrapping it in `bash -c '...'` drops the appended filenames so it runs a normal project-wide check instead. Happy to split this into its own PR if preferred.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)