### PR TITLE
feat: add query key coverage, structured logger, performance CI, and Docker docs

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,70 @@
+name: Performance
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main]
+
+env:
+  NEXT_PUBLIC_STELLAR_NETWORK: testnet
+  NEXT_PUBLIC_STELLAR_RPC_URL: https://soroban-testnet.stellar.org
+  NEXT_PUBLIC_STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+  NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+  NEXT_PUBLIC_INVOICE_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+  NEXT_PUBLIC_MARKETPLACE_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+  NEXT_PUBLIC_TOKEN_CONTRACT_ID: CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+  NEXT_PUBLIC_IPFS_GATEWAY: https://gateway.pinata.cloud/ipfs
+  NEXT_PUBLIC_APP_URL: http://localhost:3000
+  NEXT_PUBLIC_APP_NAME: Kora
+  NEXT_PUBLIC_ENABLE_MOCK_DATA: "true"
+  NEXT_PUBLIC_ENABLE_DEVTOOLS: "false"
+  NEXT_TELEMETRY_DISABLED: "1"
+
+jobs:
+  bundlesize:
+    name: Bundlesize
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Check bundle size
+        run: npm run bundlesize
+
+  lighthouse:
+    name: Lighthouse CI
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && vars.ENABLE_LIGHTHOUSE_CI == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Run Lighthouse CI
+        run: npx @lhci/cli@0.15.x autorun --collect.startServerCommand="npm run start" --collect.url="http://localhost:3000"
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,21 @@ npm run dev
 
 Open `http://localhost:3000`.
 
+### Docker Development
+
+The Docker path is useful for Wave contributors who want a reproducible local
+environment without installing Node modules on the host:
+
+```bash
+cp .env.example .env.local
+docker compose up --build
+```
+
+After the app starts, visit `http://localhost:3000` and verify hot reload by
+editing a component or copy string. Source files are bind-mounted into the
+container; `node_modules` stays in a container volume. Rebuild the image after
+dependency changes with `docker compose build --no-cache kora-frontend`.
+
 ## Mock Data Mode
 
 Mock data mode lets you work on marketplace pages, SME dashboards, investor views, invoice cards, filters, and many UI states without live Stellar contracts.

--- a/README.md
+++ b/README.md
@@ -158,17 +158,31 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-### Docker (Alternative)
+### Docker Dev Environment
 
 If you prefer Docker, run:
 
 ```bash
 cp .env.example .env.local
 # Edit .env.local with your values
-docker compose up
+docker compose up --build
 ```
 
 The app will be available at [http://localhost:3000](http://localhost:3000) with hot reload enabled.
+
+Recommended contributor flow:
+
+1. Keep `NEXT_PUBLIC_ENABLE_MOCK_DATA=true` for first-run development unless you are testing live Soroban contracts.
+2. Start the container with `docker compose up --build`.
+3. Open [http://localhost:3000](http://localhost:3000) and verify the marketplace loads.
+4. Confirm hot reload by editing a copy-only string in a component and checking that the browser updates without rebuilding the image.
+5. Stop the stack with `docker compose down`. Use `docker compose down --volumes` only when you intentionally want to remove the container-managed `node_modules` volume.
+
+Troubleshooting:
+
+- If changes do not appear, confirm Docker Desktop file sharing includes this repository path.
+- If dependencies change, rerun `docker compose build --no-cache kora-frontend`.
+- If `.env.local` is missing, Docker will fail because the compose file mounts it read-only.
 
 ### Quick Start with Mock Data
 

--- a/app/api/vitals/route.ts
+++ b/app/api/vitals/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { logger } from "@/lib/logger";
+import { logger, redact } from "@/lib/logger";
 import { verifyCsrf } from "@/lib/csrf";
 
 /**
@@ -21,6 +21,8 @@ interface VitalPayload {
   url: string;
   userAgent: string;
   timestamp: number;
+  error?: unknown;
+  context?: unknown;
 }
 
 interface VitalsBody {
@@ -55,7 +57,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         startTime: m.startTime ?? 0,
         rating: m.rating ?? "good",
         url: typeof m.url === "string" ? m.url.slice(0, 200) : "/",
+        userAgent: typeof m.userAgent === "string" ? m.userAgent.slice(0, 200) : "",
         timestamp: m.timestamp ?? Date.now(),
+        error: m.error ? redact(m.error) : undefined,
+        context: m.context ? redact(m.context) : undefined,
       }));
 
     if (sanitised.length === 0) {
@@ -72,6 +77,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         metricId: metric.id,
         rating: metric.rating,
         url: metric.url,
+        userAgent: metric.userAgent,
+        error: metric.error,
+        context: metric.context,
       });
     }
 

--- a/components/ui/ErrorPage.tsx
+++ b/components/ui/ErrorPage.tsx
@@ -11,6 +11,7 @@ import { useEffect } from "react";
 import { AlertTriangle, Home, RefreshCw } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { logger } from "@/lib/logger";
 
 interface ErrorPageProps {
   error: Error & { digest?: string };
@@ -19,32 +20,10 @@ interface ErrorPageProps {
 
 export function ErrorPage({ error, reset }: ErrorPageProps) {
   useEffect(() => {
-    console.error("[ErrorBoundary]", error);
-
-    // Log to /api/vitals for monitoring
-    const payload = {
-      metrics: [
-        {
-          name: "error",
-          value: 1,
-          id: error.digest ?? `error-${Date.now()}`,
-          label: "error-boundary",
-          startTime: Date.now(),
-          rating: "poor" as const,
-          url: typeof window !== "undefined" ? window.location.href : "/",
-          userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "",
-          timestamp: Date.now(),
-          message: error.message,
-        },
-      ],
-    };
-
-    fetch("/api/vitals", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    }).catch(() => {
-      // Silently swallow — don't cause another error from the error handler
+    logger.reportClientError(error, {
+      boundary: "ErrorPage",
+      digest: error.digest,
+      route: typeof window !== "undefined" ? window.location.pathname : null,
     });
   }, [error]);
 

--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { logger } from "../logger";
+import { logger, redact } from "../logger";
 
 describe("Structured Logger", () => {
   let consoleSpy: any;
@@ -59,5 +59,55 @@ describe("Structured Logger", () => {
     expect(logObj.error).toHaveProperty("name", "Error");
     expect(logObj.error).toHaveProperty("message", "Something went wrong");
     expect(logObj.error).toHaveProperty("stack");
+  });
+
+  it("should redact Stellar wallet addresses, private keys, and JWTs in strings", () => {
+    const publicKey = "G".padEnd(56, "A");
+    const secretKey = "S".padEnd(56, "B");
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature";
+
+    expect(redact({ wallet: publicKey })).toEqual({ wallet: "[REDACTED_WALLET]" });
+    expect(redact({ message: `secret ${secretKey}` })).toEqual({
+      message: "secret [REDACTED_SECRET_KEY]",
+    });
+    expect(redact({ header: `Bearer ${jwt}` })).toEqual({
+      header: "Bearer [REDACTED_JWT]",
+    });
+  });
+
+  it("reports client errors to vitals with a csrf token and sanitized payload", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({ token: "csrf-token" }),
+      })
+      .mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("window", { location: { href: "https://kora.test/dashboard", pathname: "/dashboard" } });
+    vi.stubGlobal("navigator", { userAgent: "vitest" });
+
+    await logger.reportClientError(new Error(`Failed for ${"G".padEnd(56, "A")}`), {
+      boundary: "TestBoundary",
+      jwt: "do-not-send",
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/auth/csrf", {
+      method: "GET",
+      credentials: "same-origin",
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/vitals",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "same-origin",
+        headers: expect.objectContaining({ "x-kora-csrf": "csrf-token" }),
+      })
+    );
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(body.metrics[0].name).toBe("client_error");
+    expect(body.metrics[0].error.message).toContain("[REDACTED_WALLET]");
+    expect(body.metrics[0].context.jwt).toBe("[REDACTED]");
+
+    vi.unstubAllGlobals();
   });
 });

--- a/lib/__tests__/queryKeys.test.ts
+++ b/lib/__tests__/queryKeys.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { getInvoiceDataSource, queryKeys } from "@/lib/queryKeys";
+import {
+  getInvalidationKeys,
+  getInvoiceDataSource,
+  queryInvalidationRules,
+  queryKeyHierarchy,
+  queryKeys,
+} from "@/lib/queryKeys";
 
 describe("queryKeys invoice detail source namespacing", () => {
   it("defaults to live when mock flag is unset", () => {
@@ -33,5 +39,75 @@ describe("queryKeys invoice detail source namespacing", () => {
     expect(queryKeys.invoices.detail("abc", "mock")).not.toEqual(
       queryKeys.invoices.detail("abc", "live")
     );
+  });
+});
+
+describe("queryKeys hierarchy", () => {
+  it("documents stable invoice key prefixes", () => {
+    expect(queryKeyHierarchy.invoices.root).toEqual(["invoices"]);
+    expect(queryKeyHierarchy.invoices.listPrefix).toEqual(["invoices", "list"]);
+    expect(queryKeyHierarchy.invoices.infinitePrefix).toEqual(["invoices", "infinite"]);
+    expect(queryKeyHierarchy.invoices.detailPrefix).toEqual(["invoices", "detail"]);
+    expect(queryKeyHierarchy.invoices.positionsPrefix).toEqual(["invoices", "positions"]);
+  });
+
+  it("sorts batch invoice ids so equivalent batches share one key", () => {
+    expect(queryKeys.invoices.batch(["9", "1", "5"])).toEqual([
+      "invoices",
+      "batch",
+      "1,5,9",
+    ]);
+  });
+
+  it("keeps account keys nested below the wallet address", () => {
+    expect(queryKeys.account.all("GABC")).toEqual(["account", "GABC"]);
+    expect(queryKeys.account.usdcBalance("GABC")).toEqual(["account", "GABC", "usdc"]);
+    expect(queryKeys.account.transactions("GABC", 25, "next")).toEqual([
+      "account",
+      "GABC",
+      "transactions",
+      25,
+      "next",
+    ]);
+  });
+});
+
+describe("query invalidation rules", () => {
+  it("covers every documented invalidation event", () => {
+    expect(Object.keys(queryInvalidationRules).sort()).toEqual([
+      "invoice_cancelled",
+      "invoice_funded",
+      "invoice_repaid",
+      "mint_invoice",
+      "usdc_balance_changed",
+      "wallet_connected",
+      "wallet_disconnected",
+    ]);
+  });
+
+  it("invalidates invoice detail and broad invoice caches when funding changes", () => {
+    expect(getInvalidationKeys("invoice_funded", { tokenId: "42" })).toEqual([
+      queryKeys.invoices.detail("42"),
+      queryKeys.invoices.all,
+    ]);
+  });
+
+  it("invalidates positions after repayment", () => {
+    expect(getInvalidationKeys("invoice_repaid", { tokenId: "42" })).toEqual([
+      queryKeys.invoices.detail("42"),
+      queryKeys.invoices.all,
+      queryKeyHierarchy.invoices.positionsPrefix,
+    ]);
+  });
+
+  it("omits concrete keys when required context is missing", () => {
+    expect(getInvalidationKeys("wallet_connected")).toEqual([]);
+    expect(getInvalidationKeys("usdc_balance_changed")).toEqual([]);
+  });
+
+  it("invalidates the USDC balance key for balance changes", () => {
+    expect(getInvalidationKeys("usdc_balance_changed", { address: "GABC" })).toEqual([
+      queryKeys.account.usdcBalance("GABC"),
+    ]);
   });
 });

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -9,6 +9,26 @@ export interface LogContext {
   [key: string]: any;
 }
 
+export interface ClientErrorReportContext extends LogContext {
+  boundary?: string;
+  digest?: string;
+  componentStack?: string;
+}
+
+const SENSITIVE_KEY_PATTERN =
+  /password|secret|token|key|authorization|cookie|signature|passphrase|mnemonic|seed|jwt/i;
+const JWT_PATTERN =
+  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g;
+const STELLAR_SECRET_PATTERN = /\bS[A-Z2-7]{55}\b/g;
+const STELLAR_PUBLIC_KEY_PATTERN = /\bG[A-Z2-7]{55}\b/g;
+
+function redactString(value: string): string {
+  return value
+    .replace(JWT_PATTERN, "[REDACTED_JWT]")
+    .replace(STELLAR_SECRET_PATTERN, "[REDACTED_SECRET_KEY]")
+    .replace(STELLAR_PUBLIC_KEY_PATTERN, "[REDACTED_WALLET]");
+}
+
 /**
  * Recursively redacts sensitive fields and serializes Error objects.
  */
@@ -16,13 +36,13 @@ export function redact(obj: any): any {
   if (obj instanceof Error) {
     return {
       name: obj.name,
-      message: obj.message,
-      stack: obj.stack,
+      message: redactString(obj.message),
+      stack: obj.stack ? redactString(obj.stack) : undefined,
     };
   }
 
   if (obj === null || typeof obj !== "object") {
-    return obj;
+    return typeof obj === "string" ? redactString(obj) : obj;
   }
 
   if (Array.isArray(obj)) {
@@ -31,19 +51,7 @@ export function redact(obj: any): any {
 
   const result: Record<string, any> = {};
   for (const key of Object.keys(obj)) {
-    const lowerKey = key.toLowerCase();
-    if (
-      lowerKey.includes("password") ||
-      lowerKey.includes("secret") ||
-      lowerKey.includes("token") ||
-      lowerKey.includes("key") ||
-      lowerKey.includes("authorization") ||
-      lowerKey.includes("cookie") ||
-      lowerKey.includes("signature") ||
-      lowerKey.includes("passphrase") ||
-      lowerKey.includes("mnemonic") ||
-      lowerKey.includes("seed")
-    ) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
       result[key] = "[REDACTED]";
     } else {
       result[key] = redact(obj[key]);
@@ -53,6 +61,10 @@ export function redact(obj: any): any {
 }
 
 class StructuredLogger {
+  private isDevelopment(): boolean {
+    return process.env.NODE_ENV === "development";
+  }
+
   private log(level: "info" | "warn" | "error", message: string, context: LogContext = {}) {
     const { requestId, route, ...extra } = context;
 
@@ -64,6 +76,12 @@ class StructuredLogger {
       route: route || null,
       ...redact(extra),
     };
+
+    if (this.isDevelopment()) {
+      const consoleMethod = level === "error" ? console.error : level === "warn" ? console.warn : console.info;
+      consoleMethod(`[${level.toUpperCase()}] ${message}`, logEntry);
+      return;
+    }
 
     console.log(JSON.stringify(logEntry));
   }
@@ -78,6 +96,59 @@ class StructuredLogger {
 
   error(message: string, context?: LogContext) {
     this.log("error", message, context);
+  }
+
+  async reportClientError(
+    error: Error & { digest?: string },
+    context: ClientErrorReportContext = {}
+  ): Promise<void> {
+    const sanitizedError = redact(error);
+    const sanitizedContext = redact(context);
+
+    this.error("[client-error]", {
+      route: context.route ?? (typeof window !== "undefined" ? window.location.pathname : null),
+      error,
+      ...context,
+    });
+
+    if (typeof window === "undefined") return;
+
+    try {
+      const csrfResponse = await fetch("/api/auth/csrf", {
+        method: "GET",
+        credentials: "same-origin",
+      });
+      const csrfData = await csrfResponse.json().catch(() => ({}));
+      const csrfToken = typeof csrfData?.token === "string" ? csrfData.token : "";
+
+      await fetch("/api/vitals", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          "Content-Type": "application/json",
+          ...(csrfToken ? { "x-kora-csrf": csrfToken } : {}),
+        },
+        body: JSON.stringify({
+          metrics: [
+            {
+              name: "client_error",
+              value: 1,
+              id: error.digest ?? `client-error-${Date.now()}`,
+              label: "error-boundary",
+              startTime: Date.now(),
+              rating: "poor",
+              url: window.location.href,
+              userAgent: navigator.userAgent,
+              timestamp: Date.now(),
+              error: sanitizedError,
+              context: sanitizedContext,
+            },
+          ],
+        }),
+      });
+    } catch (reportError) {
+      this.warn("[client-error] failed to report", { error: reportError });
+    }
   }
 }
 

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -49,3 +49,85 @@ export const queryKeys = {
     usdcBalance: (address: string) => ["account", address, "usdc"] as const,
   },
 } as const;
+
+export type QueryInvalidationEvent =
+  | "mint_invoice"
+  | "invoice_funded"
+  | "invoice_repaid"
+  | "invoice_cancelled"
+  | "wallet_connected"
+  | "wallet_disconnected"
+  | "usdc_balance_changed";
+
+export interface QueryInvalidationContext {
+  tokenId?: string;
+  address?: string;
+}
+
+/**
+ * Human-readable TanStack Query hierarchy.
+ *
+ * Keep this in sync with `queryKeys` so feature code and tests can reason about
+ * broad-list invalidation versus narrow detail/account invalidation.
+ */
+export const queryKeyHierarchy = {
+  invoices: {
+    root: queryKeys.invoices.all,
+    listPrefix: ["invoices", "list"] as const,
+    infinitePrefix: ["invoices", "infinite"] as const,
+    detailPrefix: ["invoices", "detail"] as const,
+    ownerPrefix: ["invoices", "owner"] as const,
+    positionsPrefix: ["invoices", "positions"] as const,
+    batchPrefix: ["invoices", "batch"] as const,
+  },
+  account: {
+    rootPrefix: ["account"] as const,
+    balancesSegment: "balances",
+    transactionsSegment: "transactions",
+    existsSegment: "exists",
+    usdcSegment: "usdc",
+  },
+} as const;
+
+/**
+ * Central invalidation map for mutation/event side effects.
+ *
+ * Rules return concrete query keys whenever possible. Prefix keys such as
+ * `queryKeys.invoices.all` intentionally invalidate every invoice list/detail
+ * descendant through TanStack Query's partial-key matching.
+ */
+export const queryInvalidationRules = {
+  mint_invoice: () => [queryKeys.invoices.all],
+  invoice_funded: ({ tokenId }: QueryInvalidationContext) => [
+    ...(tokenId ? [queryKeys.invoices.detail(tokenId)] : []),
+    queryKeys.invoices.all,
+  ],
+  invoice_repaid: ({ tokenId }: QueryInvalidationContext) => [
+    ...(tokenId ? [queryKeys.invoices.detail(tokenId)] : []),
+    queryKeys.invoices.all,
+    queryKeyHierarchy.invoices.positionsPrefix,
+  ],
+  invoice_cancelled: ({ tokenId }: QueryInvalidationContext) => [
+    ...(tokenId ? [queryKeys.invoices.detail(tokenId)] : []),
+    queryKeys.invoices.all,
+  ],
+  wallet_connected: ({ address }: QueryInvalidationContext) => [
+    ...(address ? [queryKeys.account.all(address)] : []),
+  ],
+  wallet_disconnected: ({ address }: QueryInvalidationContext) => [
+    ...(address ? [queryKeys.account.all(address)] : []),
+  ],
+  usdc_balance_changed: ({ address }: QueryInvalidationContext) => [
+    ...(address ? [queryKeys.account.usdcBalance(address)] : []),
+  ],
+} satisfies Record<
+  QueryInvalidationEvent,
+  (context: QueryInvalidationContext) => ReadonlyArray<readonly unknown[]>
+>;
+
+export function getInvalidationKeys(
+  event: QueryInvalidationEvent,
+  context: QueryInvalidationContext = {}
+): ReadonlyArray<readonly unknown[]> {
+  return queryInvalidationRules[event](context);
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev --turbo",
     "build": "next build",
+    "bundlesize": "bundlesize",
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
Closes #475
Closes #477
Closes #478
Closes #479

## Summary

This PR bundles four related maintenance items:

- documents TanStack Query key hierarchy and adds invalidation rule coverage
- implements structured client-side error reporting with payload redaction
- adds a dedicated GitHub Actions performance workflow for bundlesize and optional Lighthouse CI
- expands Docker contributor docs with hot reload verification and onboarding steps

## Changes

- exported `queryKeyHierarchy`, `queryInvalidationRules`, and `getInvalidationKeys` from `lib/queryKeys.ts`
- added query key and invalidation tests in `lib/__tests__/queryKeys.test.ts`
- extended `lib/logger.ts` with string-level redaction for Stellar wallet addresses, secret keys, and JWT-like tokens
- added `logger.reportClientError(...)` to fetch CSRF, sanitize payloads, and post `client_error` metrics to `/api/vitals`
- updated `components/ui/ErrorPage.tsx` to use the structured client reporter instead of ad hoc `fetch`
- updated `app/api/vitals/route.ts` to accept and sanitize structured `error` and `context` fields
- added `.github/workflows/performance.yml` for PR bundlesize checks and optional Lighthouse CI gated by `ENABLE_LIGHTHOUSE_CI`
- documented Docker development flow and hot reload verification in `README.md` and `CONTRIBUTING.md`
- added a `bundlesize` npm script so CI can call it directly

## Validation

Passed:
- `npx vitest run lib/__tests__/queryKeys.test.ts lib/__tests__/logger.test.ts --reporter=dot`
- `npx eslint lib/queryKeys.ts lib/logger.ts lib/__tests__/queryKeys.test.ts lib/__tests__/logger.test.ts components/ui/ErrorPage.tsx app/api/vitals/route.ts`

Repository baseline issues still block the full required suite:
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run build`

Notes:
- `npm run build` currently fails in the existing `next-pwa` config in `next.config.js` with `Cannot read properties of undefined (reading 'precacheFallback')`
- `npm run bundlesize` depends on a successful build, so it cannot complete until the existing build issue is resolved

## Screenshots

No user-facing visual changes beyond documentation and error reporting behavior.
