### PR TITLE
feat(ipfs): gateway fallback + CID integrity, metadata versioning/migration, Pinata degradation UX

### DIFF
--- a/app/invoice/create/page.tsx
+++ b/app/invoice/create/page.tsx
@@ -91,8 +91,14 @@ export default function CreateInvoicePage() {
     metadataCid: string;
   } | null>(null);
 
-  // Pinata health — checked when the user reaches the Upload step
-  const { isHealthy: pinataHealthy, isChecking: pinataChecking, status: pinataStatus, recheck: recheckPinata } = usePinataHealth();
+  // Pinata health — checked when the user reaches the Upload step.
+  // Auto-retries with exponential backoff so the wizard self-heals on recovery.
+  const {
+    isChecking: pinataChecking,
+    status: pinataStatus,
+    recheck: recheckPinata,
+    retryCount: pinataRetryCount,
+  } = usePinataHealth();
 
   const {
     register,
@@ -773,6 +779,11 @@ export default function CreateInvoicePage() {
                     <p className="mt-0.5 text-xs text-amber-400/80">
                       Your invoice cannot be minted right now. All your form data has been saved — you can try again when the service recovers.
                     </p>
+                    {pinataRetryCount > 0 && (
+                      <p className="mt-1 text-[11px] text-amber-400/70" aria-live="polite">
+                        Automatically re-checking… (attempt {pinataRetryCount})
+                      </p>
+                    )}
                   </div>
                   <button
                     type="button"

--- a/components/invoice/InvoiceMetadataViewer.tsx
+++ b/components/invoice/InvoiceMetadataViewer.tsx
@@ -17,7 +17,11 @@ import {
   Globe,
   Lock
 } from "lucide-react";
-import { verifyMetadataIntegrity } from "@/lib/invoiceMetadata";
+import {
+  verifyMetadataIntegrity,
+  metadataVersionBadge,
+  METADATA_VERSION,
+} from "@/lib/invoiceMetadata";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { CopyButton } from "@/components/ui/CopyButton";
@@ -62,6 +66,9 @@ export function InvoiceMetadataViewer({ invoice, isFunded = false }: InvoiceMeta
       cancelled = true;
     };
   }, [ipfsCid, metadata]);
+
+  const schemaVersion = metadata.metadataVersion ?? METADATA_VERSION;
+  const versionBadge = metadataVersionBadge(schemaVersion);
 
   const isVerified = verificationState === "verified";
   const verificationLabel =
@@ -207,8 +214,23 @@ export function InvoiceMetadataViewer({ invoice, isFunded = false }: InvoiceMeta
         {/* IPFS Metadata */}
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="flex items-center gap-2 text-base">
-              <FileText className="h-4 w-4 text-primary" /> IPFS Content Metadata
+            <CardTitle className="flex items-center justify-between gap-2 text-base">
+              <span className="flex items-center gap-2">
+                <FileText className="h-4 w-4 text-primary" /> IPFS Content Metadata
+              </span>
+              <Badge
+                variant={
+                  versionBadge.tone === "success"
+                    ? "success"
+                    : versionBadge.tone === "warning"
+                    ? "warning"
+                    : "info"
+                }
+                className="h-fit"
+                title={versionBadge.description}
+              >
+                {versionBadge.label}
+              </Badge>
             </CardTitle>
           </CardHeader>
           <CardContent className="grid gap-2">

--- a/hooks/__tests__/usePinataHealth.test.ts
+++ b/hooks/__tests__/usePinataHealth.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for usePinataHealth — Pinata health degradation UX (#394).
+ *
+ * Covers:
+ *  - initial probe on mount (down / up)
+ *  - down → up recovery via manual recheck
+ *  - recheck bypasses the health cache (invalidates before probing)
+ *  - exponential-backoff auto-retry when unhealthy
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { usePinataHealth } from "../usePinataHealth";
+import { checkPinataHealth, invalidatePinataHealthCache } from "@/lib/ipfs";
+
+vi.mock("@/lib/ipfs", () => ({
+  checkPinataHealth: vi.fn(),
+  invalidatePinataHealthCache: vi.fn(),
+}));
+
+const mockCheck = vi.mocked(checkPinataHealth);
+const mockInvalidate = vi.mocked(invalidatePinataHealthCache);
+
+describe("usePinataHealth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports healthy when the initial probe succeeds", async () => {
+    mockCheck.mockResolvedValue(true);
+
+    const { result } = renderHook(() => usePinataHealth({ autoRetry: false }));
+
+    await waitFor(() => expect(result.current.status).toBe("healthy"));
+    expect(result.current.isHealthy).toBe(true);
+    expect(result.current.lastCheckedAt).not.toBeNull();
+  });
+
+  it("reports unhealthy when the initial probe fails", async () => {
+    mockCheck.mockResolvedValue(false);
+
+    const { result } = renderHook(() => usePinataHealth({ autoRetry: false }));
+
+    await waitFor(() => expect(result.current.status).toBe("unhealthy"));
+    expect(result.current.isHealthy).toBe(false);
+  });
+
+  it("recovers from down → up on manual recheck and bypasses the cache", async () => {
+    mockCheck.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    const { result } = renderHook(() => usePinataHealth({ autoRetry: false }));
+
+    await waitFor(() => expect(result.current.status).toBe("unhealthy"));
+
+    await act(async () => {
+      result.current.recheck();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("healthy"));
+    // recheck must force a fresh probe rather than returning the cached result.
+    expect(mockInvalidate).toHaveBeenCalled();
+  });
+
+  it("auto-retries with exponential backoff while unhealthy, then recovers", async () => {
+    vi.useFakeTimers();
+    // First two probes fail, third succeeds.
+    mockCheck
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    const { result } = renderHook(() =>
+      usePinataHealth({ autoRetry: true, baseDelayMs: 1000, maxRetries: 4 })
+    );
+
+    // Initial probe resolves → unhealthy, schedules retry #1.
+    await vi.waitFor(() => expect(result.current.status).toBe("unhealthy"));
+    expect(result.current.retryCount).toBe(1);
+
+    // Advance past the first backoff (1000ms) → retry probe fails, schedules #2.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    await vi.waitFor(() => expect(result.current.retryCount).toBe(2));
+
+    // Advance past the second backoff (2000ms) → retry probe succeeds.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await vi.waitFor(() => expect(result.current.status).toBe("healthy"));
+    expect(result.current.retryCount).toBe(0);
+    expect(mockCheck).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops auto-retrying after maxRetries", async () => {
+    vi.useFakeTimers();
+    mockCheck.mockResolvedValue(false);
+
+    const { result } = renderHook(() =>
+      usePinataHealth({ autoRetry: true, baseDelayMs: 100, maxRetries: 2 })
+    );
+
+    await vi.waitFor(() => expect(result.current.retryCount).toBe(1));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100); // retry #2
+    });
+    await vi.waitFor(() => expect(result.current.retryCount).toBe(2));
+
+    // Exhaust remaining time — no further retries should be scheduled.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    // 1 initial + 2 retries = 3 total probes.
+    expect(mockCheck).toHaveBeenCalledTimes(3);
+  });
+});

--- a/hooks/usePinataHealth.ts
+++ b/hooks/usePinataHealth.ts
@@ -1,40 +1,134 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { checkPinataHealth } from "@/lib/ipfs";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { checkPinataHealth, invalidatePinataHealthCache } from "@/lib/ipfs";
 
 export type PinataHealthStatus = "idle" | "checking" | "healthy" | "unhealthy";
+
+export interface UsePinataHealthOptions {
+  /**
+   * Automatically re-check with exponential backoff after an unhealthy result.
+   * Defaults to true — the wizard recovers on its own when Pinata comes back.
+   */
+  autoRetry?: boolean;
+  /** Maximum automatic retry attempts before giving up. Default 4. */
+  maxRetries?: number;
+  /** Base delay (ms) for exponential backoff. Default 3000. */
+  baseDelayMs?: number;
+  /** Cap for a single backoff delay (ms). Default 30000. */
+  maxDelayMs?: number;
+}
 
 export interface UsePinataHealthResult {
   status: PinataHealthStatus;
   isHealthy: boolean;
   isChecking: boolean;
+  /** Number of automatic backoff retries performed since the last healthy check. */
+  retryCount: number;
+  /** Timestamp (ms) of the last completed check, or null before the first. */
+  lastCheckedAt: number | null;
+  /**
+   * Manually re-check health. Always bypasses the 60s health cache so the
+   * "Retry" button performs a real fresh ping, then resets backoff.
+   */
   recheck: () => void;
 }
 
 /**
  * Checks whether Pinata is reachable before the user attempts an upload.
- * - Fires automatically on mount
- * - Result is implicitly cached for 60 s inside checkPinataHealth()
- * - Exposes a manual `recheck()` for the retry button
+ *
+ * - Fires automatically on mount.
+ * - `recheck()` invalidates the cached health result first, so the retry button
+ *   always performs a genuine fresh probe (the 60s cache would otherwise make a
+ *   manual retry a no-op).
+ * - When `autoRetry` is enabled, an unhealthy result schedules escalating
+ *   background re-checks (exponential backoff) so the wizard self-heals once
+ *   Pinata recovers, without hammering the endpoint.
  */
-export function usePinataHealth(): UsePinataHealthResult {
-  const [status, setStatus] = useState<PinataHealthStatus>("idle");
+export function usePinataHealth(
+  options: UsePinataHealthOptions = {}
+): UsePinataHealthResult {
+  const {
+    autoRetry = true,
+    maxRetries = 4,
+    baseDelayMs = 3_000,
+    maxDelayMs = 30_000,
+  } = options;
 
-  const run = useCallback(async () => {
-    setStatus("checking");
-    const healthy = await checkPinataHealth();
-    setStatus(healthy ? "healthy" : "unhealthy");
+  const [status, setStatus] = useState<PinataHealthStatus>("idle");
+  const [retryCount, setRetryCount] = useState(0);
+  const [lastCheckedAt, setLastCheckedAt] = useState<number | null>(null);
+
+  // Timer + retry bookkeeping kept in refs so the effect deps stay stable.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retriesRef = useRef(0);
+  const mountedRef = useRef(true);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
   }, []);
 
+  /**
+   * Run a single health probe.
+   * @param force - bypass the health cache (used by manual retry).
+   */
+  const run = useCallback(
+    async (force: boolean) => {
+      if (force) invalidatePinataHealthCache();
+      setStatus("checking");
+      const healthy = await checkPinataHealth();
+      if (!mountedRef.current) return healthy;
+
+      setStatus(healthy ? "healthy" : "unhealthy");
+      setLastCheckedAt(Date.now());
+
+      if (healthy) {
+        // Recovered — stop any pending backoff and reset the counter.
+        clearTimer();
+        retriesRef.current = 0;
+        setRetryCount(0);
+      } else if (autoRetry && retriesRef.current < maxRetries) {
+        // Schedule an escalating background re-check.
+        const attempt = retriesRef.current;
+        const delay = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+        retriesRef.current = attempt + 1;
+        setRetryCount(retriesRef.current);
+        clearTimer();
+        timerRef.current = setTimeout(() => {
+          void run(true);
+        }, delay);
+      }
+      return healthy;
+    },
+    [autoRetry, maxRetries, baseDelayMs, maxDelayMs, clearTimer]
+  );
+
+  const recheck = useCallback(() => {
+    // Manual retry resets backoff and forces a fresh, uncached probe.
+    clearTimer();
+    retriesRef.current = 0;
+    setRetryCount(0);
+    void run(true);
+  }, [run, clearTimer]);
+
   useEffect(() => {
-    void run();
-  }, [run]);
+    mountedRef.current = true;
+    void run(false);
+    return () => {
+      mountedRef.current = false;
+      clearTimer();
+    };
+  }, [run, clearTimer]);
 
   return {
     status,
     isHealthy: status === "healthy",
     isChecking: status === "checking",
-    recheck: run,
+    retryCount,
+    lastCheckedAt,
+    recheck,
   };
 }

--- a/lib/__tests__/ipfsFallback.test.ts
+++ b/lib/__tests__/ipfsFallback.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for multi-gateway IPFS fallback + CID integrity verification (#393).
+ *
+ * Covers:
+ *  - decodeCid for CIDv0 (base58) and CIDv1 (base32)
+ *  - verifyCidIntegrity: match / mismatch / unverifiable
+ *  - fetchFromIpfsWithFallback: gateway rotation, tamper rejection, unavailability
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  decodeCid,
+  verifyCidIntegrity,
+  fetchFromIpfsWithFallback,
+  IpfsTamperError,
+  IpfsUnavailableError,
+  isValidCID,
+} from "../ipfs";
+
+// ─── Helpers: build a real raw (0x55) CIDv1 from content ──────────────────────
+
+const B32 = "abcdefghijklmnopqrstuvwxyz234567";
+
+function base32Encode(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let out = "";
+  for (const b of bytes) {
+    value = (value << 8) | b;
+    bits += 8;
+    while (bits >= 5) {
+      out += B32[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) out += B32[(value << (5 - bits)) & 31];
+  return out;
+}
+
+/** Compute the canonical raw-codec sha2-256 CIDv1 for the given content. */
+async function rawCidV1(content: Uint8Array): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", content));
+  const prefix = Uint8Array.from([0x01, 0x55, 0x12, 0x20]); // v1, raw, sha2-256, len 32
+  const full = new Uint8Array(prefix.length + digest.length);
+  full.set(prefix, 0);
+  full.set(digest, prefix.length);
+  return "b" + base32Encode(full);
+}
+
+function arrayBufferResponse(bytes: Uint8Array, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 502,
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  } as unknown as Response;
+}
+
+const CID_V0 = "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco";
+
+describe("decodeCid", () => {
+  it("decodes a CIDv0 (base58 dag-pb) into a 32-byte sha2-256 digest", () => {
+    const decoded = decodeCid(CID_V0);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.version).toBe(0);
+    expect(decoded!.codec).toBe(0x70); // dag-pb
+    expect(decoded!.hashCode).toBe(0x12); // sha2-256
+    expect(decoded!.digest.length).toBe(32);
+  });
+
+  it("decodes a raw CIDv1 (base32) into codec 0x55 + digest", async () => {
+    const cid = await rawCidV1(new TextEncoder().encode("hello world"));
+    const decoded = decodeCid(cid);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.version).toBe(1);
+    expect(decoded!.codec).toBe(0x55); // raw
+    expect(decoded!.digest.length).toBe(32);
+  });
+
+  it("returns null for garbage", () => {
+    expect(decodeCid("not-a-cid")).toBeNull();
+  });
+});
+
+describe("verifyCidIntegrity", () => {
+  it("returns true when content matches a raw CIDv1", async () => {
+    const content = new TextEncoder().encode("kora invoice metadata");
+    const cid = await rawCidV1(content);
+    expect(await verifyCidIntegrity(cid, content)).toBe(true);
+  });
+
+  it("returns false when content does NOT match the CID (tampered)", async () => {
+    const content = new TextEncoder().encode("original");
+    const cid = await rawCidV1(content);
+    const tampered = new TextEncoder().encode("tampered!");
+    expect(await verifyCidIntegrity(cid, tampered)).toBe(false);
+  });
+
+  it("returns null (unverifiable) for dag-pb CIDv0 — cannot recompute raw hash", async () => {
+    const content = new TextEncoder().encode("whatever");
+    expect(await verifyCidIntegrity(CID_V0, content)).toBeNull();
+  });
+});
+
+describe("fetchFromIpfsWithFallback", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("rotates to the next gateway when the first one fails", async () => {
+    const content = new TextEncoder().encode("payload-A");
+    const cid = await rawCidV1(content);
+
+    mockFetch
+      .mockRejectedValueOnce(new Error("gw1 down")) // gateway 1 unreachable
+      .mockResolvedValueOnce(arrayBufferResponse(content)); // gateway 2 serves it
+
+    const result = await fetchFromIpfsWithFallback(cid, {
+      gateways: ["https://gw1/ipfs", "https://gw2/ipfs"],
+      retriesPerGateway: 0,
+    });
+
+    expect(result.gateway).toBe("https://gw2/ipfs");
+    expect(result.integrity).toBe("verified");
+    expect(result.text).toBe("payload-A");
+  });
+
+  it("skips a gateway serving tampered content and fails over to a clean one", async () => {
+    const content = new TextEncoder().encode("real-content");
+    const cid = await rawCidV1(content);
+    const tampered = new TextEncoder().encode("evil-content");
+
+    mockFetch
+      .mockResolvedValueOnce(arrayBufferResponse(tampered)) // gw1 tampered
+      .mockResolvedValueOnce(arrayBufferResponse(content)); // gw2 clean
+
+    const result = await fetchFromIpfsWithFallback(cid, {
+      gateways: ["https://gw1/ipfs", "https://gw2/ipfs"],
+      retriesPerGateway: 0,
+    });
+
+    expect(result.gateway).toBe("https://gw2/ipfs");
+    expect(result.integrity).toBe("verified");
+  });
+
+  it("throws IpfsTamperError when every gateway serves tampered content", async () => {
+    const content = new TextEncoder().encode("authentic");
+    const cid = await rawCidV1(content);
+    const tampered = new TextEncoder().encode("forged");
+
+    mockFetch.mockResolvedValue(arrayBufferResponse(tampered));
+
+    await expect(
+      fetchFromIpfsWithFallback(cid, {
+        gateways: ["https://gw1/ipfs", "https://gw2/ipfs"],
+      })
+    ).rejects.toBeInstanceOf(IpfsTamperError);
+  });
+
+  it("throws IpfsUnavailableError when all gateways are unreachable", async () => {
+    const content = new TextEncoder().encode("x");
+    const cid = await rawCidV1(content);
+
+    mockFetch.mockRejectedValue(new Error("network down"));
+
+    await expect(
+      fetchFromIpfsWithFallback(cid, {
+        gateways: ["https://gw1/ipfs", "https://gw2/ipfs"],
+        retriesPerGateway: 0,
+      })
+    ).rejects.toBeInstanceOf(IpfsUnavailableError);
+  });
+
+  it("accepts unverifiable (dag-pb) content without flagging tampering", async () => {
+    const content = new TextEncoder().encode('{"ok":true}');
+    mockFetch.mockResolvedValueOnce(arrayBufferResponse(content));
+
+    const result = await fetchFromIpfsWithFallback(CID_V0, {
+      gateways: ["https://gw1/ipfs"],
+    });
+    expect(result.integrity).toBe("unverifiable");
+  });
+
+  it("still recognizes the broadened CID format", () => {
+    expect(isValidCID(CID_V0)).toBe(true);
+    expect(isValidCID("invalid-cid")).toBe(false);
+  });
+});

--- a/lib/__tests__/metadataVersioning.test.ts
+++ b/lib/__tests__/metadataVersioning.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for IPFS metadata schema versioning & migration (#392).
+ *
+ * Covers:
+ *  - detectMetadataVersion: v1 / legacy / unknown
+ *  - migrateLegacyToV1 field mapping
+ *  - parseAnyInvoiceMetadata: v1 passthrough, legacy migration, unknown error
+ *  - metadataVersionBadge descriptors
+ */
+import { describe, it, expect } from "vitest";
+import {
+  detectMetadataVersion,
+  migrateLegacyToV1,
+  parseAnyInvoiceMetadata,
+  metadataVersionBadge,
+  legacyInvoiceMetadataSchema,
+  METADATA_VERSION,
+  type InvoiceMetadataV1,
+} from "../invoiceMetadata";
+
+const ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+const V1_METADATA: InvoiceMetadataV1 = {
+  metadata_version: "1.0",
+  name: "Invoice INV-2024-0001",
+  description: "Tokenized invoice for services",
+  image: "ipfs://QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco",
+  invoice_number: "INV-2024-0001",
+  amount: 250000,
+  currency: "USDC",
+  due_date: "2025-03-01",
+  issuer: { address: ISSUER, name: "TechBridge Ltd" },
+  debtor: { name: "Safaricom PLC", privacy: "full" },
+};
+
+/** A pre-versioned (legacy) metadata object using camelCase keys. */
+const LEGACY_METADATA = {
+  name: "Invoice Asset",
+  description: "Legacy tokenized invoice",
+  image: "ipfs://QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco",
+  invoiceNumber: "INV-2023-0099",
+  issuerName: "Old Corp",
+  issuerAddress: ISSUER,
+  debtorName: "Legacy Debtor Co",
+  debtorAddress: "123 Old Street, Nairobi",
+  amount: 12000,
+  currency: "usdc", // lower-case to exercise normalization
+  issueDate: "2023-01-01T00:00:00.000Z",
+  dueDate: "2023-06-01T00:00:00.000Z", // full ISO to exercise date-only coercion
+  jurisdiction: "KE",
+  category: "technology",
+  documentHash: "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco",
+};
+
+describe("detectMetadataVersion", () => {
+  it("detects v1 metadata", () => {
+    expect(detectMetadataVersion(V1_METADATA)).toBe("1.0");
+  });
+
+  it("detects legacy metadata (no version field, camelCase fields)", () => {
+    expect(detectMetadataVersion(LEGACY_METADATA)).toBe("legacy");
+  });
+
+  it("returns unknown for an unrecognized shape", () => {
+    expect(detectMetadataVersion({ foo: "bar" })).toBe("unknown");
+    expect(detectMetadataVersion(null)).toBe("unknown");
+    expect(detectMetadataVersion("string")).toBe("unknown");
+  });
+
+  it("returns unknown for an unsupported future version", () => {
+    expect(detectMetadataVersion({ metadata_version: "2.0" })).toBe("unknown");
+  });
+});
+
+describe("migrateLegacyToV1", () => {
+  it("maps camelCase legacy fields to the V1 input shape", () => {
+    const parsed = legacyInvoiceMetadataSchema.parse(LEGACY_METADATA);
+    const migrated = migrateLegacyToV1(parsed);
+
+    expect(migrated.invoice_number).toBe("INV-2023-0099");
+    expect(migrated.amount).toBe(12000);
+    expect(migrated.currency).toBe("USDC"); // normalized to upper-case
+    expect(migrated.due_date).toBe("2023-06-01"); // coerced to YYYY-MM-DD
+    expect(migrated.issuer.address).toBe(ISSUER);
+    expect(migrated.debtor.name).toBe("Legacy Debtor Co");
+    expect(migrated.ipfs_document_cid).toBe(LEGACY_METADATA.documentHash);
+  });
+});
+
+describe("parseAnyInvoiceMetadata", () => {
+  it("renders v1 metadata directly", () => {
+    const { version, data } = parseAnyInvoiceMetadata(V1_METADATA);
+    expect(version).toBe("1.0");
+    expect(data.metadata_version).toBe(METADATA_VERSION);
+    expect(data.invoice_number).toBe("INV-2024-0001");
+  });
+
+  it("migrates and renders legacy metadata as valid v1", () => {
+    const { version, data } = parseAnyInvoiceMetadata(LEGACY_METADATA);
+    expect(version).toBe("legacy");
+    expect(data.metadata_version).toBe(METADATA_VERSION);
+    expect(data.invoice_number).toBe("INV-2023-0099");
+    expect(data.currency).toBe("USDC");
+    // Migration auto-builds NFT attributes.
+    expect(Array.isArray(data.attributes)).toBe(true);
+  });
+
+  it("throws a clear error for unknown metadata", () => {
+    expect(() => parseAnyInvoiceMetadata({ foo: "bar" })).toThrow(
+      /Unrecognized invoice metadata schema/
+    );
+  });
+
+  it("throws a clear error when legacy data is invalid after migration", () => {
+    const broken = { ...LEGACY_METADATA, issuerAddress: "not-a-stellar-key" };
+    expect(() => parseAnyInvoiceMetadata(broken)).toThrow();
+  });
+});
+
+describe("metadataVersionBadge", () => {
+  it("labels v1 as a success badge", () => {
+    const badge = metadataVersionBadge("1.0");
+    expect(badge.label).toBe(`Schema v${METADATA_VERSION}`);
+    expect(badge.tone).toBe("success");
+  });
+
+  it("labels legacy as a warning badge", () => {
+    const badge = metadataVersionBadge("legacy");
+    expect(badge.label).toBe("Legacy schema");
+    expect(badge.tone).toBe("warning");
+  });
+
+  it("labels unknown as an info badge", () => {
+    expect(metadataVersionBadge("unknown").tone).toBe("info");
+  });
+});

--- a/lib/invoiceMetadata.ts
+++ b/lib/invoiceMetadata.ts
@@ -11,7 +11,7 @@
 
 import { z } from "zod";
 import { env } from "@/lib/env";
-import { isValidCID } from "./ipfs";
+import { isValidCID, fetchFromIpfsWithFallback } from "./ipfs";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -299,12 +299,11 @@ export async function verifyMetadataIntegrity(
     return false;
   }
   try {
-    const gateway = env.NEXT_PUBLIC_IPFS_GATEWAY || "https://ipfs.io";
-    const response = await fetch(`${gateway}/${cid}`, { cache: "no-store" });
-    if (!response.ok) {
-      return false;
-    }
-    const remote = await response.json();
+    // Rotate across gateways so a single gateway outage doesn't fail
+    // verification. We compare canonicalized content, so integrity is asserted
+    // by content equality here; the CID hash check runs inside the fetch too.
+    const { text } = await fetchFromIpfsWithFallback(cid, { timeoutMs: 10_000 });
+    const remote = JSON.parse(text);
     return canonicalizeMetadata(remote) === canonicalizeMetadata(metadata);
   } catch (error) {
     console.warn("Invoice metadata integrity verification failed", error);
@@ -383,4 +382,193 @@ function buildAttributes(
   }
 
   return attrs;
+}
+
+// ─── Schema Versioning & Migration (#392) ─────────────────────────────────────
+
+/** Schema versions we can detect. "legacy" = pre-versioned camelCase metadata. */
+export type MetadataVersion = "1.0" | "legacy";
+
+/** Versions we can render natively without migration. */
+export const SUPPORTED_METADATA_VERSIONS = [METADATA_VERSION] as const;
+
+/**
+ * Legacy (pre-#121) invoice metadata schema.
+ *
+ * Older on-chain CIDs point at metadata written before the versioned V1 schema
+ * existed. That shape used camelCase keys and had no `metadata_version` field.
+ * We keep a lenient parser so those NFTs still render and can be migrated to V1.
+ */
+export const legacyInvoiceMetadataSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  image: z.string().optional(),
+  invoiceNumber: z.string().min(1),
+  issuerName: z.string().optional(),
+  issuerAddress: z.string().min(1),
+  debtorName: z.string().min(1),
+  debtorAddress: z.string().optional(),
+  amount: z.number().positive(),
+  currency: z.string().min(1),
+  issueDate: z.string().optional(),
+  dueDate: z.string().min(1),
+  description_: z.string().optional(),
+  jurisdiction: z.string().optional(),
+  category: z.string().optional(),
+  documentHash: z.string().optional(),
+  documentUrl: z.string().optional(),
+});
+
+export type LegacyInvoiceMetadata = z.infer<typeof legacyInvoiceMetadataSchema>;
+
+/**
+ * Detect which metadata schema a raw IPFS payload conforms to.
+ *
+ * @returns "1.0"    — has metadata_version === "1.0"
+ * @returns "legacy" — no version field but recognizably invoice metadata
+ * @returns "unknown" — unrecognized / not invoice metadata
+ */
+export function detectMetadataVersion(raw: unknown): MetadataVersion | "unknown" {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return "unknown";
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.metadata_version === "string") {
+    return obj.metadata_version === METADATA_VERSION ? "1.0" : "unknown";
+  }
+
+  // No version field — infer legacy from recognizable invoice fields.
+  const looksLikeInvoice =
+    (typeof obj.invoiceNumber === "string" || typeof obj.invoice_number === "string") &&
+    (typeof obj.amount === "number" || typeof obj.amount === "string");
+  return looksLikeInvoice ? "legacy" : "unknown";
+}
+
+/** Normalize an ISO date / date-time string to YYYY-MM-DD. */
+function toDateOnly(value: string | undefined): string {
+  if (!value) return "";
+  return value.slice(0, 10);
+}
+
+/**
+ * Migrate a legacy metadata object to the InvoiceMetadataV1 input shape.
+ *
+ * Best-effort field mapping — the result is still run through the V1 schema by
+ * {@link parseAnyInvoiceMetadata}, so genuinely malformed legacy data surfaces
+ * a clear validation error rather than a silent bad migration.
+ */
+export function migrateLegacyToV1(
+  legacy: LegacyInvoiceMetadata
+): InvoiceMetadataV1Input {
+  const currency = String(legacy.currency).toUpperCase();
+  const image =
+    legacy.image ||
+    (legacy.documentHash ? `ipfs://${legacy.documentHash}` : undefined) ||
+    legacy.documentUrl ||
+    "";
+
+  return {
+    name: legacy.name || `Invoice ${legacy.invoiceNumber}`,
+    description:
+      legacy.description ||
+      `Tokenized invoice ${legacy.invoiceNumber} (migrated from legacy schema)`,
+    image,
+    invoice_number: legacy.invoiceNumber,
+    amount: legacy.amount,
+    currency: currency as InvoiceMetadataV1Input["currency"],
+    due_date: toDateOnly(legacy.dueDate),
+    issuer: {
+      address: legacy.issuerAddress,
+      name: legacy.issuerName || undefined,
+    },
+    debtor: {
+      name: legacy.debtorName,
+      address: legacy.debtorAddress || undefined,
+      privacy: "full",
+    },
+    jurisdiction: legacy.jurisdiction as InvoiceMetadataV1Input["jurisdiction"],
+    category: legacy.category as InvoiceMetadataV1Input["category"],
+    ipfs_document_cid: legacy.documentHash,
+  };
+}
+
+/** Result of parsing metadata of any supported version. */
+export type ParsedInvoiceMetadata = {
+  /** The detected source schema version. */
+  version: MetadataVersion;
+  /** The metadata normalized to the current V1 schema. */
+  data: InvoiceMetadataV1;
+};
+
+/**
+ * Parse invoice metadata of any supported schema version into a normalized
+ * InvoiceMetadataV1 object.
+ *
+ * - V1 payloads are validated directly.
+ * - Legacy payloads are parsed, migrated to V1, then validated.
+ * - Unknown payloads throw a descriptive error.
+ *
+ * @throws {Error} if the schema is unrecognized or the (migrated) data fails
+ *                 V1 validation.
+ */
+export function parseAnyInvoiceMetadata(raw: unknown): ParsedInvoiceMetadata {
+  const version = detectMetadataVersion(raw);
+
+  if (version === "1.0") {
+    return { version, data: parseInvoiceMetadata(raw) };
+  }
+
+  if (version === "legacy") {
+    const parsed = legacyInvoiceMetadataSchema.safeParse(raw);
+    if (!parsed.success) {
+      const errors = parsed.error.issues.map(
+        (issue) => `${issue.path.join(".")}: ${issue.message}`
+      );
+      throw new Error(
+        `Invalid legacy invoice metadata:\n${errors.join("\n")}`
+      );
+    }
+    const migrated = buildInvoiceMetadata(migrateLegacyToV1(parsed.data));
+    return { version, data: migrated };
+  }
+
+  throw new Error(
+    "Unrecognized invoice metadata schema: missing metadata_version and no legacy invoice fields."
+  );
+}
+
+/** UI descriptor for a metadata version badge. */
+export interface MetadataVersionBadge {
+  label: string;
+  tone: "success" | "warning" | "info";
+  description: string;
+}
+
+/**
+ * Map a detected metadata version to a display badge.
+ * Used by the metadata viewer to surface the schema version to users.
+ */
+export function metadataVersionBadge(
+  version: MetadataVersion | "unknown"
+): MetadataVersionBadge {
+  switch (version) {
+    case "1.0":
+      return {
+        label: `Schema v${METADATA_VERSION}`,
+        tone: "success",
+        description: "Current versioned metadata schema.",
+      };
+    case "legacy":
+      return {
+        label: "Legacy schema",
+        tone: "warning",
+        description:
+          "Pre-versioned metadata, migrated to the current schema for display.",
+      };
+    default:
+      return {
+        label: "Unknown schema",
+        tone: "info",
+        description: "Metadata schema could not be identified.",
+      };
+  }
 }

--- a/lib/ipfs.ts
+++ b/lib/ipfs.ts
@@ -20,8 +20,27 @@ import { generateInvoiceSvg, svgToFile } from "@/lib/invoiceSvg";
 
 const IPFS_GATEWAY = env.NEXT_PUBLIC_IPFS_GATEWAY;
 
-// CID v0 (Qm...) or CID v1 (bafy...)
-const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|bafy[a-z2-7]{52,})$/;
+/**
+ * Ordered list of IPFS gateway bases used for content resolution.
+ *
+ * The configured gateway is tried first; the public gateways act as
+ * fallbacks so a single gateway outage never blocks content retrieval.
+ * Each entry is a base that resolves a CID via `${base}/${cid}`.
+ */
+export const IPFS_GATEWAYS: string[] = Array.from(
+  new Set(
+    [
+      IPFS_GATEWAY,
+      "https://ipfs.io/ipfs",
+      "https://cloudflare-ipfs.com/ipfs",
+      "https://gateway.pinata.cloud/ipfs",
+      "https://dweb.link/ipfs",
+    ].filter((g): g is string => Boolean(g))
+  )
+);
+
+// CID v0 (Qm...) or CID v1 base32 (bafy… dag-pb, bafk… raw, etc.)
+const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{55,})$/;
 
 // ─── Pinata Health Check ──────────────────────────────────────────────────────
 
@@ -208,6 +227,286 @@ export async function uploadInvoiceToIPFS(
 export function ipfsUrl(cid: string): string {
   validateCid(cid);
   return `${IPFS_GATEWAY}/${cid}`;
+}
+
+// ─── Multi-Gateway Fallback + CID Integrity Verification (#393) ───────────────
+
+/** Thrown when every gateway returned content that failed CID integrity checks. */
+export class IpfsTamperError extends Error {
+  constructor(cid: string) {
+    super(
+      `IPFS content for CID ${cid} failed integrity verification on all gateways. ` +
+        `The content hash does not match the CID — it may have been tampered with.`
+    );
+    this.name = "IpfsTamperError";
+  }
+}
+
+/** Thrown when no gateway could return the content (all unreachable / errored). */
+export class IpfsUnavailableError extends Error {
+  constructor(cid: string) {
+    super(`Unable to fetch IPFS content for CID ${cid} from any configured gateway.`);
+    this.name = "IpfsUnavailableError";
+  }
+}
+
+/** Result of a per-CID content-hash verification against the CID itself. */
+export type IpfsIntegrity =
+  | "verified" // content hash provably matches the CID
+  | "unverifiable" // CID uses a codec/hash we can't recompute client-side (no failure)
+  | "skipped"; // verification was explicitly disabled
+
+const MULTIHASH_SHA2_256 = 0x12;
+const CODEC_RAW = 0x55;
+
+const B58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const B32_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567";
+
+function base58Decode(str: string): Uint8Array | null {
+  const bytes: number[] = [0];
+  for (const ch of str) {
+    const value = B58_ALPHABET.indexOf(ch);
+    if (value === -1) return null;
+    let carry = value;
+    for (let j = 0; j < bytes.length; j++) {
+      carry += bytes[j] * 58;
+      bytes[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  // Preserve leading zero bytes (encoded as '1').
+  for (let k = 0; k < str.length && str[k] === "1"; k++) bytes.push(0);
+  return Uint8Array.from(bytes.reverse());
+}
+
+function base32Decode(str: string): Uint8Array | null {
+  let bits = 0;
+  let value = 0;
+  const out: number[] = [];
+  for (const ch of str.toLowerCase()) {
+    const idx = B32_ALPHABET.indexOf(ch);
+    if (idx === -1) return null;
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      out.push((value >>> bits) & 0xff);
+    }
+  }
+  return Uint8Array.from(out);
+}
+
+/** Minimal unsigned LEB128 varint reader. Returns [value, nextOffset]. */
+function readVarint(bytes: Uint8Array, offset: number): [number, number] {
+  let result = 0;
+  let shift = 0;
+  let pos = offset;
+  for (;;) {
+    const b = bytes[pos++];
+    result |= (b & 0x7f) << shift;
+    if ((b & 0x80) === 0) break;
+    shift += 7;
+  }
+  return [result >>> 0, pos];
+}
+
+interface DecodedCid {
+  version: 0 | 1;
+  codec: number;
+  hashCode: number;
+  digest: Uint8Array;
+}
+
+/**
+ * Decode a CID into its codec + multihash digest.
+ * Supports base58btc CIDv0 (Qm...) and base32 CIDv1 (bafy...).
+ * Returns null for anything we can't parse.
+ */
+export function decodeCid(cid: string): DecodedCid | null {
+  try {
+    if (cid.startsWith("Qm")) {
+      const bytes = base58Decode(cid);
+      if (!bytes || bytes.length < 2) return null;
+      const [hashCode, p1] = readVarint(bytes, 0);
+      const [len, p2] = readVarint(bytes, p1);
+      const digest = bytes.slice(p2, p2 + len);
+      if (digest.length !== len) return null;
+      return { version: 0, codec: 0x70 /* dag-pb */, hashCode, digest };
+    }
+    // CIDv1 multibase: leading char is the base prefix. 'b' => base32.
+    if (cid[0] === "b") {
+      const bytes = base32Decode(cid.slice(1));
+      if (!bytes || bytes.length < 4) return null;
+      const [version, p0] = readVarint(bytes, 0);
+      if (version !== 1) return null;
+      const [codec, p1] = readVarint(bytes, p0);
+      const [hashCode, p2] = readVarint(bytes, p1);
+      const [len, p3] = readVarint(bytes, p2);
+      const digest = bytes.slice(p3, p3 + len);
+      if (digest.length !== len) return null;
+      return { version: 1, codec, hashCode, digest };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function sha256(data: ArrayBuffer | Uint8Array): Promise<Uint8Array> {
+  const view = data instanceof Uint8Array ? data : new Uint8Array(data);
+  // Copy into a fresh ArrayBuffer-backed view to satisfy the BufferSource type.
+  const buf = view.slice();
+  const digest = await crypto.subtle.digest("SHA-256", buf as unknown as BufferSource);
+  return new Uint8Array(digest);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+/**
+ * Verify that fetched content matches the digest embedded in its CID.
+ *
+ * Returns:
+ *  - `true`  — content sha2-256 hash matches the CID digest
+ *  - `false` — content does NOT match (possible tampering)
+ *  - `null`  — the CID uses a codec/hash we cannot recompute from raw bytes
+ *              (e.g. dag-pb wrapped blocks). This is NOT a failure — callers
+ *              should treat it as "unverifiable" rather than "tampered".
+ *
+ * Only sha2-256 `raw` (0x55) CIDs can be verified from the raw content bytes,
+ * which covers the small single-block JSON/SVG payloads Kora pins.
+ */
+export async function verifyCidIntegrity(
+  cid: string,
+  content: ArrayBuffer | Uint8Array
+): Promise<boolean | null> {
+  const decoded = decodeCid(cid);
+  if (!decoded) return null;
+  if (decoded.hashCode !== MULTIHASH_SHA2_256) return null;
+  // dag-pb (0x70, and all CIDv0) hashes a wrapped block, not the raw bytes —
+  // we cannot recompute it here without re-chunking, so treat as unverifiable.
+  if (decoded.codec !== CODEC_RAW) return null;
+  const computed = await sha256(content);
+  return bytesEqual(computed, decoded.digest);
+}
+
+export interface IpfsFetchOptions {
+  /** Per-gateway timeout in ms. Default 8000. */
+  timeoutMs?: number;
+  /** Retries per gateway before rotating to the next. Default 1. */
+  retriesPerGateway?: number;
+  /** Gateway bases to try, in order. Defaults to IPFS_GATEWAYS. */
+  gateways?: string[];
+  /** Skip CID integrity verification (e.g. mock mode). Default false. */
+  skipIntegrity?: boolean;
+}
+
+export interface IpfsFetchResult {
+  bytes: Uint8Array;
+  text: string;
+  /** Gateway base that successfully served the content. */
+  gateway: string;
+  /** Outcome of CID integrity verification for the returned content. */
+  integrity: IpfsIntegrity;
+}
+
+async function fetchOnce(
+  url: string,
+  timeoutMs: number
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal, cache: "no-store" });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetch IPFS content with gateway rotation, per-gateway timeout/retry, and
+ * CID integrity verification.
+ *
+ * Gateways are tried in order. A gateway that times out, errors, or returns a
+ * non-2xx response is skipped. If a gateway returns content whose hash does not
+ * match the CID, that gateway is skipped as tampered and the next is tried.
+ *
+ * @throws {InvalidCIDError}     if `cid` is not a valid CID
+ * @throws {IpfsTamperError}     if every gateway that responded failed integrity
+ * @throws {IpfsUnavailableError} if no gateway could return the content
+ */
+export async function fetchFromIpfsWithFallback(
+  cid: string,
+  options: IpfsFetchOptions = {}
+): Promise<IpfsFetchResult> {
+  validateCid(cid);
+  const {
+    timeoutMs = 8_000,
+    retriesPerGateway = 1,
+    gateways = IPFS_GATEWAYS,
+    skipIntegrity = false,
+  } = options;
+
+  let sawTamper = false;
+
+  for (const gateway of gateways) {
+    for (let attempt = 0; attempt <= retriesPerGateway; attempt++) {
+      try {
+        const res = await fetchOnce(`${gateway}/${cid}`, timeoutMs);
+        if (!res.ok) continue;
+
+        const bytes = new Uint8Array(await res.arrayBuffer());
+
+        let integrity: IpfsIntegrity = "skipped";
+        if (!skipIntegrity) {
+          const verified = await verifyCidIntegrity(cid, bytes);
+          if (verified === false) {
+            // Content was altered in transit or at this gateway — reject it.
+            sawTamper = true;
+            break; // stop retrying this gateway; rotate to the next
+          }
+          integrity = verified === true ? "verified" : "unverifiable";
+        }
+
+        return {
+          bytes,
+          text: new TextDecoder().decode(bytes),
+          gateway,
+          integrity,
+        };
+      } catch {
+        // Timeout or network error — fall through to retry / next gateway.
+      }
+    }
+  }
+
+  if (sawTamper) throw new IpfsTamperError(cid);
+  throw new IpfsUnavailableError(cid);
+}
+
+/**
+ * Fetch and JSON-parse IPFS content with gateway fallback + integrity check.
+ * Returns the parsed value plus the gateway used and the integrity outcome.
+ */
+export async function fetchIpfsJsonWithFallback<T = unknown>(
+  cid: string,
+  options: IpfsFetchOptions = {}
+): Promise<{ data: T; gateway: string; integrity: IpfsIntegrity }> {
+  const result = await fetchFromIpfsWithFallback(cid, options);
+  return {
+    data: JSON.parse(result.text) as T,
+    gateway: result.gateway,
+    integrity: result.integrity,
+  };
 }
 
 // ─── Validated V1 Metadata Upload ────────────────────────────────────────────

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -219,6 +219,9 @@ const ALLOWED_STRING_KEYS = new Set([
   "name", "description", "image", "invoiceNumber", "issuerAddress",
   "debtorName", "debtorAddress", "currency", "issueDate", "dueDate",
   "jurisdiction", "category", "documentHash", "documentUrl",
+  // Schema versioning (#392) — preserve the version marker through sanitization
+  // so downstream consumers can detect legacy vs. versioned metadata.
+  "metadata_version", "metadataVersion",
 ]);
 
 const ALLOWED_NUMBER_KEYS = new Set(["amount", "apr"]);

--- a/next.config.js
+++ b/next.config.js
@@ -84,7 +84,7 @@ const withPWA = require("next-pwa")({
     // 8. IPFS gateway images — stale-while-revalidate
     {
       urlPattern:
-        /^https:\/\/(?:gateway\.pinata\.cloud|ipfs\.io|cloudflare-ipfs\.com)\/.*/i,
+        /^https:\/\/(?:gateway\.pinata\.cloud|ipfs\.io|cloudflare-ipfs\.com|dweb\.link|[a-z0-9]+\.ipfs\.dweb\.link)\/.*/i,
       handler: "StaleWhileRevalidate",
       options: {
         cacheName: "ipfs-assets",
@@ -123,6 +123,7 @@ const CSP_DIRECTIVES = {
     "https://ipfs.io",
     "https://gateway.pinata.cloud",
     "https://cloudflare-ipfs.com",
+    "https://dweb.link",
     "https://nftstorage.link",
     "https://*.ipfs.dweb.link",
     // Wallet provider icons
@@ -141,6 +142,8 @@ const CSP_DIRECTIVES = {
     "https://gateway.pinata.cloud",
     "https://ipfs.io",
     "https://cloudflare-ipfs.com",
+    "https://dweb.link",
+    "https://*.ipfs.dweb.link",
     "wss:",
   ],
   "frame-src": ["'none'"],
@@ -258,6 +261,7 @@ const nextConfig = {
       { protocol: "https", hostname: "ipfs.io" },
       { protocol: "https", hostname: "gateway.pinata.cloud" },
       { protocol: "https", hostname: "cloudflare-ipfs.com" },
+      { protocol: "https", hostname: "dweb.link" },
       { protocol: "https", hostname: "nftstorage.link" },
       { protocol: "https", hostname: "*.ipfs.dweb.link" },
 

--- a/services/invoiceService.ts
+++ b/services/invoiceService.ts
@@ -16,7 +16,14 @@ import type {
   InvoiceStatus,
 } from "@/types";
 import { MOCK_INVOICES } from "./mockData";
-import { uploadFileToPinata, uploadInvoiceMetadata, isValidCID } from "@/lib/ipfs";
+import {
+  uploadFileToPinata,
+  uploadInvoiceMetadata,
+  isValidCID,
+  fetchIpfsJsonWithFallback,
+  IpfsTamperError,
+  IpfsUnavailableError,
+} from "@/lib/ipfs";
 import { invoiceContract, marketplaceContract } from "@/lib/stellar/contracts";
 import { submitTransaction, waitForTransaction } from "@/lib/stellar/client";
 import { sanitizeIpfsMetadata } from "@/lib/security";
@@ -51,6 +58,40 @@ function mapContractError(error: unknown): ServiceError {
     return { code: "ALREADY_REPAID", message: "This invoice has already been repaid" };
   }
   return { code: "CONTRACT_ERROR", message: `Contract error: ${message}` };
+}
+
+/**
+ * Fetch, verify, and sanitize invoice metadata from IPFS.
+ *
+ * Uses multi-gateway fallback with per-gateway timeout/retry (#393): if the
+ * configured gateway is down we rotate to public gateways. The content hash is
+ * verified against the CID where possible, and tampered content is surfaced as
+ * a distinct IPFS_TAMPERED error so the UI can warn the user.
+ */
+async function fetchAndSanitizeIpfsMetadata(
+  cid: string
+): Promise<Result<Record<string, unknown>>> {
+  if (!isValidCID(cid)) {
+    return failure("INVALID_CID", "Invalid IPFS CID format");
+  }
+  try {
+    const { data } = await fetchIpfsJsonWithFallback<unknown>(cid, {
+      timeoutMs: 10_000,
+      // In mock mode the CID is synthetic and won't hash-match — skip verification.
+      skipIntegrity: env.NEXT_PUBLIC_ENABLE_MOCK_DATA,
+    });
+    return success(sanitizeIpfsMetadata(data));
+  } catch (error) {
+    if (error instanceof IpfsTamperError) {
+      return failure("IPFS_TAMPERED", error.message, { cid });
+    }
+    if (error instanceof IpfsUnavailableError) {
+      return failure("IPFS_ERROR", error.message, { cid });
+    }
+    return failure("IPFS_ERROR", "Failed to fetch IPFS metadata", {
+      cause: String(error),
+    });
+  }
 }
 
 // ─── Mock Invoice Service ─────────────────────────────────────────────────
@@ -179,21 +220,7 @@ class MockInvoiceService implements IInvoiceService {
   }
 
   async getIpfsMetadata(cid: string): Promise<Result<Record<string, unknown>>> {
-    try {
-      const gateway = env.NEXT_PUBLIC_IPFS_GATEWAY;
-      if (!isValidCID(cid)) {
-        return failure("INVALID_CID", "Invalid IPFS CID format");
-      }
-      const res = await fetch(`${gateway}/${cid}`, { signal: AbortSignal.timeout(10_000) });
-      if (!res.ok) {
-        return failure("IPFS_ERROR", `IPFS fetch failed with status ${res.status}`);
-      }
-      const raw: unknown = await res.json();
-      const sanitized = sanitizeIpfsMetadata(raw);
-      return success(sanitized);
-    } catch (error) {
-      return failure("IPFS_ERROR", "Failed to fetch IPFS metadata", { cause: String(error) });
-    }
+    return fetchAndSanitizeIpfsMetadata(cid);
   }
 
   async createInvoice(
@@ -326,21 +353,7 @@ class LiveInvoiceService implements IInvoiceService {
   }
 
   async getIpfsMetadata(cid: string): Promise<Result<Record<string, unknown>>> {
-    try {
-      const gateway = env.NEXT_PUBLIC_IPFS_GATEWAY;
-      if (!isValidCID(cid)) {
-        return failure("INVALID_CID", "Invalid IPFS CID format");
-      }
-      const res = await fetch(`${gateway}/${cid}`, { signal: AbortSignal.timeout(10_000) });
-      if (!res.ok) {
-        return failure("IPFS_ERROR", `IPFS fetch failed with status ${res.status}`);
-      }
-      const raw: unknown = await res.json();
-      const sanitized = sanitizeIpfsMetadata(raw);
-      return success(sanitized);
-    } catch (error) {
-      return failure("IPFS_ERROR", "Failed to fetch IPFS metadata", { cause: String(error) });
-    }
+    return fetchAndSanitizeIpfsMetadata(cid);
   }
 
   async createInvoice(

--- a/types/contract.ts
+++ b/types/contract.ts
@@ -56,6 +56,7 @@ export type ServiceErrorCode =
   | "FETCH_ERROR"
   | "INVALID_CID"
   | "IPFS_ERROR"
+  | "IPFS_TAMPERED"
   | "CONTRACT_ERROR"
   | "SUBMISSION_ERROR"
   | "CONFIRMATION_ERROR"

--- a/types/invoice.ts
+++ b/types/invoice.ts
@@ -56,6 +56,8 @@ export interface InvoiceMetadata {
   category: InvoiceCategory;
   documentHash: string; // IPFS CID of the PDF
   documentUrl: string;
+  /** Detected IPFS metadata schema version ("1.0" | "legacy"). Optional. */
+  metadataVersion?: "1.0" | "legacy";
 }
 
 export interface InvoiceFinancingTerms {


### PR DESCRIPTION
## Summary

Hardens the IPFS layer of the invoice flow across three related areas.

Closes #392
Closes #393
Closes #394

---

### #393 — Multi-gateway IPFS fallback + CID integrity verification
`lib/ipfs.ts`, `services/invoiceService.ts`, `next.config.js`

- **`IPFS_GATEWAYS`** — configured gateway first, then public fallbacks (`ipfs.io`, `cloudflare-ipfs.com`, `gateway.pinata.cloud`, `dweb.link`), deduped.
- **`fetchFromIpfsWithFallback`** — rotates gateways with a per-gateway timeout + retry; a gateway that times out, errors, or serves content failing integrity is skipped.
- **CID integrity** — `decodeCid` (CIDv0 base58 / CIDv1 base32 + varint) and `verifyCidIntegrity` recompute the sha2-256 digest for `raw` CIDs and compare it to the CID. dag-pb/CIDv0 return "unverifiable" (never a false tamper alarm).
- **Tamper handling** — tampered content throws `IpfsTamperError`; `getIpfsMetadata` surfaces it as a distinct `IPFS_TAMPERED` service error. `verifyMetadataIntegrity` now uses the fallback fetch.
- `next.config.js` — `dweb.link` added to CSP `connect-src`/`img-src`, image `remotePatterns`, and the PWA runtime cache.

### #392 — IPFS metadata schema versioning & migration
`lib/invoiceMetadata.ts`, `components/invoice/InvoiceMetadataViewer.tsx`, `lib/security.ts`

- **`detectMetadataVersion`** → `"1.0" | "legacy" | "unknown"`.
- **Legacy parser + `migrateLegacyToV1`** — maps pre-versioned camelCase metadata to the V1 input shape (currency normalization, date-only coercion, issuer/debtor mapping).
- **`parseAnyInvoiceMetadata`** — validates V1 directly, migrates+validates legacy, throws a clear error for unknown schemas.
- **Version badge** — `metadataVersionBadge` + a schema-version badge in the metadata viewer.
- Sanitizer preserves the version marker so downstream consumers can detect legacy vs. versioned metadata.

### #394 — Pinata health degradation UX
`hooks/usePinataHealth.ts`, `app/invoice/create/page.tsx`

- **Cache-bypassing retry** — `recheck()` now invalidates the 60s health cache, so the retry button performs a genuine fresh probe (previously a no-op within the cache window).
- **Exponential-backoff auto-retry** — the wizard self-heals when Pinata recovers, with backoff progress surfaced in the degraded-mode banner.
- Step-3 gating / blocked mint / degraded copy retained.

---

## Tests
New unit tests (29 passing):
- `hooks/__tests__/usePinataHealth.test.ts` — down/up transitions, cache-bypassing recheck, backoff.
- `lib/__tests__/ipfsFallback.test.ts` — gateway rotation, tamper rejection & failover, CID integrity.
- `lib/__tests__/metadataVersioning.test.ts` — detect / migrate / parse / badge.

## Notes
- Scope limited to these three issues; pre-existing repo breakage (unrelated failing `ipfs.test.ts` cases, e2e type errors, lint-staged `tsc` config) was intentionally left untouched.
- `eslint --max-warnings=0` and full-project `tsc --noEmit` both pass on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)