### PR TITLE
Devoclan/ci tests e2e issues

### DIFF
--- a/.github/workflows/nightly-testnet-e2e.yml
+++ b/.github/workflows/nightly-testnet-e2e.yml
@@ -1,0 +1,55 @@
+name: Nightly Testnet E2E
+
+# Opt-in E2E suite that mints, funds, and repays a real invoice against the
+# live Soroban testnet contracts (see e2e/testnet-nightly.spec.ts). Kept
+# separate from test.yml, which only ever runs against mock data, and only
+# ever runs on a schedule or manual dispatch — never on push/PR.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  testnet-e2e:
+    name: Testnet mint / fund / repay
+    runs-on: ubuntu-latest
+    env:
+      RUN_TESTNET_E2E: "true"
+      TESTNET_E2E_SECRET_KEY: ${{ secrets.TESTNET_E2E_SECRET_KEY }}
+      NEXT_PUBLIC_STELLAR_NETWORK: testnet
+      NEXT_PUBLIC_STELLAR_RPC_URL: https://soroban-testnet.stellar.org
+      NEXT_PUBLIC_STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+      NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+      NEXT_PUBLIC_INVOICE_CONTRACT_ID: ${{ secrets.TESTNET_INVOICE_CONTRACT_ID }}
+      NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID: ${{ secrets.TESTNET_MARKETPLACE_CONTRACT_ID }}
+      NEXT_PUBLIC_TOKEN_CONTRACT_ID: ${{ secrets.TESTNET_TOKEN_CONTRACT_ID }}
+      NEXT_PUBLIC_IPFS_GATEWAY: https://gateway.pinata.cloud/ipfs
+      NEXT_PUBLIC_ENABLE_MOCK_DATA: "false"
+      PINATA_JWT: ${{ secrets.PINATA_JWT }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run nightly testnet E2E (mint, fund, repay)
+        run: npx playwright test e2e/testnet-nightly.spec.ts --project=chromium
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-testnet-nightly-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,45 @@
+name: Security
+
+# Bundles the dependency vulnerability gate (scripts/audit.js) together with
+# secret scanning so both checks run as a single required security job,
+# independent of the existing CI workflow.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  dependency-audit-gate:
+    name: Dependency Vulnerability Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Enforce dependency vulnerability gate
+        run: node scripts/audit.js
+
+  secret-scan:
+    name: Secret Scanning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * E2E — Wallet-gated /analytics page.
+ *
+ * Covers:
+ *  - Disconnected: shows the "Connect your wallet" gate instead of analytics
+ *  - Disconnected: "Connect Wallet" CTA opens the wallet connect modal
+ *  - Connected: wallet gate is dismissed and the analytics page renders
+ *
+ * Wallet simulation strategy:
+ *   Inject a Zustand-compatible localStorage entry for `kora-wallet-store`
+ *   before navigating so the app rehydrates as connected, same approach as
+ *   e2e/dashboard.spec.ts.
+ */
+import { test, expect, type BrowserContext } from "@playwright/test";
+import { MOCK_ADDRESS } from "./helpers/mock-wallet";
+
+async function injectConnectedWallet(context: BrowserContext) {
+  await context.addInitScript((address) => {
+    const walletState = {
+      state: {
+        address,
+        publicKey: address,
+        isConnected: true,
+        provider: "freighter",
+        balance: "1000.00",
+        isVerified: false,
+        verifiedAt: null,
+      },
+      version: 0,
+    };
+    localStorage.setItem("kora-wallet-store", JSON.stringify(walletState));
+  }, MOCK_ADDRESS);
+}
+
+test.describe("Analytics page — disconnected", () => {
+  test("shows connect wallet gate when no wallet is connected", async ({ page }) => {
+    await page.goto("/analytics");
+
+    await expect(
+      page.getByRole("heading", { name: /connect your wallet/i })
+    ).toBeVisible();
+    await expect(page.getByText(/view your portfolio analytics/i)).toBeVisible();
+  });
+
+  test("connect wallet CTA opens the wallet connect modal", async ({ page }) => {
+    await page.goto("/analytics");
+
+    await page.getByRole("button", { name: /connect wallet/i }).click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+});
+
+test.describe("Analytics page — connected", () => {
+  test("renders analytics once a wallet is connected", async ({ page, context }) => {
+    await injectConnectedWallet(context);
+    await page.goto("/analytics");
+
+    await expect(
+      page.getByRole("heading", { name: /connect your wallet/i })
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/testnet-nightly.spec.ts
+++ b/e2e/testnet-nightly.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Opt-in nightly testnet E2E — mint, fund, repay against real contracts.
+ *
+ * Unlike the rest of the e2e/ suite (mock wallet, mock data), this spec
+ * talks to the live Soroban testnet contracts using a funded keypair, the
+ * same way scripts/seed-testnet.ts does. It is intentionally NOT part of
+ * the default `npm run test:e2e` / CI `test.yml` run:
+ *
+ *   - It is skipped unless RUN_TESTNET_E2E=true is set.
+ *   - It requires TESTNET_E2E_SECRET_KEY (a funded testnet account) and
+ *     NEXT_PUBLIC_STELLAR_NETWORK=testnet.
+ *
+ * See .github/workflows/nightly-testnet-e2e.yml for the scheduled runner
+ * that opts in and provides these secrets.
+ */
+import { test, expect } from "@playwright/test";
+
+const RUN_TESTNET_E2E = process.env.RUN_TESTNET_E2E === "true";
+const SECRET_KEY = process.env.TESTNET_E2E_SECRET_KEY;
+
+test.describe("Testnet — mint, fund, repay (real contracts)", () => {
+  test.skip(
+    !RUN_TESTNET_E2E,
+    "Opt-in nightly-only suite. Set RUN_TESTNET_E2E=true to run against live testnet contracts."
+  );
+
+  test("mints, funds, and repays a real invoice on testnet", async () => {
+    expect(
+      SECRET_KEY,
+      "TESTNET_E2E_SECRET_KEY must be set (funded testnet keypair) when RUN_TESTNET_E2E=true"
+    ).toBeTruthy();
+
+    const { env } = await import("@/lib/env");
+    expect(env.NEXT_PUBLIC_STELLAR_NETWORK).toBe("testnet");
+
+    const StellarSdk = await import("@stellar/stellar-sdk");
+    const { fundTestnetAccount, submitTransaction, waitForTransaction } = await import(
+      "@/lib/stellar/client"
+    );
+    const { invoiceContract, marketplaceContract, buildTestnetUsdcMintTx } = await import(
+      "@/lib/stellar/contracts"
+    );
+
+    const owner = StellarSdk.Keypair.fromSecret(SECRET_KEY!);
+    await fundTestnetAccount(owner.publicKey());
+
+    const usdcMintXdr = await buildTestnetUsdcMintTx(owner.publicKey(), 1_000_000_000n);
+    const signedUsdcMint = await signWithKeypair(StellarSdk, usdcMintXdr, owner);
+    const usdcResult = await submitTransaction(signedUsdcMint);
+    await waitForTransaction(usdcResult.hash);
+
+    const dueDate = BigInt(Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60);
+    const mintXdr = await invoiceContract.mintInvoice(
+      {
+        ipfsCid: "QmNightlyTestnetE2EPlaceholder",
+        amount: 1_000_000_000n,
+        financingAmount: 900_000_000n,
+        discountRate: 1000,
+        dueDate,
+      },
+      owner.publicKey()
+    );
+    const signedMint = await signWithKeypair(StellarSdk, mintXdr, owner);
+    const mintResult = await submitTransaction(signedMint);
+    const mintConfirmation = await waitForTransaction(mintResult.hash);
+    expect(mintConfirmation.status).toBe("SUCCESS");
+
+    const onChainInvoice = await invoiceContract.getInvoice(
+      /* tokenId */ 0n,
+      owner.publicKey()
+    );
+    expect(onChainInvoice).toBeTruthy();
+
+    const fundXdr = await marketplaceContract.fundInvoice(
+      { tokenId: 0n, amount: 900_000_000n },
+      owner.publicKey()
+    );
+    const signedFund = await signWithKeypair(StellarSdk, fundXdr, owner);
+    const fundResult = await submitTransaction(signedFund);
+    const fundConfirmation = await waitForTransaction(fundResult.hash);
+    expect(fundConfirmation.status).toBe("SUCCESS");
+
+    const repayXdr = await marketplaceContract.repayInvoice(
+      { tokenId: 0n },
+      owner.publicKey()
+    );
+    const signedRepay = await signWithKeypair(StellarSdk, repayXdr, owner);
+    const repayResult = await submitTransaction(signedRepay);
+    const repayConfirmation = await waitForTransaction(repayResult.hash);
+    expect(repayConfirmation.status).toBe("SUCCESS");
+  });
+});
+
+async function signWithKeypair(
+  StellarSdk: typeof import("@stellar/stellar-sdk"),
+  unsignedXdr: string,
+  keypair: InstanceType<typeof StellarSdk.Keypair>
+): Promise<string> {
+  const { env } = await import("@/lib/env");
+  const tx = StellarSdk.TransactionBuilder.fromXDR(
+    unsignedXdr,
+    env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE
+  );
+  tx.sign(keypair);
+  return tx.toXDR();
+}

--- a/e2e/transactions.spec.ts
+++ b/e2e/transactions.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * E2E — Wallet-gated /transactions page.
+ *
+ * Covers:
+ *  - Disconnected: shows the "Connect your wallet" gate instead of history
+ *  - Disconnected: "Connect Wallet" CTA opens the wallet connect modal
+ *  - Connected: wallet gate is dismissed and transaction history renders
+ *
+ * Wallet simulation strategy:
+ *   Inject a Zustand-compatible localStorage entry for `kora-wallet-store`
+ *   before navigating so the app rehydrates as connected, same approach as
+ *   e2e/dashboard.spec.ts.
+ */
+import { test, expect, type BrowserContext } from "@playwright/test";
+import { MOCK_ADDRESS } from "./helpers/mock-wallet";
+
+async function injectConnectedWallet(context: BrowserContext) {
+  await context.addInitScript((address) => {
+    const walletState = {
+      state: {
+        address,
+        publicKey: address,
+        isConnected: true,
+        provider: "freighter",
+        balance: "1000.00",
+        isVerified: false,
+        verifiedAt: null,
+      },
+      version: 0,
+    };
+    localStorage.setItem("kora-wallet-store", JSON.stringify(walletState));
+  }, MOCK_ADDRESS);
+}
+
+test.describe("Transactions page — disconnected", () => {
+  test("shows connect wallet gate when no wallet is connected", async ({ page }) => {
+    await page.goto("/transactions");
+
+    await expect(
+      page.getByRole("heading", { name: /connect your wallet/i })
+    ).toBeVisible();
+    await expect(
+      page.getByText(/connect to view your on-chain transaction history/i)
+    ).toBeVisible();
+  });
+
+  test("connect wallet CTA opens the wallet connect modal", async ({ page }) => {
+    await page.goto("/transactions");
+
+    await page.getByRole("button", { name: /connect wallet/i }).click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+});
+
+test.describe("Transactions page — connected", () => {
+  test("renders transaction history once a wallet is connected", async ({ page, context }) => {
+    await injectConnectedWallet(context);
+    await page.goto("/transactions");
+
+    await expect(
+      page.getByRole("heading", { name: /connect your wallet/i })
+    ).not.toBeVisible();
+  });
+});

--- a/services/__tests__/invoiceService.factory.test.ts
+++ b/services/__tests__/invoiceService.factory.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration coverage for the mock/live InvoiceService factory switch.
+ *
+ * createInvoiceService() picks MockInvoiceService or LiveInvoiceService based
+ * on env.NEXT_PUBLIC_ENABLE_MOCK_DATA. These tests mock the Soroban RPC layer
+ * (lib/stellar/contracts, lib/stellar/client) and IPFS layer so LiveInvoiceService's
+ * read/write paths can be exercised without a real network, and assert that the
+ * factory actually swaps implementations rather than always using mock data.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockEnv = {
+  NEXT_PUBLIC_ENABLE_MOCK_DATA: true,
+  NEXT_PUBLIC_IPFS_GATEWAY: "https://gateway.pinata.cloud/ipfs",
+};
+
+vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
+const getInvoice = vi.fn();
+const mintInvoice = vi.fn();
+const cancelInvoice = vi.fn();
+const fundInvoice = vi.fn();
+const repayInvoice = vi.fn();
+const claimYield = vi.fn();
+const getPositions = vi.fn();
+
+vi.mock("@/lib/stellar/contracts", () => ({
+  invoiceContract: { getInvoice, mintInvoice, cancelInvoice },
+  marketplaceContract: { fundInvoice, repayInvoice, claimYield, getPositions },
+}));
+
+const submitTransaction = vi.fn();
+const waitForTransaction = vi.fn();
+
+vi.mock("@/lib/stellar/client", () => ({
+  submitTransaction,
+  waitForTransaction,
+}));
+
+vi.mock("@/lib/ipfs", () => ({
+  uploadFileToPinata: vi.fn().mockResolvedValue("QmDocCid"),
+  uploadInvoiceMetadata: vi.fn().mockResolvedValue("QmMetaCid"),
+  isValidCID: vi.fn().mockReturnValue(true),
+  fetchIpfsJsonWithFallback: vi.fn().mockResolvedValue({ raw: {} }),
+  IpfsTamperError: class IpfsTamperError extends Error {},
+  IpfsUnavailableError: class IpfsUnavailableError extends Error {},
+}));
+
+vi.mock("@/lib/security", () => ({
+  sanitizeIpfsMetadata: vi.fn((data) => data),
+}));
+
+describe("createInvoiceService factory switch", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("returns a MockInvoiceService that resolves from local fixtures with no RPC calls", async () => {
+    mockEnv.NEXT_PUBLIC_ENABLE_MOCK_DATA = true;
+    const { createInvoiceService } = await import("../invoiceService");
+
+    const service = createInvoiceService();
+    const result = await service.getInvoices();
+
+    expect(result.ok).toBe(true);
+    expect(getInvoice).not.toHaveBeenCalled();
+    expect(fundInvoice).not.toHaveBeenCalled();
+  });
+
+  it("returns a LiveInvoiceService that reads through the mocked RPC contract client", async () => {
+    mockEnv.NEXT_PUBLIC_ENABLE_MOCK_DATA = false;
+    getInvoice.mockResolvedValue({
+      owner: "GOWNER",
+      ipfs_cid: "QmCid",
+      amount: 1_000_000n,
+      financing_amount: 900_000n,
+      discount_rate: 500,
+      due_date: 1893456000n,
+      status: 0,
+    });
+
+    const { createInvoiceService } = await import("../invoiceService");
+    const service = createInvoiceService();
+
+    const result = await service.getInvoice("inv_42", "GSOURCE");
+
+    expect(getInvoice).toHaveBeenCalledWith(42n, "GSOURCE");
+    expect(result.ok).toBe(true);
+  });
+
+  it("live getInvoice fails fast without a source public key, without hitting RPC", async () => {
+    mockEnv.NEXT_PUBLIC_ENABLE_MOCK_DATA = false;
+    const { createInvoiceService } = await import("../invoiceService");
+    const service = createInvoiceService();
+
+    const result = await service.getInvoice("inv_42");
+
+    expect(result.ok).toBe(false);
+    expect(getInvoice).not.toHaveBeenCalled();
+  });
+
+  it("routes live writes (mint/fund/repay) through the mocked contract clients", async () => {
+    mockEnv.NEXT_PUBLIC_ENABLE_MOCK_DATA = false;
+    mintInvoice.mockResolvedValue("unsigned-mint-xdr");
+    fundInvoice.mockResolvedValue("unsigned-fund-xdr");
+    repayInvoice.mockResolvedValue("unsigned-repay-xdr");
+
+    const { createInvoiceService } = await import("../invoiceService");
+    const service = createInvoiceService();
+
+    const mintResult = await service.createInvoice(
+      {
+        document: new File(["x"], "invoice.pdf"),
+        invoiceNumber: "INV-1",
+        description: "test",
+        debtorName: "Acme",
+        debtorAddress: "GDEBTOR",
+        amount: 1000,
+        currency: "USDC",
+        issueDate: "2026-01-01",
+        dueDate: "2026-06-01",
+        listingExpiryDate: "2026-05-01",
+        jurisdiction: "US",
+        category: "trade",
+        discountRate: 0.05,
+      } as any,
+      "GOWNER"
+    );
+    expect(mintResult.ok).toBe(true);
+    expect(mintInvoice).toHaveBeenCalledTimes(1);
+
+    const fundResult = await service.fundInvoice("42", 500, "GINVESTOR");
+    expect(fundResult.ok).toBe(true);
+    expect(fundInvoice).toHaveBeenCalledWith(
+      { tokenId: 42n, amount: 500_000_000n },
+      "GINVESTOR"
+    );
+
+    const repayResult = await service.repayInvoice("42", "GOWNER");
+    expect(repayResult.ok).toBe(true);
+    expect(repayInvoice).toHaveBeenCalledWith({ tokenId: 42n }, "GOWNER");
+  });
+
+  it("mock writes never touch the RPC contract clients", async () => {
+    mockEnv.NEXT_PUBLIC_ENABLE_MOCK_DATA = true;
+    const { createInvoiceService } = await import("../invoiceService");
+    const service = createInvoiceService();
+
+    await service.fundInvoice("42", 500, "GINVESTOR");
+
+    expect(fundInvoice).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
closes #427
closes #428
closes #429
closes #430

Enforce dependency vulnerability gates and bundle secret scanning in CI.

Full LiveInvoiceService coverage with mocked RPC for read/write factory switch.
Opt-in nightly testnet E2E for mint, fund, and repay against real contracts.

Playwright specs for wallet-gated analytics and transaction history pages.

