### PR TITLE
feat(performance): add web vitals regression gate in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,28 @@ jobs:
           PLAYWRIGHT_BASE_URL: http://localhost:3000
 
       - name: Run Playwright performance baseline test
+        # Warn-only: these are wall-clock timings of a scripted scroll, which is
+        # too noisy on shared runners to gate a merge on.
         continue-on-error: true
-        run: npx playwright test e2e/performance.spec.ts --project=chromium
+        run: >-
+          npx playwright test e2e/performance.spec.ts --project=chromium
+          --grep-invert "web vitals have not regressed"
+        env:
+          CI: true
+          PLAYWRIGHT_BASE_URL: http://localhost:3000
+
+      - name: Web Vitals regression gate
+        # Deliberately NOT continue-on-error — this is the gate (Issue #437).
+        # Core Web Vitals are browser-reported measurements of a single page
+        # load, and evaluateVitalsRegression() requires both a >10% and an
+        # absolute-delta breach, so this is stable enough to block a merge.
+        #
+        # If a regression here is intentional, regenerate the baseline with
+        #   UPDATE_VITALS_BASELINE=true npx playwright test e2e/performance
+        # and commit performance-baseline.json in the same PR.
+        run: >-
+          npx playwright test e2e/performance.spec.ts --project=chromium
+          --grep "web vitals have not regressed"
         env:
           CI: true
           PLAYWRIGHT_BASE_URL: http://localhost:3000

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -416,6 +416,49 @@ Most interactive pages are client-rendered because they require wallet state. In
 - **CI:** CI should run `pnpm install --frozen-lockfile`, `pnpm lint`, and `pnpm test` (if tests exist) before publishing artifacts.
 - **Secrets:** Use the hosting provider's secret store for server-only variables (e.g., `PINATA_JWT`, private indexer keys). Do not expose them as `NEXT_PUBLIC_*`.
 
+### Web Vitals regression gate
+
+`e2e/performance.spec.ts` runs two performance checks, and they are gated
+differently on purpose:
+
+| Check | Measures | CI behaviour |
+|---|---|---|
+| Marketplace load test | Wall-clock timings of a scripted scroll | **Warn only** — too noisy on shared runners to block a merge |
+| Web Vitals gate | Browser-reported LCP, CLS, TTFB, FCP for one page load | **Fails the build** |
+
+The gate is **relative, not absolute**. `VITAL_THRESHOLDS` in `lib/webVitals.ts`
+already answers *"is this page fast enough"*, but a PR can double LCP while
+staying comfortably under 2500 ms and nothing would notice until it crosses the
+bar months later. `evaluateVitalsRegression()` instead compares each run against
+the `webVitals` block in [`performance-baseline.json`](performance-baseline.json)
+and fails when a metric grew by more than **10%**.
+
+To keep the false-positive rate survivable on shared CI hardware, a metric must
+breach **both** a proportional and an absolute floor (`REGRESSION_MIN_DELTA`).
+A TTFB moving 8 ms → 9 ms is +12.5% but is indistinguishable from runner noise,
+so it does not fail. Metrics absent from either the run or the baseline are
+skipped rather than failed — but a run where *nothing* could be compared fails
+too, since that means the collector broke rather than that everything passed.
+
+#### Updating the baseline
+
+When a change makes a metric legitimately slower — a deliberate trade-off, a new
+above-the-fold feature — update the baseline rather than loosening the threshold:
+
+```bash
+UPDATE_VITALS_BASELINE=true npx playwright test e2e/performance
+```
+
+Then commit the regenerated `performance-baseline.json` **in the same PR**, and
+say in the description why the regression is acceptable.
+
+> **Never** update the baseline on `main` to turn a red build green. That
+> silently ratchets the budget upward and defeats the point of the gate.
+
+The same spec also POSTs its measurements to `/api/vitals`, so the ingest
+endpoint gets synthetic traffic on every CI run and a broken handler surfaces in
+CI instead of silently dropping real user metrics in production.
+
 ## Appendix / Glossary
 
 - **Soroban:** Stellar's smart contract platform.

--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -1,6 +1,12 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import fs from "fs";
 import path from "path";
+import {
+  evaluateVitalsRegression,
+  formatRegression,
+  GATED_VITALS,
+  REGRESSION_THRESHOLD_PCT,
+} from "../lib/webVitals";
 
 const baselinePath = path.resolve(__dirname, "../performance-baseline.json");
 
@@ -9,6 +15,57 @@ interface PerformanceData {
   timeToFilterResponseMs: number;
   timeToLoad50InvoicesMs: number;
   timeToLoad100InvoicesMs: number;
+}
+
+interface BaselineFile extends Partial<PerformanceData> {
+  webVitals?: Record<string, number>;
+}
+
+/**
+ * Collect Core Web Vitals from the live page (Issue #437).
+ *
+ * Read straight from the Performance Timeline rather than through the
+ * `web-vitals` package: the entries are already buffered by the time the test
+ * asks for them, so there is no race with observer registration, and the E2E
+ * run stays independent of the app's own reporting wiring.
+ *
+ * - LCP  — last `largest-contentful-paint` entry (the spec emits several as the
+ *          candidate element changes; only the final one counts)
+ * - CLS  — sum of layout-shift values, excluding shifts within 500ms of user
+ *          input, per the Core Web Vitals definition
+ * - TTFB — `responseStart` from the navigation entry
+ * - FCP  — `first-contentful-paint` paint entry
+ */
+async function collectWebVitals(page: Page): Promise<Record<string, number>> {
+  return page.evaluate(() => {
+    const lcpEntries = performance.getEntriesByType(
+      "largest-contentful-paint",
+    ) as PerformanceEntry[];
+    const lcp =
+      lcpEntries.length > 0
+        ? lcpEntries[lcpEntries.length - 1].startTime
+        : undefined;
+
+    const cls = (
+      performance.getEntriesByType("layout-shift") as Array<
+        PerformanceEntry & { value: number; hadRecentInput: boolean }
+      >
+    ).reduce((sum, entry) => (entry.hadRecentInput ? sum : sum + entry.value), 0);
+
+    const [navigation] = performance.getEntriesByType(
+      "navigation",
+    ) as PerformanceNavigationTiming[];
+
+    const fcp = performance
+      .getEntriesByName("first-contentful-paint")
+      .at(0)?.startTime;
+
+    const vitals: Record<string, number> = { CLS: cls };
+    if (typeof lcp === "number") vitals.LCP = lcp;
+    if (navigation) vitals.TTFB = navigation.responseStart;
+    if (typeof fcp === "number") vitals.FCP = fcp;
+    return vitals;
+  });
 }
 
 test.describe("Marketplace Performance Load Testing", () => {
@@ -85,7 +142,7 @@ test.describe("Marketplace Performance Load Testing", () => {
     console.log(JSON.stringify(currentData, null, 2));
 
     if (fs.existsSync(baselinePath)) {
-      const baseline = JSON.parse(fs.readFileSync(baselinePath, "utf-8")) as Partial<PerformanceData>;
+      const baseline = JSON.parse(fs.readFileSync(baselinePath, "utf-8")) as BaselineFile;
       console.log("=== Baseline Performance ===");
       console.log(JSON.stringify(baseline, null, 2));
 
@@ -117,5 +174,124 @@ test.describe("Marketplace Performance Load Testing", () => {
       fs.writeFileSync(baselinePath, JSON.stringify(currentData, null, 2));
       console.log(`\n💾  Performance baseline updated successfully at ${baselinePath}\n`);
     }
+  });
+
+  // ─── Web Vitals regression gate (Issue #437) ──────────────────────────────
+  //
+  // Unlike the load test above, this one FAILS the build. The custom timings
+  // are wall-clock measurements of a scripted scroll, which is inherently noisy
+  // on shared CI runners — hence warn-only. Core Web Vitals are browser-reported
+  // measurements of a single page load, stable enough to gate on once paired
+  // with the absolute-delta floor in evaluateVitalsRegression().
+  //
+  // The check is relative, not absolute: VITAL_THRESHOLDS already answers "is
+  // this fast enough", but a PR can double LCP while staying under 2500ms and
+  // nothing would notice. This catches that.
+  //
+  // ── Updating the baseline ────────────────────────────────────────────────
+  // performance-baseline.json holds a `webVitals` object. When a change makes
+  // a metric legitimately slower — a deliberate trade-off, a new above-the-fold
+  // feature — update it deliberately rather than loosening the threshold:
+  //
+  //   1. Run this spec on the PR branch:  npx playwright test e2e/performance
+  //   2. Read the measured values from the "=== Measured Web Vitals ===" block
+  //      in the output.
+  //   3. Or regenerate automatically:
+  //        UPDATE_VITALS_BASELINE=true npx playwright test e2e/performance
+  //   4. Commit the updated performance-baseline.json **in the same PR**, and
+  //      say in the description why the regression is acceptable.
+  //
+  // Never update the baseline on main to make a red build go green — that
+  // silently ratchets the budget and defeats the gate.
+
+  test("web vitals have not regressed beyond baseline", async ({ page }, testInfo) => {
+    await page.goto("/marketplace");
+    await page.waitForLoadState("networkidle");
+
+    // LCP is only finalised once the page stops producing new candidates.
+    // Scrolling would restart that, so measure a settled initial viewport.
+    await page.waitForTimeout(1_000);
+
+    const vitals = await collectWebVitals(page);
+
+    console.log("=== Measured Web Vitals ===");
+    console.log(JSON.stringify(vitals, null, 2));
+
+    // Feed the app's own ingest endpoint with the E2E run, so /api/vitals sees
+    // synthetic traffic on every CI run and a broken handler surfaces here
+    // rather than silently dropping real user metrics in production.
+    const ingest = await page.request.post("/api/vitals", {
+      data: {
+        metrics: Object.entries(vitals).map(([name, value]) => ({
+          name,
+          value,
+          id: `e2e-${name}-${Date.now()}`,
+          label: "e2e",
+          startTime: 0,
+          rating: "good",
+          url: "/marketplace",
+          userAgent: "playwright",
+          timestamp: Date.now(),
+        })),
+      },
+    });
+    expect(
+      ingest.status(),
+      "/api/vitals should accept the E2E vitals payload",
+    ).toBe(204);
+
+    if (process.env.UPDATE_VITALS_BASELINE === "true") {
+      const existing = fs.existsSync(baselinePath)
+        ? (JSON.parse(fs.readFileSync(baselinePath, "utf-8")) as BaselineFile)
+        : {};
+      fs.writeFileSync(
+        baselinePath,
+        `${JSON.stringify({ ...existing, webVitals: vitals }, null, 2)}\n`,
+      );
+      console.log(`\n💾  Web Vitals baseline updated at ${baselinePath}\n`);
+      test.skip(true, "Baseline regenerated — skipping the gate for this run.");
+      return;
+    }
+
+    const baseline = fs.existsSync(baselinePath)
+      ? (JSON.parse(fs.readFileSync(baselinePath, "utf-8")) as BaselineFile)
+      : undefined;
+
+    const report = evaluateVitalsRegression(vitals, baseline?.webVitals);
+
+    for (const entry of report.passed) {
+      console.log(`✅  ${formatRegression(entry)}`);
+    }
+    if (report.skipped.length > 0) {
+      console.log(
+        `ℹ️  Skipped (no baseline or not measured): ${report.skipped.join(", ")}`,
+      );
+    }
+
+    for (const regression of report.regressions) {
+      const message = `[PERF REGRESSION] ${formatRegression(regression)}`;
+      console.error(message);
+      testInfo.annotations.push({
+        type: "performance-regression",
+        description: message,
+      });
+    }
+
+    // A run where nothing could be compared is not a pass — it means the
+    // collector broke, or the baseline is missing the gated metrics, and
+    // reporting green would hide that the gate is not actually running.
+    expect(
+      report.passed.length + report.regressions.length,
+      `no gated vitals could be compared (skipped: ${report.skipped.join(", ") || "none"}). ` +
+        `Expected at least one of ${GATED_VITALS.join(", ")} in both the run and performance-baseline.json.`,
+    ).toBeGreaterThan(0);
+
+    expect(
+      report.regressions.map(formatRegression),
+      `Web Vitals regressed by more than ${REGRESSION_THRESHOLD_PCT * 100}% vs performance-baseline.json.\n` +
+        `If this regression is intentional, regenerate the baseline with\n` +
+        `  UPDATE_VITALS_BASELINE=true npx playwright test e2e/performance\n` +
+        `and commit performance-baseline.json in this PR with a justification.`,
+    ).toEqual([]);
   });
 });

--- a/lib/webVitals.ts
+++ b/lib/webVitals.ts
@@ -40,6 +40,133 @@ export function getVitalRating(name: string, value: number): VitalRating {
   return "poor";
 }
 
+// ─── CI regression gate (Issue #437) ─────────────────────────────────────────
+//
+// VITAL_THRESHOLDS above answers "is this page fast enough in absolute terms".
+// That is not the same question CI needs to ask. A page can sit comfortably
+// under the "good" LCP bar while a PR doubles it — still green, still a real
+// regression, and nothing catches it until it crosses 2500ms months later.
+//
+// The gate below is relative: it compares a run against the committed
+// performance-baseline.json and fails when a metric has grown by more than
+// REGRESSION_THRESHOLD_PCT. Consumed by e2e/performance.spec.ts.
+
+/** A metric regresses when it exceeds baseline by more than this fraction. */
+export const REGRESSION_THRESHOLD_PCT = 0.1;
+
+/**
+ * Minimum absolute growth before a metric can be reported as a regression.
+ *
+ * Percentage alone is far too twitchy at the small end: a TTFB moving 8ms →
+ * 9ms is +12.5% and would fail the build, but it is indistinguishable from CI
+ * runner noise. A regression must be both proportionally *and* absolutely
+ * meaningful, which is what keeps the false-positive rate survivable on shared
+ * CI hardware.
+ *
+ * Keyed by metric; `default` covers millisecond metrics not listed.
+ */
+export const REGRESSION_MIN_DELTA: Record<string, number> = {
+  // CLS is unitless and typically ~0.0–0.25, so its floor is not in ms.
+  CLS: 0.02,
+  default: 50,
+};
+
+/** Vitals the CI gate enforces. */
+export const GATED_VITALS = ["LCP", "CLS", "TTFB", "FCP"] as const;
+
+export interface VitalRegression {
+  name: string;
+  current: number;
+  baseline: number;
+  /** Growth as a fraction of baseline, e.g. 0.23 for +23%. */
+  changePct: number;
+  limit: number;
+}
+
+export interface VitalsRegressionReport {
+  regressions: VitalRegression[];
+  /** Metrics that were compared and stayed within budget. */
+  passed: VitalRegression[];
+  /** Present in one set of numbers but not the other — never a failure. */
+  skipped: string[];
+}
+
+/**
+ * Compare a run's vitals against a baseline and classify each metric.
+ *
+ * Pure and side-effect free so the gate's logic can be reasoned about (and
+ * unit-tested) without booting a browser. The caller decides what to do with
+ * a non-empty `regressions` array — the spec fails the test, but a report-only
+ * mode is equally possible.
+ *
+ * A metric is a regression only when **both** conditions hold:
+ *   1. `current > baseline * (1 + REGRESSION_THRESHOLD_PCT)`
+ *   2. `current - baseline >= REGRESSION_MIN_DELTA[name]`
+ *
+ * Metrics missing from either side are skipped rather than failed, so adding a
+ * new vital does not break the build until a baseline is recorded for it.
+ */
+export function evaluateVitalsRegression(
+  current: Record<string, number>,
+  baseline: Record<string, number> | undefined,
+  metrics: readonly string[] = GATED_VITALS,
+): VitalsRegressionReport {
+  const report: VitalsRegressionReport = {
+    regressions: [],
+    passed: [],
+    skipped: [],
+  };
+
+  for (const name of metrics) {
+    const currentValue = current[name];
+    const baselineValue = baseline?.[name];
+
+    if (typeof currentValue !== "number" || !Number.isFinite(currentValue)) {
+      report.skipped.push(name);
+      continue;
+    }
+    if (typeof baselineValue !== "number" || !Number.isFinite(baselineValue)) {
+      report.skipped.push(name);
+      continue;
+    }
+
+    const limit = baselineValue * (1 + REGRESSION_THRESHOLD_PCT);
+    const minDelta = REGRESSION_MIN_DELTA[name] ?? REGRESSION_MIN_DELTA.default;
+    // Guard against a zero baseline, which would make changePct infinite.
+    const changePct =
+      baselineValue === 0 ? 0 : (currentValue - baselineValue) / baselineValue;
+
+    const entry: VitalRegression = {
+      name,
+      current: currentValue,
+      baseline: baselineValue,
+      changePct,
+      limit,
+    };
+
+    const overBudget =
+      currentValue > limit && currentValue - baselineValue >= minDelta;
+
+    if (overBudget) {
+      report.regressions.push(entry);
+    } else {
+      report.passed.push(entry);
+    }
+  }
+
+  return report;
+}
+
+/** Human-readable one-liner for a regression, for CI logs and failure output. */
+export function formatRegression(r: VitalRegression): string {
+  const pct = (r.changePct * 100).toFixed(1);
+  const unit = VITAL_THRESHOLDS[r.name]?.unit ?? "";
+  return (
+    `${r.name}: ${r.current.toFixed(2)}${unit} vs baseline ` +
+    `${r.baseline.toFixed(2)}${unit} (+${pct}%, limit ${r.limit.toFixed(2)}${unit})`
+  );
+}
+
 // ─── Console logger (development) ────────────────────────────────────────────
 
 const RATING_STYLES: Record<VitalRating, string> = {

--- a/performance-baseline.json
+++ b/performance-baseline.json
@@ -2,5 +2,11 @@
   "timeToFirstCardMs": 500,
   "timeToFilterResponseMs": 800,
   "timeToLoad50InvoicesMs": 1200,
-  "timeToLoad100InvoicesMs": 2500
+  "timeToLoad100InvoicesMs": 2500,
+  "webVitals": {
+    "LCP": 2500,
+    "CLS": 0.1,
+    "TTFB": 800,
+    "FCP": 1800
+  }
 }


### PR DESCRIPTION
Closes #437

## Problem

Web Vitals collection already existed (`lib/webVitals.ts` reporting to `/api/vitals`), and `e2e/performance.spec.ts` already compared custom timings against `performance-baseline.json` — but it only **warned**, and the CI step ran with `continue-on-error: true`, so nothing could ever fail a build. No Core Web Vital was measured in E2E at all.

## A relative gate, not an absolute one

`VITAL_THRESHOLDS` answers *"is this page fast enough"*. That isn't the question CI needs to ask. A PR can double LCP while staying comfortably under the 2500 ms "good" bar — still green, still a real regression, and nothing notices until it crosses the bar months later.

`evaluateVitalsRegression()` compares a run against a new `webVitals` block in `performance-baseline.json` and reports any metric that grew by more than **10%**. It's pure and side-effect free, so the gate's logic can be reasoned about — and unit-tested — without booting a browser.

## Keeping the false-positive rate survivable

This is the part that decides whether the gate survives contact with shared CI runners.

Percentage alone is far too twitchy at the small end: TTFB moving 8 ms → 9 ms is +12.5% and would fail the build, while being indistinguishable from runner noise. So a regression must breach **both** a proportional threshold and an absolute floor (`REGRESSION_MIN_DELTA`, keyed per metric since CLS is unitless and lives on a ~0–0.25 scale).

Metrics missing from either side are **skipped** rather than failed, so adding a new vital doesn't break the build before a baseline exists for it.

A run where *nothing* could be compared **fails**, though — that means the collector broke or the baseline lost its gated metrics, and reporting green would hide that the gate isn't actually running.

## Collection

`collectWebVitals()` reads LCP, CLS, TTFB and FCP straight off the Performance Timeline rather than through the `web-vitals` package: the entries are already buffered by the time the test asks for them, so there's no race with observer registration, and the E2E run stays independent of the app's own reporting wiring. CLS excludes input-adjacent shifts per the Core Web Vitals definition; LCP takes the final candidate.

The spec also POSTs its measurements to `/api/vitals` and asserts `204`, so the ingest endpoint gets synthetic traffic on every CI run — a broken handler surfaces in CI instead of silently dropping real user metrics in production.

## CI wiring

| Step | Measures | Behaviour |
|---|---|---|
| `Run Playwright performance baseline test` | Wall-clock timings of a scripted scroll | `continue-on-error` (unchanged), now `--grep-invert`s the vitals test |
| `Web Vitals regression gate` **(new)** | LCP, CLS, TTFB, FCP for one page load | **No `continue-on-error` — fails the build** |

The split is deliberate: the scroll timings are genuinely too noisy to gate a merge on, while browser-reported vitals for a single page load are not.

## Updating the baseline

Documented in `ARCHITECTURE.md` (Deployment & CI), in the spec, and in the workflow step:

```bash
UPDATE_VITALS_BASELINE=true npx playwright test e2e/performance
```

Commit the regenerated `performance-baseline.json` in the same PR with a justification. The docs carry an explicit warning never to regenerate it on `main` to turn a red build green — that silently ratchets the budget upward and defeats the gate.

## Acceptance criteria

- [x] CI fails on LCP regression — dedicated gate step without `continue-on-error`
- [x] Baseline update process documented — ARCHITECTURE.md, spec comments, workflow comment
- [x] Vitals API receives E2E data — spec POSTs to `/api/vitals` and asserts 204
- [x] False positive rate acceptable — dual proportional + absolute-delta requirement, per-metric floors, skip-don't-fail on missing metrics

## Note on the seeded baseline

I seeded `webVitals` with the Core Web Vitals "good" values (LCP 2500, CLS 0.1, TTFB 800, FCP 1800) rather than measured numbers, since I can't produce a trustworthy measurement of your CI hardware from here. That's a deliberately loose starting point — it will catch gross regressions immediately but won't be tight until someone runs `UPDATE_VITALS_BASELINE=true` on a green main and commits the real figures. Worth doing as a follow-up.

`eslint --max-warnings=0` and `tsc --noEmit` pass (enforced by the repo's lint-staged pre-commit hook). I did not execute the Playwright suite locally.