### PR TITLE
feat(accessibility): add screen-reader announcements for transaction toasts

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -30,6 +30,10 @@ const InProgressOverlay = dynamic(
   () => import("@/components/transactions").then((m) => m.InProgressOverlay),
   { ssr: false, loading: () => null }
 );
+const TransactionAnnouncer = dynamic(
+  () => import("@/components/transactions").then((m) => m.TransactionAnnouncer),
+  { ssr: false, loading: () => null }
+);
 
 import { ThemeProvider } from "@/components/layout/ThemeProvider";
 import { LocaleProvider } from "@/i18n/LocaleProvider";
@@ -99,6 +103,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
           {isEnabled("onboarding-tour") && <OnboardingTour />}
           <WalletConnectModal />
           <InProgressOverlay />
+          <TransactionAnnouncer />
           <InstallPrompt />
           <FeedbackWidget />
           <KeyboardShortcutsProvider />

--- a/components/transactions/InProgressOverlay.tsx
+++ b/components/transactions/InProgressOverlay.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Loader2, X } from "lucide-react";
 import { useUIStore } from "@/store/uiStore";
@@ -17,6 +18,8 @@ import { cn } from "@/lib/utils";
 export function InProgressOverlay() {
   const { txState, setTxState } = useUIStore();
   const isSigningStage = txState.status === "signing";
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
   const handleCancel = () => {
     setTxState({ status: "idle" });
@@ -28,11 +31,26 @@ export function InProgressOverlay() {
     }
   };
 
+  // Move focus into the dialog when it opens (screen readers only reliably
+  // announce a role="dialog" region's labelledby/describedby once focus
+  // actually enters it) and restore focus to whatever triggered it on close.
+  useEffect(() => {
+    if (isSigningStage) {
+      previousFocusRef.current = document.activeElement as HTMLElement | null;
+      dialogRef.current?.focus();
+    } else {
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+    }
+  }, [isSigningStage]);
+
   return (
     <AnimatePresence>
       {isSigningStage && (
         <motion.div
           key="overlay"
+          ref={dialogRef}
+          tabIndex={-1}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -42,7 +60,7 @@ export function InProgressOverlay() {
           aria-modal="true"
           aria-labelledby="signing-title"
           aria-describedby="signing-description"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm focus:outline-none"
         >
           {/* Content */}
           <motion.div

--- a/components/transactions/TransactionToasts.tsx
+++ b/components/transactions/TransactionToasts.tsx
@@ -7,6 +7,7 @@ import { StellarTxLink } from "@/components/ui/stellar-tx-link";
 import { useUIStore } from "@/store/uiStore";
 import { toast } from "sonner";
 import type { NotificationPreferenceType } from "@/hooks/useToast";
+import { useTxAnnouncement } from "@/hooks/useTransaction";
 
 export type NotificationVariant = "pending" | "success" | "error" | "warning";
 
@@ -162,6 +163,28 @@ export function WarningTransactionToast({ message, details }: { message: string;
         </div>
       </div>
     </motion.div>
+  );
+}
+
+/**
+ * Persistent, visually-hidden live regions announcing transaction lifecycle
+ * changes (building/simulating/signing/submitting/polling/confirmed/failed)
+ * to assistive tech (#441). Mount once, globally — see app/providers.tsx —
+ * so it's a reliable single source of truth independent of the Sonner
+ * toasts, which are visual-first and whose DOM nodes are too transient to
+ * depend on for announcements.
+ */
+export function TransactionAnnouncer() {
+  const { polite, assertive } = useTxAnnouncement();
+  return (
+    <>
+      <span className="sr-only" role="status" aria-live="polite">
+        {polite ?? ""}
+      </span>
+      <span className="sr-only" role="alert" aria-live="assertive">
+        {assertive ?? ""}
+      </span>
+    </>
   );
 }
 

--- a/components/transactions/index.ts
+++ b/components/transactions/index.ts
@@ -1,3 +1,3 @@
-export { PendingTransactionToast, SuccessTransactionToast, ErrorTransactionToast, WarningTransactionToast, useTransactionToast } from "./TransactionToasts";
+export { PendingTransactionToast, SuccessTransactionToast, ErrorTransactionToast, WarningTransactionToast, TransactionAnnouncer, useTransactionToast } from "./TransactionToasts";
 export { InProgressOverlay } from "./InProgressOverlay";
 export { TransactionHistoryDrawer } from "./TransactionHistoryDrawer";

--- a/hooks/useTransaction.ts
+++ b/hooks/useTransaction.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useToast } from "./useToast";
 import type { NotificationPreferenceType } from "./useToast";
@@ -11,7 +11,7 @@ import { env } from "@/lib/env";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { useUIStore } from "@/store/uiStore";
 import { useTransactionHistoryStore } from "@/store/transactionHistoryStore";
-import type { ServiceError } from "@/types";
+import type { ServiceError, TxState } from "@/types";
 
 export type TxLifecycleStatus =
   | "idle"
@@ -332,4 +332,79 @@ export function useTransaction() {
     error: state.error,
     simulationPreview,
   };
+}
+
+const TX_ANNOUNCEMENT_MESSAGES: Record<Exclude<TxState["status"], "idle">, string> = {
+  building: "Building transaction…",
+  simulating: "Simulating transaction…",
+  signing: "Waiting for wallet signature…",
+  submitting: "Submitting transaction…",
+  polling: "Waiting for confirmation on the network…",
+  confirmed: "Transaction confirmed successfully.",
+  failed: "Transaction failed.",
+  timeout: "Transaction timed out. You can retry.",
+};
+
+/**
+ * Screen-reader announcements for the transaction lifecycle (#441).
+ *
+ * Sonner toasts are visual-first: role/aria-live attributes on individual
+ * toast contents aren't a reliable substitute for a dedicated, persistent
+ * live region, since toast DOM nodes are transient and timing varies by
+ * animation/portal library. This mirrors the "announce + dedupe +
+ * auto-clear" pattern already used by useCountdown's `announce` field, but
+ * reads from the global tx state (useUIStore) so it's a single source of
+ * truth no matter which screen/button started the transaction — covering
+ * funding, repayment, claims, and any other flow that goes through
+ * useTransaction().execute().
+ *
+ * Two independent regions are returned so failures interrupt (`assertive`)
+ * while everything else waits its turn (`polite`), and each region only
+ * updates when its message actually changes, so re-renders don't spam
+ * assistive tech with repeat announcements.
+ */
+export function useTxAnnouncement() {
+  const txState = useUIStore((s) => s.txState);
+  const [polite, setPolite] = useState<string | null>(null);
+  const [assertive, setAssertive] = useState<string | null>(null);
+  const lastAnnounced = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (txState.status === "idle") {
+      // Reset so the next transaction cycle announces even if it produces
+      // the same text as the last one (e.g. two "confirmed" in a row).
+      lastAnnounced.current = null;
+      return;
+    }
+
+    const message =
+      txState.status === "failed"
+        ? `Transaction failed: ${txState.error.message}`
+        : TX_ANNOUNCEMENT_MESSAGES[txState.status];
+
+    if (!message || message === lastAnnounced.current) return;
+    lastAnnounced.current = message;
+
+    if (txState.status === "failed") {
+      setAssertive(message);
+    } else {
+      setPolite(message);
+    }
+  }, [txState]);
+
+  // Clear each region a short time after announcing so assistive tech
+  // doesn't re-read stale text if the same status recurs later.
+  useEffect(() => {
+    if (!polite) return;
+    const timer = setTimeout(() => setPolite(null), 5000);
+    return () => clearTimeout(timer);
+  }, [polite]);
+
+  useEffect(() => {
+    if (!assertive) return;
+    const timer = setTimeout(() => setAssertive(null), 5000);
+    return () => clearTimeout(timer);
+  }, [assertive]);
+
+  return { polite, assertive };
 }


### PR DESCRIPTION
## Summary

The individual toast components (`PendingTransactionToast`, `SuccessTransactionToast`, etc.) already had `role`/`aria-live`/`aria-label` on their content, but that's not reliable on its own — Sonner toast nodes are transient, portal-rendered, and timing varies across browser/screen-reader combos, so per-toast ARIA attributes are not a substitute for a dedicated, persistent live region. This adds one:

1. **`hooks/useTransaction.ts`** — `useTxAnnouncement()` reads the *global* tx state (`useUIStore`), so it's a single source of truth no matter which screen/button started the transaction — funding, repayment, claims, etc. all flow through the shared `execute()`. Mirrors the existing `announce`/dedupe/auto-clear pattern already used by `useCountdown` elsewhere in this codebase: only announces when the message actually changes, and resets on return to `idle` so the next transaction cycle re-announces even if it produces identical text (e.g. two "confirmed" in a row).
2. **`components/transactions/TransactionToasts.tsx`** — `TransactionAnnouncer`: two persistent `sr-only` live regions driven by that hook — `role="status" aria-live="polite"` for progress/success, `role="alert" aria-live="assertive"` for failures (with the actual error reason included).
3. **`app/providers.tsx`** — mounts `TransactionAnnouncer` once, globally, right next to the existing `InProgressOverlay`, so it's always present regardless of which page triggers a transaction.
4. **`components/transactions/InProgressOverlay.tsx`** — the signing-stage overlay was already `role="dialog"` with `aria-labelledby`/`aria-describedby`, but never moved focus into it. Many screen readers only reliably announce a dialog's accessible name/description once focus actually enters it — this was a real gap for the "confirm" state specifically. Focus now moves into the dialog on open and returns to the triggering element on close.

## Acceptance criteria
- [x] Screen reader announces tx success — polite region, "Transaction confirmed successfully."
- [x] Failure announced with reason — assertive region, `Transaction failed: ${error.message}`
- [x] No announcement spam — dedupe via last-announced-message ref, matching the existing `useCountdown` pattern
- [ ] Storybook a11y passes — not run (out of scope per task instructions, no testing performed)

## Test plan
No automated tests run (out of scope for this change per task instructions). Checked `__tests__/*.integration.test.tsx` files that mock `@/hooks/useTransaction` — they mock only `useTransaction` itself and render specific flow components, not the global `Providers` tree that mounts `TransactionAnnouncer`, so the new `useTxAnnouncement` export shouldn't be reached by those mocks. Worth a maintainer double-checking under CI.

Closes #441