### PR TITLE
feat(performance): tune tanstack query stale times per network mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -163,6 +163,43 @@ We use **two separate state systems** for different concerns:
 - Automatic background refetching, caching, deduplication
 - Cache keys: `["invoices", filters, sort]`, `["invoice", id]`
 
+#### Query tuning per network mode
+
+Stale times and refetch intervals are **not fixed** — they are resolved per
+network mode from the `QUERY_TUNING` table in [`lib/featureFlags.ts`](lib/featureFlags.ts)
+via `getQueryTuning()`. The two modes have fundamentally different freshness
+characteristics:
+
+| | `live` | `mock` |
+|---|---|---|
+| Data source | Soroban RPC / indexer | static `MOCK_INVOICES` fixture |
+| Freshness driver | **contract events** (`useContractEvents`) | nothing — data is immutable |
+| `staleTime` | 5 s | 5 min |
+| `gcTime` | 5 min | 5 min |
+| Refetch timers | 2 min (backstop only) | disabled (`false`) |
+
+**Live mode is event-driven.** `useContractEvents` streams `invoice_funded` /
+`invoice_repaid` / `invoice_cancelled` and invalidates the affected query keys
+as they arrive, so timers are a safety net for a degraded stream rather than the
+primary freshness mechanism. The short 5 s `staleTime` exists so that an
+event-invalidated query refetches promptly instead of serving a stale entry.
+
+Pushing the timers out to 2 min is what removes the duplicate requests: the
+previous fixed 15 s / 30 s polls raced the event stream, refetching keys the
+stream had already invalidated seconds earlier.
+
+**Mock mode disables polling entirely.** The fixture cannot change, so every
+refetch returned a byte-identical result. Mutations still invalidate explicitly,
+so optimistic updates and the invoice wizard are unaffected.
+
+All timers are additionally gated on tab visibility (`whenVisible()` in
+`hooks/useInvoices.ts`); a hidden tab refreshes on `visibilitychange` instead.
+
+**Changing the timings:** edit `QUERY_TUNING` in `lib/featureFlags.ts` — that
+table is the single source of truth. `getNetworkMode()` there also backs
+`getInvoiceDataSource()` in `lib/queryKeys.ts`, so cache-key namespacing and
+query tuning can never disagree about which mode is active.
+
 ### Client State — Zustand
 
 - **walletStore**: Persisted to `localStorage` via `zustand/middleware/persist`. Survives page refresh.

--- a/hooks/useInvoices.ts
+++ b/hooks/useInvoices.ts
@@ -8,6 +8,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/queryKeys";
+import { getQueryTuning } from "@/lib/featureFlags";
 import { useInvoiceStore } from "@/store/invoiceStore";
 import {
   fetchInvoices,
@@ -28,9 +29,20 @@ export {
   MAX_CONCURRENT_PREFETCHES,
 } from "./usePrefetchInvoice";
 
-const STALE_30S = 30_000;
-const GC_5MIN = 5 * 60 * 1000;
-const POLL_INTERVAL_MS = 30_000;
+/**
+ * Gate a tuned refetch interval on tab visibility.
+ *
+ * Returns `false` (no polling) when the interval is disabled for the active
+ * network mode, or when the tab is hidden — a backgrounded tab is refreshed on
+ * `visibilitychange` instead, so there is nothing to gain from polling it.
+ */
+function whenVisible(interval: number | false): number | false {
+  if (interval === false) return false;
+  if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+    return false;
+  }
+  return interval;
+}
 
 const SORT_KEY_MAP: Record<string, MarketplaceSortKey> = {
   apr: "apr",
@@ -63,6 +75,7 @@ export function useInvoices(pageOrOpts?: number | { refetchInterval?: number }, 
   const page = typeof pageOrOpts === "number" ? pageOrOpts : 1;
   const refetchInterval = typeof pageOrOpts === "object" ? pageOrOpts?.refetchInterval : opts?.refetchInterval;
   const { filters, sort } = useInvoiceStore();
+  const tuning = getQueryTuning();
   return useQuery({
     queryKey: queryKeys.invoices.list(filters, sort, page),
     queryFn: () =>
@@ -71,12 +84,11 @@ export function useInvoices(pageOrOpts?: number | { refetchInterval?: number }, 
         { key: SORT_KEY_MAP[sort.sortBy] ?? "apr", direction: sort.sortDir },
         page
       ),
-    staleTime: STALE_30S,
-    gcTime: GC_5MIN,
-    refetchInterval: () =>
-      typeof document !== "undefined" && document.visibilityState === "hidden"
-        ? false
-        : 15_000,
+    staleTime: tuning.staleTime,
+    gcTime: tuning.gcTime,
+    // An explicit caller-supplied interval wins over the mode default; before
+    // this it was computed and then silently ignored by a hard-coded 15 s.
+    refetchInterval: () => whenVisible(refetchInterval ?? tuning.listRefetchInterval),
     refetchIntervalInBackground: false,
   });
 }
@@ -97,6 +109,7 @@ export function useInfiniteInvoices(options?: {
   const enabled = options?.enabled ?? true;
   const filters = useInvoiceStore((s) => s.filters);
   const sortBy = useInvoiceStore((s) => s.sortBy);
+  const tuning = getQueryTuning();
 
   return useInfiniteQuery({
     queryKey: queryKeys.invoices.infinite(filters, sortBy, pageSize),
@@ -116,8 +129,8 @@ export function useInfiniteInvoices(options?: {
     initialPageParam: 1,
     getNextPageParam: (last) => (last.hasMore ? last.page + 1 : undefined),
     enabled,
-    staleTime: STALE_30S,
-    gcTime: GC_5MIN,
+    staleTime: tuning.staleTime,
+    gcTime: tuning.gcTime,
   });
 }
 
@@ -126,18 +139,21 @@ export function useInfiniteInvoices(options?: {
 const ACTIVE_STATUSES = new Set(["listed", "partially_funded"]);
 
 export function useInvoice(id: string, walletAddress?: string) {
+  const tuning = getQueryTuning();
   return useQuery({
     queryKey: queryKeys.invoices.detail(id),
     queryFn: () => fetchInvoiceById(id, walletAddress),
     enabled: !!id,
-    staleTime: STALE_30S,
-    gcTime: GC_5MIN,
+    staleTime: tuning.staleTime,
+    gcTime: tuning.gcTime,
     refetchInterval: (query) => {
-      if (typeof document !== "undefined" && document.visibilityState === "hidden") return false;
+      // Only invoices that can still change are worth polling at all: a
+      // settled or fully-funded invoice is terminal until an event says
+      // otherwise, and events invalidate this key directly.
       const status = query.state.data?.status;
       if (!status || !ACTIVE_STATUSES.has(status)) return false;
       if ((query.state.data?.funding.fundingProgress ?? 0) >= 1) return false;
-      return ACTIVE_STATUSES.has(status) ? 15_000 : 60_000;
+      return whenVisible(tuning.detailRefetchInterval);
     },
     refetchIntervalInBackground: false,
   });
@@ -146,17 +162,15 @@ export function useInvoice(id: string, walletAddress?: string) {
 // ─── SME invoices ─────────────────────────────────────────────────────────────
 
 export function useSMEInvoices(address: string | undefined) {
+  const tuning = getQueryTuning();
   return useQuery({
     queryKey: queryKeys.invoices.byOwner(address ?? ""),
     queryFn: () => fetchInvoicesByOwner(address!),
     enabled: !!address,
-    staleTime: STALE_30S,
-    gcTime: GC_5MIN,
-    // Visibility-based polling: refetch every 30s only when the tab is visible
-    refetchInterval: () =>
-      typeof document !== "undefined" && document.visibilityState === "hidden"
-        ? false
-        : POLL_INTERVAL_MS,
+    staleTime: tuning.staleTime,
+    gcTime: tuning.gcTime,
+    // Backstop poll, gated on tab visibility. Disabled entirely in mock mode.
+    refetchInterval: () => whenVisible(tuning.ownerRefetchInterval),
     refetchIntervalInBackground: false,
   });
 }
@@ -185,6 +199,7 @@ export function useBatchInvoicePolling(
 ) {
   const queryClient = useQueryClient();
   const { mergeInvoicesBatch } = useInvoiceStore();
+  const tuning = getQueryTuning();
 
   // Track intersection visibility via a ref so the refetchInterval closure
   // always reads the latest value without causing re-renders.
@@ -215,18 +230,15 @@ export function useBatchInvoicePolling(
       return invoices;
     },
     enabled,
-    staleTime: STALE_30S,
-    gcTime: GC_5MIN,
+    staleTime: tuning.staleTime,
+    gcTime: tuning.gcTime,
     refetchInterval: () => {
-      // Pause when the tab is hidden
-      if (typeof document !== "undefined" && document.visibilityState === "hidden") {
-        return false;
-      }
-      // Pause when the sentinel element has scrolled out of view
+      // Pause when the sentinel element has scrolled out of view. Tab
+      // visibility and the mode default are handled by whenVisible().
       if (!isVisibleRef.current) {
         return false;
       }
-      return POLL_INTERVAL_MS;
+      return whenVisible(tuning.batchRefetchInterval);
     },
     refetchIntervalInBackground: false,
   });
@@ -256,12 +268,13 @@ export function useBatchInvoicePolling(
 // ─── Investor positions ───────────────────────────────────────────────────────
 
 export function useInvestorPositions(address: string | undefined) {
+  const tuning = getQueryTuning();
   return useQuery({
     queryKey: queryKeys.invoices.positions(address ?? ""),
     queryFn: () => fetchInvestorPositions(address!),
     enabled: !!address,
-    staleTime: STALE_30S,
-    gcTime: GC_5MIN,
+    staleTime: tuning.staleTime,
+    gcTime: tuning.gcTime,
   });
 }
 

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -47,3 +47,106 @@ export function isEnabled(flag: FeatureFlag): boolean {
   const envVar = FLAG_ENV_MAP[flag];
   return process.env[envVar] === "true";
 }
+
+// ─── Network mode & query tuning — Issue #436 ────────────────────────────────
+//
+// Kora resolves invoice data in one of two network modes, and they have very
+// different freshness characteristics:
+//
+// - **mock** (`mock-data` flag on) — invoices come from the static
+//   `MOCK_INVOICES` fixture. The data is immutable for the lifetime of the tab,
+//   so any background refetch is pure waste: it burns a render pass and returns
+//   a byte-identical result.
+//
+// - **live** — invoices come from Soroban RPC / the indexer, and
+//   `useContractEvents` streams `invoice_funded` / `invoice_repaid` /
+//   `invoice_cancelled` events, invalidating the affected query keys as they
+//   arrive. Freshness is therefore *event-driven*, not timer-driven.
+//
+// Previously the invoice hooks used a fixed 30 s stale time with 15 s / 30 s
+// poll timers in both modes. In live mode that duplicated work the event stream
+// already does — an event invalidates a key, then the timer refetches the same
+// key seconds later. In mock mode it refetched data that cannot change. The
+// tuning table below replaces those scattered magic constants with one
+// per-mode definition.
+
+/** Whether app data resolves from mock fixtures or the live indexer. */
+export type NetworkMode = "mock" | "live";
+
+/** Resolve the active network mode from the `mock-data` flag. */
+export function getNetworkMode(): NetworkMode {
+  return isEnabled("mock-data") ? "mock" : "live";
+}
+
+/** True when cache freshness is driven by the contract event stream. */
+export function isEventDriven(mode: NetworkMode = getNetworkMode()): boolean {
+  return mode === "live";
+}
+
+/**
+ * TanStack Query timings for a single network mode.
+ *
+ * A `false` refetch interval disables timer-based polling for that query;
+ * freshness then comes from cache invalidation — contract events, mutation
+ * `onSettled` handlers, or an explicit `refetch()`.
+ */
+export interface QueryTuning {
+  /** How long a fetched result is considered fresh. */
+  staleTime: number;
+  /** How long an unused result stays cached before garbage collection. */
+  gcTime: number;
+  /**
+   * Backstop poll for marketplace/list queries. In live mode this is a long
+   * safety net for a degraded event stream — not the primary freshness path.
+   */
+  listRefetchInterval: number | false;
+  /** Backstop poll for a detail query whose invoice is still fundable. */
+  detailRefetchInterval: number | false;
+  /** Backstop poll for owner-scoped ("my invoices") queries. */
+  ownerRefetchInterval: number | false;
+  /** Backstop poll for the batched token-id watcher. */
+  batchRefetchInterval: number | false;
+}
+
+const GC_5_MIN = 5 * 60 * 1000;
+
+/**
+ * Per-mode tuning table.
+ *
+ * **live** — `staleTime` is short (5 s) because the event stream invalidates
+ * keys the moment on-chain state changes; a short stale window means the
+ * invalidated query refetches promptly instead of serving a stale entry. Timer
+ * intervals are pushed out to 2 min so they act purely as a backstop for a
+ * degraded stream (`useContractEvents` already falls back SSE → RPC stream →
+ * 5 s polling internally) rather than racing it, which is what produced the
+ * duplicate requests.
+ *
+ * **mock** — the fixture never changes, so `staleTime` is 5 min and every timer
+ * is disabled. Mutations still invalidate explicitly, so optimistic updates and
+ * the invoice wizard continue to work.
+ */
+export const QUERY_TUNING: Record<NetworkMode, QueryTuning> = {
+  live: {
+    staleTime: 5_000,
+    gcTime: GC_5_MIN,
+    listRefetchInterval: 120_000,
+    detailRefetchInterval: 120_000,
+    ownerRefetchInterval: 120_000,
+    batchRefetchInterval: 120_000,
+  },
+  mock: {
+    staleTime: GC_5_MIN,
+    gcTime: GC_5_MIN,
+    listRefetchInterval: false,
+    detailRefetchInterval: false,
+    ownerRefetchInterval: false,
+    batchRefetchInterval: false,
+  },
+};
+
+/** Tuning for the active mode, or an explicitly supplied one (used in tests). */
+export function getQueryTuning(
+  mode: NetworkMode = getNetworkMode(),
+): QueryTuning {
+  return QUERY_TUNING[mode];
+}

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -1,15 +1,25 @@
 import type { FilterState, SortState } from "@/store/invoiceStore";
-
-/** Whether invoice queries resolve from mock data or the live indexer. */
-export type InvoiceDataSource = "mock" | "live";
+import { getNetworkMode, type NetworkMode } from "@/lib/featureFlags";
 
 /**
- * Resolve the active invoice data source from env.
- * Kept as a pure process.env read so query keys stay usable in client + tests
- * without pulling the full Zod env module.
+ * Whether invoice queries resolve from mock data or the live indexer.
+ *
+ * Alias of {@link NetworkMode} — the data source and the network mode are the
+ * same axis, and Issue #436 made `@/lib/featureFlags` the single definition so
+ * key namespacing and query tuning can never disagree about which mode is
+ * active. Kept as a named export for existing import sites.
+ */
+export type InvoiceDataSource = NetworkMode;
+
+/**
+ * Resolve the active invoice data source.
+ *
+ * Delegates to `getNetworkMode()`, which stays a plain env read so query keys
+ * remain usable on the client and in unit tests without pulling in the full Zod
+ * env module.
  */
 export function getInvoiceDataSource(): InvoiceDataSource {
-  return process.env.NEXT_PUBLIC_ENABLE_MOCK_DATA === "true" ? "mock" : "live";
+  return getNetworkMode();
 }
 
 export const queryKeys = {


### PR DESCRIPTION
Closes #436

## Problem

Invoice queries used a fixed `staleTime` of 30s with 15s/30s poll timers in **both** network modes. Neither mode wanted that:

- **Live mode** — `useContractEvents` already streams `invoice_funded` / `invoice_repaid` / `invoice_cancelled` and invalidates the affected query keys as they arrive. The timers raced that stream, refetching keys the event handler had invalidated seconds earlier. Those are the duplicate requests called out in the acceptance criteria.
- **Mock mode** — invoices resolve from the static `MOCK_INVOICES` fixture, which cannot change for the lifetime of the tab. Every refetch burned a render pass to return a byte-identical result.

## Approach

A per-mode `QUERY_TUNING` table in `lib/featureFlags.ts`, resolved via `getQueryTuning()`:

| | `live` | `mock` |
|---|---|---|
| Freshness driver | contract events | nothing — data is immutable |
| `staleTime` | 5s | 5min |
| `gcTime` | 5min | 5min |
| Refetch timers | 120s (backstop only) | disabled (`false`) |

**Live mode becomes event-driven.** The short 5s stale window means an event-invalidated query refetches promptly instead of serving a stale entry. The 120s timer is a safety net for a degraded stream — `useContractEvents` already falls back SSE → RPC stream → 5s polling internally — rather than competing with it. That separation is what removes the duplicate requests.

**Mock mode stops polling entirely.** Mutations still invalidate explicitly, so optimistic updates and the invoice wizard are unaffected.

`lib/featureFlags.ts` was the natural home: it already owns the `mock-data` flag, so mode detection and mode-dependent tuning now live together.

## Also in this change

- `whenVisible()` centralises the tab-visibility gate that was copy-pasted across four hooks.
- **Bug fix:** `useInvoices()` accepted a `refetchInterval` option, computed it, then silently discarded it — the query used a hard-coded `15_000` literal. A caller-supplied interval now wins over the mode default.
- `getInvoiceDataSource()` in `lib/queryKeys.ts` delegates to `getNetworkMode()`, so cache-key namespacing and query tuning can't disagree about which mode is active. `InvoiceDataSource` is kept as an alias for existing import sites.

## Acceptance criteria

- [x] Live mode refetches on events not timer — timers moved to a 120s backstop; events remain the freshness path
- [x] Mock mode avoids unnecessary refetch — all four timers disabled, `staleTime` 5min
- [x] Config documented — `ARCHITECTURE.md` → State Management, with the table, the rationale, and where to change it
- [x] No duplicate requests — the event stream and the poll timer no longer target the same keys on overlapping schedules

## Files

- `lib/featureFlags.ts` — `NetworkMode`, `getNetworkMode()`, `isEventDriven()`, `QueryTuning`, `QUERY_TUNING`, `getQueryTuning()`
- `hooks/useInvoices.ts` — all six hooks read from the tuning table; `whenVisible()` helper
- `lib/queryKeys.ts` — single source of truth for mode detection
- `ARCHITECTURE.md` — documentation

## Note on verification

`npm install` fails in my environment with a network `ETIMEDOUT`, so I could not run `lint` / `type-check` / `test` / `build` locally before opening this. The change is types-only plus constant plumbing with no API surface changes, so I'm relying on CI here — happy to push fixes if anything goes red.