### PR TITLE
feat(secondary-market): implement transfer_position soroban contract integration

### DIFF
--- a/hooks/useTransaction.ts
+++ b/hooks/useTransaction.ts
@@ -6,6 +6,7 @@ import { useToast } from "./useToast";
 import type { NotificationPreferenceType } from "./useToast";
 import { useWallet } from "./useWallet";
 import { useNetworkValidation } from "./useNetworkValidation";
+import { useTxSimulation } from "./useTxSimulation";
 import { rpc, submitTransaction, BadSequenceError, sequenceManager } from "@/lib/stellar/client";
 import { env } from "@/lib/env";
 import * as StellarSdk from "@stellar/stellar-sdk";
@@ -331,5 +332,58 @@ export function useTransaction() {
     txHash: state.txHash,
     error: state.error,
     simulationPreview,
+  };
+}
+
+/**
+ * P2P position transfer flow (#443) — combines useTransaction + the
+ * simulation-preview gate (see hooks/useTxSimulation.ts) so callers get the
+ * same "build → simulate → preview → sign → submit → poll" pipeline as
+ * fund/claim/cancel, without re-wiring it per screen.
+ *
+ * `acceptTransfer` is a stub: it surfaces
+ * `prepareAcceptPositionTransfer`'s NOT_IMPLEMENTED error through the normal
+ * error/toast path until the buyer-acceptance contract ABI is confirmed
+ * (see the doc comment on that function in services/invoiceService.ts).
+ */
+export function useTransferPositionFlow() {
+  const tx = useTransaction();
+  const { simulationDialogProps, onSimulationPreview } = useTxSimulation();
+
+  const transferPosition = useCallback(
+    async (positionId: string, toAddress: string, sellerAddress: string) => {
+      const { prepareTransferPosition } = await import(
+        "@/services/invoiceService"
+      );
+      return tx.execute(
+        () => prepareTransferPosition(positionId, toAddress, sellerAddress),
+        {
+          onSimulationPreview,
+          successMessage: "Position transferred successfully!",
+          txType: "transfer",
+        }
+      );
+    },
+    [tx, onSimulationPreview]
+  );
+
+  const acceptTransfer = useCallback(
+    async (positionId: string, buyerAddress: string) => {
+      const { prepareAcceptPositionTransfer } = await import(
+        "@/services/invoiceService"
+      );
+      return tx.execute(
+        () => prepareAcceptPositionTransfer(positionId, buyerAddress),
+        { onSimulationPreview, txType: "transfer" }
+      );
+    },
+    [tx, onSimulationPreview]
+  );
+
+  return {
+    ...tx,
+    transferPosition,
+    acceptTransfer,
+    simulationDialogProps,
   };
 }

--- a/lib/stellar/contracts.ts
+++ b/lib/stellar/contracts.ts
@@ -13,6 +13,7 @@ import type {
   FundInvoiceParams,
   RepayInvoiceParams,
   ClaimYieldParams,
+  TransferPositionParams,
   OnChainInvoice,
 } from "@/types/contract";
 import type { InvoicePosition } from "@/types/invoice";
@@ -425,6 +426,24 @@ class MarketplaceContractClient {
       this.contractId,
       "claim_yield",
       [scvU64(params.tokenId)],
+      sourcePublicKey
+    );
+  }
+
+  /**
+   * P2P secondary-market transfer of an investor position to a new owner.
+   * See the `TransferPositionParams` doc comment in types/contract.ts for
+   * the assumed contract ABI. Returns unsigned XDR string, to be signed by
+   * the current position owner (`sourcePublicKey`).
+   */
+  async transferPosition(
+    params: TransferPositionParams,
+    sourcePublicKey: string
+  ): Promise<string> {
+    return buildCall(
+      this.contractId,
+      "transfer_position",
+      [scvU64(params.positionId), scvAddress(params.toAddress)],
       sourcePublicKey
     );
   }

--- a/services/invoiceService.ts
+++ b/services/invoiceService.ts
@@ -28,6 +28,7 @@ import { invoiceContract, marketplaceContract } from "@/lib/stellar/contracts";
 import { submitTransaction, waitForTransaction } from "@/lib/stellar/client";
 import { sanitizeIpfsMetadata } from "@/lib/security";
 import { env } from "@/lib/env";
+import { isValidStellarAddress } from "@/lib/utils";
 
 // ─── Helper: Create successful result ──────────────────────────────────────
 function success<T>(value: T): Result<T> {
@@ -58,6 +59,21 @@ function mapContractError(error: unknown): ServiceError {
     return { code: "ALREADY_REPAID", message: "This invoice has already been repaid" };
   }
   return { code: "CONTRACT_ERROR", message: `Contract error: ${message}` };
+}
+
+// ─── Helper: Map contract errors for the transfer_position flow ───────────
+function mapTransferError(error: unknown): ServiceError {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("Invoice not found")) {
+    return { code: "NOT_FOUND", message: "Position not found" };
+  }
+  if (message.includes("Unauthorized")) {
+    return {
+      code: "UNAUTHORIZED",
+      message: "Only the current position owner can transfer it",
+    };
+  }
+  return { code: "TRANSFER_ERROR", message: `Transfer failed: ${message}` };
 }
 
 /**
@@ -297,6 +313,27 @@ class MockInvoiceService implements IInvoiceService {
     }
   }
 
+  async transferPosition(
+    positionId: string,
+    toAddress: string,
+    sellerAddress: string
+  ): Promise<Result<string>> {
+    try {
+      if (!isValidStellarAddress(toAddress)) {
+        return failure("INVALID_INPUT", "Recipient address is not a valid Stellar G-address");
+      }
+      if (toAddress === sellerAddress) {
+        return failure("INVALID_INPUT", "Cannot transfer a position to yourself");
+      }
+      await this.delay();
+      return success(
+        `mock_unsigned_xdr_transfer_${positionId}_${toAddress}_${sellerAddress}`
+      );
+    } catch (error) {
+      return failure("TRANSFER_ERROR", "Failed to prepare position transfer", { cause: String(error) });
+    }
+  }
+
   async submitTransaction(signedXdr: string): Promise<Result<string>> {
     try {
       await this.delay();
@@ -532,6 +569,30 @@ class LiveInvoiceService implements IInvoiceService {
       return success(xdr);
     } catch (error) {
       const err = mapContractError(error);
+      return failure(err.code, err.message, err.details);
+    }
+  }
+
+  async transferPosition(
+    positionId: string,
+    toAddress: string,
+    sellerAddress: string
+  ): Promise<Result<string>> {
+    try {
+      if (!isValidStellarAddress(toAddress)) {
+        return failure("INVALID_INPUT", "Recipient address is not a valid Stellar G-address");
+      }
+      if (toAddress === sellerAddress) {
+        return failure("INVALID_INPUT", "Cannot transfer a position to yourself");
+      }
+
+      const xdr = await marketplaceContract.transferPosition(
+        { positionId: BigInt(positionId), toAddress },
+        sellerAddress
+      );
+      return success(xdr);
+    } catch (error) {
+      const err = mapTransferError(error);
       return failure(err.code, err.message, err.details);
     }
   }
@@ -787,6 +848,50 @@ export async function prepareCancelInvoice(
   const result = await service.cancelInvoice(tokenId, ownerAddress);
   if (!result.ok) throw new Error(result.error.message);
   return result.value;
+}
+
+/**
+ * Build an unsigned XDR to transfer an investor position to a new owner
+ * (P2P secondary-market sale). Signed by the current position owner.
+ *
+ * See the `TransferPositionParams` doc comment in types/contract.ts for the
+ * assumed single-call contract ABI.
+ */
+export async function prepareTransferPosition(
+  positionId: string,
+  toAddress: string,
+  sellerAddress: string
+): Promise<string> {
+  const result = await service.transferPosition(positionId, toAddress, sellerAddress);
+  if (!result.ok) throw new Error(result.error.message);
+  return result.value;
+}
+
+/**
+ * Buyer acceptance flow — STUB (#443).
+ *
+ * `transferPosition`/`prepareTransferPosition` above assume the deployed
+ * `transfer_position` contract method is a single call authorized only by
+ * the seller (no separate buyer co-signature), matching `claim_position`.
+ * If that assumption doesn't hold once the deployed contract's ABI is
+ * confirmed and a two-step propose/accept pattern is required instead, this
+ * is the intended integration point for the buyer's acceptance transaction:
+ * build the buyer-signed accept call here (e.g. `accept_position_transfer`
+ * or similar) the same way `prepareTransferPosition` builds the seller's.
+ *
+ * Deliberately unimplemented until the contract ABI is confirmed — mirrors
+ * the NOT_IMPLEMENTED pattern already used by `getInvoices`/
+ * `getInvoicesByOwner` in LiveInvoiceService for the same reason.
+ */
+export async function prepareAcceptPositionTransfer(
+  _positionId: string,
+  _buyerAddress: string
+): Promise<never> {
+  throw new Error(
+    "Buyer acceptance for transfer_position is not yet implemented — " +
+      "pending confirmation of the deployed contract's transfer ABI. " +
+      "See prepareAcceptPositionTransfer in services/invoiceService.ts."
+  );
 }
 
 export async function submitAndConfirm(signedXdr: string): Promise<string> {

--- a/types/contract.ts
+++ b/types/contract.ts
@@ -67,6 +67,7 @@ export type ServiceErrorCode =
   | "REPAY_ERROR"
   | "CLAIM_ERROR"
   | "CANCEL_ERROR"
+  | "TRANSFER_ERROR"
   | "NOT_IMPLEMENTED"
   | "UNKNOWN_ERROR";
 
@@ -110,6 +111,22 @@ export interface RepayInvoiceParams {
 
 export interface ClaimYieldParams {
   tokenId: bigint;
+}
+
+/**
+ * P2P secondary-market transfer of an investor position (#443).
+ *
+ * ABI assumption: `transfer_position(position_id: u64, to: Address)` is a
+ * single atomic call authorized by the position's current owner (the
+ * `sourcePublicKey` signer), mirroring `claim_position`/`claim_yield`. The
+ * recipient is not required to co-sign the transfer itself. If the deployed
+ * contract instead requires a two-step propose/accept pattern, wire the
+ * buyer's confirmation into `acceptPositionTransfer` in
+ * services/invoiceService.ts, which is currently a documented stub.
+ */
+export interface TransferPositionParams {
+  positionId: bigint;
+  toAddress: string;
 }
 
 // ─── API Response Wrappers ────────────────────────────────────────────────────

--- a/types/service.ts
+++ b/types/service.ts
@@ -58,5 +58,16 @@ export interface IInvoiceService {
 
   cancelInvoice(tokenId: string, ownerAddress: string): Promise<Result<string>>;
 
+  /**
+   * Transfer an investor position to a new owner (P2P secondary-market
+   * sale). Returns unsigned XDR string, signed by `sellerAddress` (the
+   * current position owner).
+   */
+  transferPosition(
+    positionId: string,
+    toAddress: string,
+    sellerAddress: string
+  ): Promise<Result<string>>;
+
   submitTransaction(signedXdr: string): Promise<Result<string>>;
 }


### PR DESCRIPTION
## Summary

Implements the P2P secondary-market position transfer requested in #443, following the suggested execution steps:

1. **`lib/stellar/contracts.ts`** — `MarketplaceContractClient.transferPosition()` builds an unsigned `transfer_position(position_id, to)` call through the existing `buildCall()`/`simulate()` pipeline (same XDR-build + simulation path every other contract method already uses).
2. **`types/contract.ts`** — `TransferPositionParams` + `TRANSFER_ERROR` service error code. The contract ABI assumption is documented directly on the type (see doc comment): a single call authorized only by the seller/current owner, mirroring `claim_position`/`claim_yield` — I couldn't verify this against the actual deployed contract source from this repo alone, so it's called out explicitly rather than silently assumed.
3. **`services/invoiceService.ts`** — `transferPosition()` on both `MockInvoiceService` and `LiveInvoiceService` (added to the shared `IInvoiceService` interface in `types/service.ts`), plus the `prepareTransferPosition()` legacy-API wrapper matching the existing `prepareFundInvoice`/`prepareClaimPosition`/etc. pattern. Validates the recipient is a real Stellar address and rejects self-transfers before hitting the contract.
4. **Tx simulation preview** — `hooks/useTransaction.ts` adds `useTransferPositionFlow()`, which wires `prepareTransferPosition` into the existing `useTransaction`/`useTxSimulation` pipeline so transfers get the same build → simulate → preview → sign → submit → poll flow (and `TxSimulationPreview` dialog) as fund/claim/cancel already do — no new simulation logic needed since that infrastructure is already generic.
5. **Buyer acceptance flow stub** — `prepareAcceptPositionTransfer()` in `invoiceService.ts` and `acceptTransfer()` in `useTransferPositionFlow()` are wired end-to-end but deliberately throw `NOT_IMPLEMENTED`, mirroring the same pattern `LiveInvoiceService` already uses for other not-yet-confirmed contract behavior (see `getInvoices`/`getInvoicesByOwner`). If the deployed contract actually requires a two-step propose/accept instead of the single seller-authorized call assumed here, this is the integration point to complete once that's confirmed.

## Acceptance criteria
- [x] Unsigned XDR builds for transfer — `transferPosition`/`prepareTransferPosition`
- [x] Simulation works — reuses the existing generic `simulate()`/`useTransaction` pipeline
- [x] Service method — implemented on both Mock and Live `IInvoiceService`
- [x] Documented contract ABI assumption — see `TransferPositionParams` doc comment in `types/contract.ts`

## Test plan
No automated tests run (out of scope for this change per task instructions). Checked existing `vi.mock("@/services/invoiceService")` call sites in `__tests__/` — all mock only the specific functions they use, so the new exports don't require any test updates.

Closes #443