### PR TITLE
feat(secondary-market): design secondary market listing ui for invoice positions

### DIFF
--- a/app/dashboard/investor/page.tsx
+++ b/app/dashboard/investor/page.tsx
@@ -4,16 +4,18 @@ import { useCallback, useMemo, useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { Store, TrendingUp, DollarSign, BarChart3, Clock, AlertTriangle } from "lucide-react";
+import { Store, TrendingUp, DollarSign, BarChart3, Clock, AlertTriangle, Tag } from "lucide-react";
 import dynamic from "next/dynamic";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { StatCard } from "@/components/ui/stat-card";
 import { useWallet } from "@/hooks/useWallet";
-import { useUIStore, useInvoiceStore, DEFAULT_FILTERS } from "@/store";
+import { useUIStore, useInvoiceStore, usePositionListingStore, DEFAULT_FILTERS } from "@/store";
 import { usePositions } from "@/hooks/usePositions";
 import { useTransaction } from "@/hooks/useTransaction";
 import { prepareClaimPosition } from "@/services/invoiceService";
+import { ListPositionDialog } from "@/components/invoice/ListPositionDialog";
 import type { PortfolioDonutProps, DonutFilter } from "@/components/dashboard/PortfolioDonut";
 import {
   marketplacePathForAllocation,
@@ -27,6 +29,7 @@ import {
   cn,
 } from "@/lib/utils";
 import type { InvestorPosition, InvoicePosition } from "@/types/invoice";
+import { computeImpliedDiscount } from "@/types/invoice";
 import type { ColumnDef, DataTableProps } from "@/types/table";
 import { InvestorDashboardSkeleton } from "@/components/ui/skeleton";
 
@@ -76,6 +79,8 @@ export default function InvestorDashboardPage() {
   const { execute } = useTransaction();
   const [donutFilter, setDonutFilter] = useState<DonutFilter | null>(null);
   const [loadTimedOut, setLoadTimedOut] = useState(false);
+  const [listingTarget, setListingTarget] = useState<InvestorPosition | null>(null);
+  const { listings, listPosition, unlistPosition } = usePositionListingStore();
 
   const positionsData: InvestorPosition[] = useMemo(
     () => positionsQuery.data ?? [],
@@ -147,6 +152,19 @@ export default function InvestorDashboardPage() {
       onSuccess: () => positionsQuery.refetch(),
     });
   };
+
+  const handleListSubmit = (askPrice: number) => {
+    if (!listingTarget) return;
+    listPosition({
+      positionId: listingTarget.id,
+      askPrice,
+      impliedDiscount: computeImpliedDiscount(askPrice, listingTarget.expectedReturn),
+      listedAt: new Date().toISOString(),
+    });
+    setListingTarget(null);
+  };
+
+  const listedPositions = positionsData.filter((pos) => listings[pos.id]);
 
   if (!isConnected) {
     return (
@@ -345,6 +363,20 @@ export default function InvestorDashboardPage() {
       ),
     },
     {
+      id: "listing",
+      header: "Listing",
+      sortable: false,
+      cell: (row) =>
+        listings[row.id] ? (
+          <Badge variant="kora">
+            <Tag className="mr-1 h-3 w-3" aria-hidden />
+            Listed · {formatCurrency(listings[row.id].askPrice, "USDC", true)}
+          </Badge>
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        ),
+    },
+    {
       id: "actions",
       header: "",
       sortable: false,
@@ -355,6 +387,24 @@ export default function InvestorDashboardPage() {
               Claim
             </Button>
           ) : null}
+          {row.status === "active" &&
+            (listings[row.id] ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => unlistPosition(row.id)}
+              >
+                Unlist
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setListingTarget(row)}
+              >
+                <Tag className="h-3.5 w-3.5" /> List for Sale
+              </Button>
+            ))}
           <Link
             href={`/marketplace/${row.invoice?.id ?? row.invoiceId}`}
             className="text-xs text-primary hover:opacity-80"
@@ -446,6 +496,68 @@ export default function InvestorDashboardPage() {
           />
         </CardContent>
       </Card>
+
+      {listedPositions.length > 0 && (
+        <Card className="mt-8">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Tag className="h-4 w-4 text-primary" aria-hidden />
+              Active Listings
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-4 sm:p-6">
+            <div className="space-y-3">
+              {listedPositions.map((pos) => {
+                const listing = listings[pos.id];
+                if (!listing) return null;
+                const currency = pos.invoice?.metadata.currency ?? "USDC";
+                return (
+                  <div
+                    key={pos.id}
+                    className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-muted/30 p-3"
+                  >
+                    <div>
+                      <p className="font-medium text-foreground">
+                        {pos.invoice?.metadata.invoiceNumber ?? `Invoice ${pos.invoiceId}`}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Listed {formatDate(listing.listedAt)}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <p className="font-semibold text-foreground">
+                        {formatCurrency(listing.askPrice, currency)}
+                      </p>
+                      <p
+                        className={cn(
+                          "text-xs",
+                          listing.impliedDiscount >= 0 ? "text-success" : "text-warning",
+                        )}
+                      >
+                        {(listing.impliedDiscount * 100).toFixed(2)}% implied discount
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => unlistPosition(pos.id)}
+                    >
+                      Unlist
+                    </Button>
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <ListPositionDialog
+        position={listingTarget}
+        open={listingTarget !== null}
+        onOpenChange={(open) => !open && setListingTarget(null)}
+        onSubmit={handleListSubmit}
+      />
     </div>
   );
 }

--- a/components/invoice/ListPositionDialog.tsx
+++ b/components/invoice/ListPositionDialog.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { Tag } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { NumberInput } from "@/components/ui/number-input";
+import { formatCurrency } from "@/lib/utils";
+import { computeImpliedDiscount } from "@/types/invoice";
+import type { InvestorPosition } from "@/types/invoice";
+
+interface ListPositionDialogProps {
+  position: InvestorPosition | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (askPrice: number) => void;
+}
+
+/**
+ * Listing form for the secondary market (#442): lets an investor set an ask
+ * price for an active position and previews the implied discount before
+ * submitting.
+ */
+export function ListPositionDialog({
+  position,
+  open,
+  onOpenChange,
+  onSubmit,
+}: ListPositionDialogProps) {
+  const [askPrice, setAskPrice] = useState<string>("");
+
+  if (!position) return null;
+
+  const currency = position.invoice?.metadata.currency ?? "USDC";
+  const parsedAsk = Number.parseFloat(askPrice);
+  const askIsValid = Number.isFinite(parsedAsk) && parsedAsk > 0;
+  const impliedDiscount = askIsValid
+    ? computeImpliedDiscount(parsedAsk, position.expectedReturn)
+    : null;
+
+  const handleSubmit = () => {
+    if (!askIsValid) return;
+    onSubmit(parsedAsk);
+    setAskPrice("");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Tag className="h-4 w-4 text-primary" aria-hidden />
+            List position for sale
+          </DialogTitle>
+          <DialogDescription>
+            Set an ask price for this position on the secondary market.
+            Expected return: {formatCurrency(position.expectedReturn, currency)}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <NumberInput
+            label="Ask price"
+            placeholder={position.expectedReturn.toFixed(2)}
+            value={askPrice}
+            onChange={(e) => setAskPrice(e.target.value)}
+            min={0}
+            step="0.01"
+            showUSDC={currency === "USDC"}
+            error={
+              askPrice.length > 0 && !askIsValid
+                ? "Enter a valid ask price greater than 0"
+                : undefined
+            }
+          />
+
+          {impliedDiscount !== null && (
+            <div className="rounded-lg border border-border bg-muted/30 p-3">
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Implied discount
+              </p>
+              <p
+                className={
+                  impliedDiscount >= 0
+                    ? "mt-1 text-lg font-bold text-success"
+                    : "mt-1 text-lg font-bold text-warning"
+                }
+              >
+                {(impliedDiscount * 100).toFixed(2)}%
+              </p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {impliedDiscount >= 0
+                  ? "Buyer receives a discount versus your expected return."
+                  : "You're asking above your expected return."}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!askIsValid}>
+            List for sale
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/store/index.ts
+++ b/store/index.ts
@@ -2,5 +2,6 @@ export * from "./walletStore";
 export * from "./invoiceStore";
 export * from "./uiStore";
 export * from "./transactionStore";
+export * from "./positionListingStore";
 export { useTransactionHistoryStore } from "./transactionHistoryStore";
 export type { TransactionRecord, TxType as HistoryTxType, TxStatus as HistoryTxStatus } from "./transactionHistoryStore";

--- a/store/positionListingStore.ts
+++ b/store/positionListingStore.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { PositionListing } from "@/types";
+import { createPersistentJSONStorage } from "./storageAdapter";
+
+interface PositionListingState {
+  /** Keyed by position id (InvestorPosition.id / InvoicePosition.invoiceId). */
+  listings: Record<string, PositionListing>;
+  listPosition: (listing: PositionListing) => void;
+  unlistPosition: (positionId: string) => void;
+  getListing: (positionId: string) => PositionListing | undefined;
+}
+
+export const usePositionListingStore = create<PositionListingState>()(
+  persist(
+    (set, get) => ({
+      listings: {},
+
+      listPosition: (listing) =>
+        set((state) => ({
+          listings: { ...state.listings, [listing.positionId]: listing },
+        })),
+
+      unlistPosition: (positionId) =>
+        set((state) => {
+          const next = { ...state.listings };
+          delete next[positionId];
+          return { listings: next };
+        }),
+
+      getListing: (positionId) => get().listings[positionId],
+    }),
+    {
+      name: "kora-position-listings",
+      storage: createPersistentJSONStorage(),
+    }
+  )
+);

--- a/types/invoice.ts
+++ b/types/invoice.ts
@@ -129,6 +129,36 @@ export interface InvestorPosition {
   status: "active" | "repaid" | "defaulted";
 }
 
+// ─── Secondary Market Listings (v0.4) ────────────────────────────────────────
+//
+// UI-only for now (#442): lets an investor mark a position "for sale" with an
+// ask price, and shows it back on the dashboard. The actual on-chain P2P
+// transfer (once a buyer is found) is implemented separately — see
+// prepareTransferPosition in services/invoiceService.ts (#443).
+
+export interface PositionListing {
+  /** InvestorPosition.id (or InvoicePosition.invoiceId when no distinct id exists) */
+  positionId: string;
+  /** Price the seller is asking, in the position's invoice currency */
+  askPrice: number;
+  /**
+   * Discount implied by askPrice vs. the position's expectedReturn, 0–1.
+   * Positive = selling below expected return (a discount for the buyer);
+   * negative = selling at a premium.
+   */
+  impliedDiscount: number;
+  listedAt: string; // ISO 8601
+}
+
+/** Computes the discount (0–1) implied by an ask price vs. expected return. */
+export function computeImpliedDiscount(
+  askPrice: number,
+  expectedReturn: number
+): number {
+  if (expectedReturn <= 0) return 0;
+  return (expectedReturn - askPrice) / expectedReturn;
+}
+
 // ─── Create Invoice Form ──────────────────────────────────────────────────────
 
 export interface CreateInvoiceFormData {


### PR DESCRIPTION
## Summary

README's v0.4 secondary market roadmap had no UI at all. This implements the UI shell requested in #442 (the on-chain transfer itself is covered separately by #443's `transferPosition`/`prepareTransferPosition`):

1. **`types/invoice.ts`** — `PositionListing` type + `computeImpliedDiscount()` helper (ask price vs. expected return, 0–1).
2. **`store/positionListingStore.ts`** — new persisted Zustand store, matching the existing `store/*.ts` + `storageAdapter` pattern, tracking listings by position id (list / unlist / get). Wired into the `store/index.ts` barrel.
3. **`components/invoice/ListPositionDialog.tsx`** — ask-price form with a live implied-discount preview, built entirely from existing `Dialog`/`NumberInput`/`Button` primitives — design-system tokens throughout, no bespoke styling.
4. **`app/dashboard/investor/page.tsx`**:
   - "List for Sale" / "Unlist" action in the positions table (active positions only).
   - New "Listing" column showing the ask price badge on already-listed rows.
   - New "Active Listings" section below the positions table, surfacing every current listing with its ask price and implied discount.

## Acceptance criteria
- [x] Investor can create listing UI — `ListPositionDialog` + "List for Sale" action
- [x] Ask price and discount shown — in the dialog preview, the "Listing" column badge, and the Active Listings section
- [x] Listings visible on investor dashboard — "Active Listings" card
- [x] Matches design system tokens — reused `Dialog`, `NumberInput`, `Badge` (`kora` variant), `Card`, `Button` with no one-off styles

## Test plan
No automated tests run (out of scope for this change per task instructions). Checked `e2e/dashboard.spec.ts` and related specs — they exercise the investor dashboard generally but don't assert on exact table columns, so the added column/section shouldn't conflict.

Closes #442