### PR TITLE
feat: Polish theme toggle with system preference and FOUC prevention

### DIFF
--- a/e2e/__testers__/query-exclusion.e2e-spec.ts
+++ b/e2e/__testers__/query-exclusion.e2e-spec.ts
@@ -1,0 +1,175 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { getConnection } from 'typeorm';
+import { UserEntity } from '../src/modules/users/entities/user.entity';
+import { WalletEntity } from '../src/modules/users/entities/wallet.entity';
+import { UsersModule } from '../src/modules/users/users.module';
+import { UsersService } from '../src/modules/users/users.service';
+import { WalletService } from '../src/modules/users/wallet.service';
+
+describe('Query Exclusion Logic Integration Tests', () => {
+  let app: INestApplication;
+  let usersService: UsersService;
+  let walletService: WalletService;
+  let userId1: string;
+  let userId2: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot(),
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          host: process.env.DB_HOST || 'localhost',
+          port: parseInt(process.env.DB_PORT || '5432'),
+          username: process.env.DB_USER || 'postgres',
+          password: process.env.DB_PASSWORD || 'postgres',
+          database: process.env.DB_NAME || 'test_db',
+          entities: [UserEntity, WalletEntity],
+          synchronize: true, // For testing purposes
+        }),
+        UsersModule,
+      ],
+      providers: [UsersService, WalletService],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    usersService = moduleFixture.get<UsersService>(UsersService);
+    walletService = moduleFixture.get<WalletService>(WalletService);
+
+    await app.init();
+
+    // Create two test users
+    const user1 = await usersService.createUser({
+      email: `user1-${Date.now()}@example.com`,
+      firstName: 'User',
+      lastName: 'One',
+      status: 'active',
+    });
+    userId1 = user1.id;
+
+    const user2 = await usersService.createUser({
+      email: `user2-${Date.now()}@example.com`,
+      firstName: 'User',
+      lastName: 'Two',
+      status: 'active',
+    });
+    userId2 = user2.id;
+  });
+
+  afterAll(async () => {
+    // Clean up test data
+    const entityManager = getConnection().manager;
+    await entityManager.query('DELETE FROM wallets WHERE userId IN ($1, $2)', [userId1, userId2]);
+    await entityManager.query('DELETE FROM users WHERE id IN ($1, $2)', [userId1, userId2]);
+    
+    await app.close();
+  });
+
+  it('should exclude soft-deleted users from active user queries', async () => {
+    // Verify both users exist initially
+    const initialUser1 = await usersService.findActiveUserById(userId1);
+    const initialUser2 = await usersService.findActiveUserById(userId2);
+    expect(initialUser1).toBeDefined();
+    expect(initialUser2).toBeDefined();
+
+    // Soft delete user1
+    await usersService.softDeleteUser(userId1);
+
+    // Verify user1 is no longer found in active queries
+    await expect(usersService.findActiveUserById(userId1)).rejects.toThrow('Active user not found');
+
+    // Verify user2 is still found in active queries
+    const activeUser2 = await usersService.findActiveUserById(userId2);
+    expect(activeUser2).toBeDefined();
+    expect(activeUser2.id).toBe(userId2);
+
+    // Verify soft-deleted user can still be found with withDeleted queries
+    const softDeletedUser1 = await usersService.findUserById(userId1);
+    expect(softDeletedUser1).toBeDefined();
+    expect(softDeletedUser1.id).toBe(userId1);
+    expect(softDeletedUser1.deletedAt).toBeDefined();
+  });
+
+  it('should exclude soft-deleted wallets from active wallet queries', async () => {
+    // Create wallets for both users
+    const wallet1 = await walletService.createWallet(userId1, {
+      publicKey: '0x1111111111111111111111111111111111111111',
+      name: 'User1 Wallet 1',
+      type: 'crypto',
+    });
+
+    const wallet2 = await walletService.createWallet(userId2, {
+      publicKey: '0x2222222222222222222222222222222222222222',
+      name: 'User2 Wallet 1',
+      type: 'crypto',
+    });
+
+    expect(wallet1).toBeDefined();
+    expect(wallet2).toBeDefined();
+
+    // Verify both wallets can be found initially
+    const foundWallet1 = await walletService.getWalletById(wallet1.id);
+    const foundWallet2 = await walletService.getWalletById(wallet2.id);
+    expect(foundWallet1).toBeDefined();
+    expect(foundWallet2).toBeDefined();
+
+    // Soft delete wallet1
+    await walletService.softDeleteWallet(wallet1.id);
+
+    // Verify wallet1 is no longer found in active queries
+    await expect(walletService.getWalletById(wallet1.id)).rejects.toThrow('Wallet not found');
+
+    // Verify wallet2 is still found in active queries
+    const activeWallet2 = await walletService.getWalletById(wallet2.id);
+    expect(activeWallet2).toBeDefined();
+    expect(activeWallet2.id).toBe(wallet2.id);
+
+    // Verify soft-deleted wallet can still be found with withDeleted queries
+    const walletRepo = getConnection().manager.getRepository(WalletEntity);
+    const softDeletedWallet1 = await walletRepo.findOne({
+      where: { id: wallet1.id },
+      withDeleted: true,
+    });
+    expect(softDeletedWallet1).toBeDefined();
+    expect(softDeletedWallet1!.id).toBe(wallet1.id);
+    expect(softDeletedWallet1!.deletedAt).toBeDefined();
+  });
+
+  it('should exclude soft-deleted wallets when getting all wallets for a user', async () => {
+    // Create multiple wallets for user2
+    const wallet2a = await walletService.createWallet(userId2, {
+      publicKey: '0x3333333333333333333333333333333333333333',
+      name: 'User2 Wallet A',
+      type: 'crypto',
+    });
+
+    const wallet2b = await walletService.createWallet(userId2, {
+      publicKey: '0x4444444444444444444444444444444444444444',
+      name: 'User2 Wallet B',
+      type: 'crypto',
+    });
+
+    // Verify both wallets are found initially
+    const allWalletsBefore = await walletService.getWalletsByUser(userId2);
+    expect(allWalletsBefore.length).toBe(2);
+
+    // Soft delete one of the wallets
+    await walletService.softDeleteWallet(wallet2a.id);
+
+    // Verify only the non-deleted wallet is returned
+    const allWalletsAfter = await walletService.getWalletsByUser(userId2);
+    expect(allWalletsAfter.length).toBe(1);
+    expect(allWalletsAfter[0].id).toBe(wallet2b.id);
+
+    // Verify the soft-deleted wallet still exists in the database
+    const walletRepo = getConnection().manager.getRepository(WalletEntity);
+    const allWalletsIncludingDeleted = await walletRepo.find({
+      where: { userId: userId2 },
+      withDeleted: true,
+    });
+    expect(allWalletsIncludingDeleted.length).toBe(2);
+  });
+});

--- a/e2e/__testers__/risk-engine.e2e-spec.ts
+++ b/e2e/__testers__/risk-engine.e2e-spec.ts
@@ -1,0 +1,160 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RiskEngineModule } from '../src/modules/risk-engine/risk-engine.module';
+import { RiskState } from '../src/modules/risk-engine/entities/risk-state.entity';
+import { RiskPosition } from '../src/modules/risk-engine/entities/risk-position.entity';
+import { RiskSnapshot } from '../src/modules/risk-engine/entities/risk-snapshot.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+describe('RiskEngine (e2e)', () => {
+  let app: INestApplication;
+  let riskStateRepo: Repository<RiskState>;
+  let positionRepo: Repository<RiskPosition>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'better-sqlite3',
+          database: ':memory:',
+          entities: [RiskState, RiskPosition, RiskSnapshot],
+          synchronize: true,
+        }),
+        RiskEngineModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    riskStateRepo = moduleFixture.get<Repository<RiskState>>(
+      getRepositoryToken(RiskState),
+    );
+    positionRepo = moduleFixture.get<Repository<RiskPosition>>(
+      getRepositoryToken(RiskPosition),
+    );
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  const userId = 'user-123';
+
+  it('should create initial risk state', async () => {
+    // Manually create risk state or use update endpoint to auto-create
+    await request(app.getHttpServer())
+      .post(`/risk/refresh/${userId}`)
+      .expect(201); // 201 Created
+
+    const state = await riskStateRepo.findOne({ where: { userId } });
+    if (!state) throw new Error('Risk state not found');
+    expect(Number(state.totalEquity)).toBe(0);
+  });
+
+  it('should update risk metrics with positions', async () => {
+    // Seed positions directly
+    const state = await riskStateRepo.findOne({ where: { userId } });
+    if (!state) throw new Error('Risk state not found');
+
+    // Update equity first
+    state.totalEquity = 10000;
+    await riskStateRepo.save(state);
+
+    await positionRepo.save([
+      {
+        userId,
+        symbol: 'EURUSD',
+        quantity: 10000,
+        entryPrice: 1.1,
+        currentPrice: 1.105,
+        leverage: 10,
+        side: 'BUY',
+        assetType: 'FOREX',
+        riskState: state,
+      },
+      {
+        userId,
+        symbol: 'BTCUSD',
+        quantity: 0.1,
+        entryPrice: 50000,
+        currentPrice: 48000,
+        leverage: 2,
+        side: 'BUY',
+        assetType: 'CRYPTO',
+        riskState: state,
+      },
+    ] as any[]);
+
+    // Trigger update
+    const response = await request(app.getHttpServer())
+      .post(`/risk/refresh/${userId}`)
+      .expect(201);
+
+    expect(Number(response.body.usedMargin)).toBeGreaterThan(0);
+    // EURUSD Margin: (10000 * 1.1050) / 10 = 1105
+    // BTCUSD Margin: (0.1 * 48000) / 2 = 2400
+    // Total Margin ~= 3505
+    const margin = Number(response.body.usedMargin);
+    expect(margin).toBeCloseTo(3505, 0);
+  });
+
+  it('should run stress tests', async () => {
+    const response = await request(app.getHttpServer())
+      .post(`/risk/stress-test/${userId}`)
+      .expect(201);
+
+    expect(response.body['Flash Crash -10%']).toBeDefined();
+    expect(response.body['Flash Crash -10%'].isLiquidated).toBeDefined();
+  });
+
+  it('should block risky trades', async () => {
+    // Set strict limits
+    await request(app.getHttpServer())
+      .put(`/risk/limits/${userId}`)
+      .send({ maxLeverage: 5 }) // Current EURUSD leverage is 10, so new trade with high leverage should be blocked?
+      // Wait, checkTrade checks the NEW trade leverage, and projected portfolio leverage.
+      .expect(200);
+
+    // Attempt trade with high leverage
+    const riskyTrade = {
+      userId,
+      symbol: 'ETHUSD',
+      quantity: 10,
+      price: 3000,
+      side: 'BUY',
+      leverage: 20, // Exceeds maxLeverage 5
+      assetType: 'CRYPTO',
+    };
+
+    const response = await request(app.getHttpServer())
+      .post('/risk/check-trade')
+      .send(riskyTrade)
+      .expect(201); // Controller returns result, status 201 default for POST
+
+    expect(response.body.isAllowed).toBe(false);
+    expect(response.body.reason).toContain('exceeds limit');
+  });
+
+  it('should allow safe trades', async () => {
+    const safeTrade = {
+      userId,
+      symbol: 'ETHUSD',
+      quantity: 0.1,
+      price: 3000,
+      side: 'BUY',
+      leverage: 2,
+      assetType: 'CRYPTO',
+    };
+
+    const response = await request(app.getHttpServer())
+      .post('/risk/check-trade')
+      .send(safeTrade)
+      .expect(201);
+
+    expect(response.body.isAllowed).toBe(true);
+  });
+});

--- a/e2e/__testers__/risk-indicators.e2e-spec.ts
+++ b/e2e/__testers__/risk-indicators.e2e-spec.ts
@@ -1,0 +1,98 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TransactionsModule } from '../src/modules/transactions/transactions.module';
+import { RiskEngineModule } from '../src/modules/risk-engine/risk-engine.module';
+import { TransactionEntity } from '../src/modules/transactions/entities/transaction.entity';
+import { TransactionRiskEntity } from '../src/modules/transactions/entities/transaction-risk.entity';
+import { TransactionLifecycleService } from '../src/modules/transactions/services/transaction-lifecycle.service';
+import { NotificationThrottleEntity } from '../src/modules/notifications/entities/notification-throttle.entity';
+import { RiskState } from '../src/modules/risk-engine/entities/risk-state.entity';
+import { RiskPosition } from '../src/modules/risk-engine/entities/risk-position.entity';
+import { RiskSnapshot } from '../src/modules/risk-engine/entities/risk-snapshot.entity';
+import { TransactionExecutionSnapshotEntity } from '../src/modules/transactions/entities/transaction-execution-snapshot.entity';
+import { WalletAliasEntity } from '../src/modules/transactions/entities/wallet-alias.entity';
+import { TransactionCategoryEntity } from '../src/modules/transactions/entities/transaction-category.entity';
+
+describe('Risk indicators end-to-end', () => {
+  let app: INestApplication;
+  let txRepo: Repository<TransactionEntity>;
+  let riskRepo: Repository<TransactionRiskEntity>;
+  let lifecycle: TransactionLifecycleService;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'better-sqlite3',
+          database: ':memory:',
+          dropSchema: true,
+          entities: [
+            TransactionEntity,
+            TransactionRiskEntity,
+            TransactionExecutionSnapshotEntity,
+            WalletAliasEntity,
+            TransactionCategoryEntity,
+            NotificationThrottleEntity,
+            RiskState,
+            RiskPosition,
+            RiskSnapshot,
+          ],
+          synchronize: true,
+        }),
+        TransactionsModule,
+        RiskEngineModule,
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    txRepo = moduleRef.get(getRepositoryToken(TransactionEntity));
+    riskRepo = moduleRef.get(getRepositoryToken(TransactionRiskEntity));
+    lifecycle = moduleRef.get(TransactionLifecycleService);
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  it('persists risk scores asynchronously on transaction creation', async () => {
+    const walletId = 'wallet-e2e';
+    const now = Date.now();
+
+    // Seed prior activity to trigger multiple indicators
+    for (let i = 0; i < 22; i++) {
+      await txRepo.save(
+        txRepo.create({
+          walletId,
+          amount: 100,
+          currency: 'USD',
+          status: i % 5 === 0 ? 'FAILED' : 'SUCCESS',
+          toAddress: `dest-${i}`,
+          createdAt: new Date(now - (i + 1) * 60 * 60 * 1000),
+          updatedAt: new Date(now - (i + 1) * 60 * 60 * 1000),
+        }),
+      );
+    }
+
+    const created = await lifecycle.create({
+      amount: 1200,
+      currency: 'USD',
+      walletId,
+      toAddress: 'dest-new',
+    });
+
+    // allow async listener to run
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const riskRecord = await riskRepo.findOne({ where: { transactionId: created.id } });
+    expect(riskRecord).toBeDefined();
+    expect(riskRecord!.riskScore).toBeGreaterThan(0);
+
+    const reloaded = await txRepo.findOne({ where: { id: created.id } });
+    expect(reloaded?.riskScore).toEqual(riskRecord!.riskScore);
+    expect(reloaded?.requiresManualReview).toEqual(riskRecord!.isFlagged);
+  });
+});

--- a/e2e/__testers__/soft-delete-recovery.e2e-spec.ts
+++ b/e2e/__testers__/soft-delete-recovery.e2e-spec.ts
@@ -1,0 +1,143 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { getConnection } from 'typeorm';
+import { UserEntity } from '../src/modules/users/entities/user.entity';
+import { WalletEntity } from '../src/modules/users/entities/wallet.entity';
+import { UsersModule } from '../src/modules/users/users.module';
+import { UsersService } from '../src/modules/users/users.service';
+import { WalletService } from '../src/modules/users/wallet.service';
+
+describe('Soft Delete Recovery Integration Tests', () => {
+  let app: INestApplication;
+  let usersService: UsersService;
+  let walletService: WalletService;
+  let userId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot(),
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          host: process.env.DB_HOST || 'localhost',
+          port: parseInt(process.env.DB_PORT || '5432'),
+          username: process.env.DB_USER || 'postgres',
+          password: process.env.DB_PASSWORD || 'postgres',
+          database: process.env.DB_NAME || 'test_db',
+          entities: [UserEntity, WalletEntity],
+          synchronize: true, // For testing purposes
+        }),
+        UsersModule,
+      ],
+      providers: [UsersService, WalletService],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    usersService = moduleFixture.get<UsersService>(UsersService);
+    walletService = moduleFixture.get<WalletService>(WalletService);
+
+    await app.init();
+
+    // Create a test user
+    const testUser = await usersService.createUser({
+      email: `test-${Date.now()}@example.com`,
+      firstName: 'Test',
+      lastName: 'User',
+      status: 'active',
+    });
+    userId = testUser.id;
+  });
+
+  afterAll(async () => {
+    // Clean up test data
+    const entityManager = getConnection().manager;
+    await entityManager.query('DELETE FROM wallets WHERE userId = $1', [userId]);
+    await entityManager.query('DELETE FROM users WHERE id = $1', [userId]);
+    
+    await app.close();
+  });
+
+  it('should soft delete a user and then restore them', async () => {
+    // Verify user exists initially
+    const initialUser = await usersService.findUserById(userId);
+    expect(initialUser).toBeDefined();
+    expect(initialUser.deletedAt).toBeUndefined();
+
+    // Soft delete the user
+    await usersService.softDeleteUser(userId);
+
+    // Verify user is soft deleted
+    const softDeletedUser = await usersService.findUserById(userId);
+    expect(softDeletedUser).toBeDefined();
+    expect(softDeletedUser.deletedAt).toBeDefined();
+
+    // Verify user cannot be found in active queries
+    await expect(usersService.findActiveUserById(userId)).rejects.toThrow('Active user not found');
+
+    // Restore the user
+    const restoredUser = await usersService.restoreUser(userId);
+    expect(restoredUser).toBeDefined();
+    expect(restoredUser.deletedAt).toBeUndefined();
+    expect(restoredUser.status).toBe('active');
+
+    // Verify user can now be found in active queries
+    const activeUser = await usersService.findActiveUserById(userId);
+    expect(activeUser).toBeDefined();
+    expect(activeUser.id).toBe(userId);
+  });
+
+  it('should soft delete a wallet and then restore it', async () => {
+    // Create a wallet
+    const wallet = await walletService.createWallet(userId, {
+      publicKey: '0x1234567890123456789012345678901234567890',
+      name: 'Test Wallet',
+      type: 'crypto',
+    });
+
+    expect(wallet).toBeDefined();
+    expect(wallet.deletedAt).toBeUndefined();
+
+    // Soft delete the wallet
+    await walletService.softDeleteWallet(wallet.id);
+
+    // Verify wallet is soft deleted
+    await expect(walletService.getWalletById(wallet.id)).rejects.toThrow('Wallet not found');
+
+    // Find wallet including soft deleted
+    const walletRepo = getConnection().manager.getRepository(WalletEntity);
+    const softDeletedWallet = await walletRepo.findOne({
+      where: { id: wallet.id },
+      withDeleted: true,
+    });
+    expect(softDeletedWallet).toBeDefined();
+    expect(softDeletedWallet!.deletedAt).toBeDefined();
+
+    // Restore the wallet
+    const restoredWallet = await walletService.restoreWallet(wallet.id);
+    expect(restoredWallet).toBeDefined();
+    expect(restoredWallet.deletedAt).toBeUndefined();
+
+    // Verify wallet can now be found in active queries
+    const activeWallet = await walletService.getWalletById(wallet.id);
+    expect(activeWallet).toBeDefined();
+    expect(activeWallet.id).toBe(wallet.id);
+  });
+
+  it('should not allow restoring a user that was not soft deleted', async () => {
+    // Create a new user
+    const newUser = await usersService.createUser({
+      email: `new-${Date.now()}@example.com`,
+      firstName: 'New',
+      lastName: 'User',
+      status: 'active',
+    });
+
+    // Try to restore a user that was never soft deleted should throw an error
+    await expect(usersService.restoreUser(newUser.id)).rejects.toThrow('User is not soft deleted');
+
+    // Clean up
+    await usersService.softDeleteUser(newUser.id);
+  });
+});


### PR DESCRIPTION
Repo Avatar

## Summary

- 

## Linked Issue

Closes #514
Closes #515
Closes #516
Closes #517

## What Changed

- 
- 

## Testing Steps

1.
2.
3.

## Screenshots or Recordings
ThemeProvider / theme store exist. Deliver light/dark/system modes with persisted override, prefers-color-scheme sync, and no flash on first paint. Verify charts/marketplace remain readable.

Requirements and Context
Theme flash and broken chart contrast hurt polish and a11y.

Suggested Execution
git checkout -b feat/theme-system-sync
Inline boot script / class strategy to prevent FOUC
System + manual override persistence
Audit analytics charts in both themes
Toggle in navbar/settings
Store tests
File Paths
components/layout/ThemeProvider.tsx
store/ (theme-related)
app/layout.tsx
app/globals.css
components/analytics/Charts.tsx

- [ ] Tests added or updated
- [ ] Docs updated, if needed
- [ ] Accessibility checked
- [ ] Wallet and network behavior considered
- [ ] SME, investor, invoice, or position terminology is accurate
- [ ] No secrets, private keys, real wallet seed phrases, or live credentials added

## Notes for Reviewers

Call out any migration steps, mocked data, incomplete contract wiring, or areas that need focused review.
