### PR TITLE
feat(invoice-lifecycle): add partial-fill funding validators with min ticket enforcement

### DIFF
--- a/lib/funding/__tests__/partialFill.test.ts
+++ b/lib/funding/__tests__/partialFill.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampFundingAmount,
+  computeRemainingCapacity,
+  evaluateFundingAmount,
+  leavesDustRemainder,
+  maxFundableAmount,
+  type FundingLimits,
+} from "../partialFill";
+
+const limits = (overrides: Partial<FundingLimits> = {}): FundingLimits => ({
+  remainingCapacity: 10_000,
+  minTicket: 1_000,
+  ...overrides,
+});
+
+describe("computeRemainingCapacity", () => {
+  it("subtracts raised from financing amount", () => {
+    expect(computeRemainingCapacity(50_000, 12_500)).toBe(37_500);
+  });
+
+  it("never goes negative on over-funding", () => {
+    expect(computeRemainingCapacity(50_000, 51_000)).toBe(0);
+  });
+
+  it("returns 0 for non-finite inputs", () => {
+    expect(computeRemainingCapacity(Number.NaN, 10)).toBe(0);
+  });
+});
+
+describe("maxFundableAmount", () => {
+  it("defaults to remaining capacity", () => {
+    expect(maxFundableAmount(limits())).toBe(10_000);
+  });
+
+  it("is bounded by max ticket and balance", () => {
+    expect(maxFundableAmount(limits({ maxTicket: 5_000 }))).toBe(5_000);
+    expect(maxFundableAmount(limits({ maxTicket: 5_000, availableBalance: 2_500 }))).toBe(2_500);
+  });
+
+  it("ignores an unknown balance", () => {
+    expect(maxFundableAmount(limits({ availableBalance: null }))).toBe(10_000);
+  });
+});
+
+describe("clampFundingAmount", () => {
+  it("clamps to the fundable ceiling", () => {
+    expect(clampFundingAmount(99_000, limits())).toBe(10_000);
+  });
+
+  it("raises a too-small amount to the min ticket", () => {
+    expect(clampFundingAmount(10, limits())).toBe(1_000);
+  });
+
+  it("never exceeds the ceiling when capacity is below the min ticket", () => {
+    expect(clampFundingAmount(900, limits({ remainingCapacity: 400 }))).toBe(400);
+  });
+
+  it("returns 0 when nothing is fundable", () => {
+    expect(clampFundingAmount(500, limits({ remainingCapacity: 0 }))).toBe(0);
+    expect(clampFundingAmount(Number.NaN, limits())).toBe(0);
+  });
+});
+
+describe("leavesDustRemainder", () => {
+  it("flags a remainder smaller than the min ticket", () => {
+    expect(leavesDustRemainder(9_500, limits())).toBe(true);
+  });
+
+  it("allows an exact full fill", () => {
+    expect(leavesDustRemainder(10_000, limits())).toBe(false);
+  });
+
+  it("allows a remainder of exactly the min ticket", () => {
+    expect(leavesDustRemainder(9_000, limits())).toBe(false);
+  });
+});
+
+describe("evaluateFundingAmount", () => {
+  it("accepts a valid ticket", () => {
+    expect(evaluateFundingAmount("2500", limits())).toEqual({
+      ok: true,
+      amount: 2_500,
+    });
+  });
+
+  it("accepts an exact full fill", () => {
+    expect(evaluateFundingAmount(10_000, limits()).ok).toBe(true);
+  });
+
+  it("rejects non-numeric input", () => {
+    expect(evaluateFundingAmount("abc", limits())).toMatchObject({
+      ok: false,
+      reason: "invalid",
+      messageKey: "invalidAmount",
+    });
+  });
+
+  it("rejects zero and negative amounts", () => {
+    expect(evaluateFundingAmount(0, limits()).reason).toBe("notPositive");
+    expect(evaluateFundingAmount(-100, limits()).reason).toBe("notPositive");
+  });
+
+  it("rejects below the min ticket with the min in values", () => {
+    expect(evaluateFundingAmount(999, limits())).toMatchObject({
+      reason: "belowMinTicket",
+      messageKey: "minInvestment",
+      values: { amount: 1_000 },
+    });
+  });
+
+  it("rejects above the remaining capacity", () => {
+    expect(evaluateFundingAmount(10_001, limits())).toMatchObject({
+      reason: "exceedsCapacity",
+      values: { amount: 10_000 },
+    });
+  });
+
+  it("rejects above the max ticket", () => {
+    expect(evaluateFundingAmount(6_000, limits({ maxTicket: 5_000 }))).toMatchObject({
+      reason: "aboveMaxTicket",
+      messageKey: "maxInvestment",
+      values: { amount: 5_000 },
+    });
+  });
+
+  it("rejects a fill that would leave dust", () => {
+    expect(evaluateFundingAmount(9_500, limits())).toMatchObject({
+      reason: "dustRemainder",
+      values: { amount: 10_000, min: 1_000 },
+    });
+  });
+
+  it("rejects an amount above the wallet balance", () => {
+    expect(evaluateFundingAmount(5_000, limits({ availableBalance: 4_999 }))).toMatchObject({
+      reason: "insufficientBalance",
+      values: { amount: 4_999 },
+    });
+  });
+
+  it("skips the balance check while the balance is unknown", () => {
+    expect(evaluateFundingAmount(5_000, limits({ availableBalance: null })).ok).toBe(true);
+  });
+
+  it("reports capacity before balance when both fail", () => {
+    expect(evaluateFundingAmount(20_000, limits({ availableBalance: 100 })).reason).toBe(
+      "exceedsCapacity"
+    );
+  });
+
+  it("tolerates 2-decimal float drift on an exact full fill", () => {
+    const l = limits({ remainingCapacity: 0.1 + 0.2, minTicket: 0.01 });
+    expect(evaluateFundingAmount(0.3, l).ok).toBe(true);
+  });
+});

--- a/lib/funding/partialFill.ts
+++ b/lib/funding/partialFill.ts
@@ -1,0 +1,152 @@
+/**
+ * Partial-fill funding math and validation.
+ *
+ * Pure helpers shared by the marketplace funding panel so that remaining
+ * capacity, min/max ticket clamps and balance checks are computed in one
+ * place instead of being re-derived inline in the UI.
+ *
+ * Validation returns i18n message keys (plus interpolation values) rather
+ * than formatted strings — formatting stays the caller's job.
+ */
+
+/** Tolerance for float comparisons on 2-decimal money amounts. */
+const EPSILON = 1e-9;
+
+export type FundingRejectionReason =
+  | "invalid"
+  | "notPositive"
+  | "belowMinTicket"
+  | "aboveMaxTicket"
+  | "exceedsCapacity"
+  | "insufficientBalance"
+  | "dustRemainder";
+
+export interface FundingLimits {
+  /** Capacity still open on the invoice, in the invoice currency. */
+  remainingCapacity: number;
+  /** Smallest ticket an investor may take. */
+  minTicket: number;
+  /** Largest single ticket, when the listing caps it. */
+  maxTicket?: number | null;
+  /** Investor's spendable USDC balance; `null`/`undefined` when unknown. */
+  availableBalance?: number | null;
+}
+
+export interface FundingEvaluation {
+  ok: boolean;
+  reason?: FundingRejectionReason;
+  /** Key under the `invoiceDetail.errors` namespace. */
+  messageKey?: string;
+  /** Interpolation values for `messageKey`. */
+  values?: Record<string, number>;
+  /** Parsed amount when the input was numeric. */
+  amount?: number;
+}
+
+/** Remaining capacity of a listing, never negative. */
+export function computeRemainingCapacity(financingAmount: number, totalRaised: number): number {
+  if (!Number.isFinite(financingAmount) || !Number.isFinite(totalRaised)) return 0;
+  return Math.max(0, financingAmount - totalRaised);
+}
+
+/**
+ * Largest amount an investor can currently fund: the remaining capacity,
+ * bounded by the max ticket and their balance.
+ */
+export function maxFundableAmount(limits: FundingLimits): number {
+  const caps = [limits.remainingCapacity];
+  if (typeof limits.maxTicket === "number" && limits.maxTicket > 0) {
+    caps.push(limits.maxTicket);
+  }
+  if (typeof limits.availableBalance === "number") {
+    caps.push(limits.availableBalance);
+  }
+  return Math.max(0, Math.min(...caps));
+}
+
+/** Clamp a requested amount into the fundable band. */
+export function clampFundingAmount(amount: number, limits: FundingLimits): number {
+  if (!Number.isFinite(amount)) return 0;
+  const ceiling = maxFundableAmount(limits);
+  if (ceiling <= 0) return 0;
+  return Math.min(Math.max(amount, Math.min(limits.minTicket, ceiling)), ceiling);
+}
+
+/**
+ * True when funding `amount` would leave a remainder too small for anyone
+ * else to take (dust). Such a fill has to be an all-or-nothing full fill.
+ */
+export function leavesDustRemainder(amount: number, limits: FundingLimits): boolean {
+  const remainder = limits.remainingCapacity - amount;
+  return remainder > EPSILON && remainder < limits.minTicket - EPSILON;
+}
+
+/**
+ * Validate a funding amount against capacity, ticket size and balance.
+ * Checks run cheapest-and-most-specific first so the investor sees the one
+ * reason that actually blocks them.
+ */
+export function evaluateFundingAmount(
+  raw: string | number,
+  limits: FundingLimits
+): FundingEvaluation {
+  const amount = typeof raw === "number" ? raw : Number.parseFloat(String(raw).trim());
+
+  if (!Number.isFinite(amount)) {
+    return { ok: false, reason: "invalid", messageKey: "invalidAmount" };
+  }
+  if (amount <= 0) {
+    return { ok: false, reason: "notPositive", messageKey: "invalidAmount", amount };
+  }
+  if (amount < limits.minTicket - EPSILON) {
+    return {
+      ok: false,
+      reason: "belowMinTicket",
+      messageKey: "minInvestment",
+      values: { amount: limits.minTicket },
+      amount,
+    };
+  }
+  if (amount > limits.remainingCapacity + EPSILON) {
+    return {
+      ok: false,
+      reason: "exceedsCapacity",
+      messageKey: "exceedsCapacity",
+      values: { amount: limits.remainingCapacity },
+      amount,
+    };
+  }
+  if (
+    typeof limits.maxTicket === "number" &&
+    limits.maxTicket > 0 &&
+    amount > limits.maxTicket + EPSILON
+  ) {
+    return {
+      ok: false,
+      reason: "aboveMaxTicket",
+      messageKey: "maxInvestment",
+      values: { amount: limits.maxTicket },
+      amount,
+    };
+  }
+  if (leavesDustRemainder(amount, limits)) {
+    return {
+      ok: false,
+      reason: "dustRemainder",
+      messageKey: "dustRemainder",
+      values: { amount: limits.remainingCapacity, min: limits.minTicket },
+      amount,
+    };
+  }
+  if (typeof limits.availableBalance === "number" && amount > limits.availableBalance + EPSILON) {
+    return {
+      ok: false,
+      reason: "insufficientBalance",
+      messageKey: "insufficientBalance",
+      values: { amount: limits.availableBalance },
+      amount,
+    };
+  }
+
+  return { ok: true, amount };
+}

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -197,7 +197,10 @@
     "errors": {
       "minInvestment": "الحد الأدنى للاستثمار هو {amount}",
       "exceedsCapacity": "يتجاوز المبلغ الطاقة الاستيعابية المتبقية البالغة {amount}",
-      "insufficientBalance": "رصيد USDC غير كافٍ. المتاح: {amount}"
+      "insufficientBalance": "رصيد USDC غير كافٍ. المتاح: {amount}",
+      "invalidAmount": "أدخل مبلغ تمويل صالحًا",
+      "maxInvestment": "الحد الأقصى للاستثمار هو {amount}",
+      "dustRemainder": "سيترك هذا مبلغًا أقل من الحد الأدنى للاستثمار دون تمويل. مَوِّل كامل المبلغ المتبقي {amount} أو اترك {min} على الأقل."
     },
     "hint": {
       "minRemaining": "الحد الأدنى: ${min} · الطاقة المتبقية: ${remaining}"

--- a/messages/en.json
+++ b/messages/en.json
@@ -197,7 +197,10 @@
     "errors": {
       "minInvestment": "Minimum investment is {amount}",
       "exceedsCapacity": "Amount exceeds remaining capacity of {amount}",
-      "insufficientBalance": "Insufficient USDC balance. Available: {amount}"
+      "insufficientBalance": "Insufficient USDC balance. Available: {amount}",
+      "invalidAmount": "Enter a valid funding amount",
+      "maxInvestment": "Maximum investment is {amount}",
+      "dustRemainder": "This would leave less than the minimum ticket unfunded. Fund the full remaining {amount} or leave at least {min}."
     },
     "hint": {
       "minRemaining": "Min: ${min} · Remaining Capacity: ${remaining}"

--- a/messages/es.json
+++ b/messages/es.json
@@ -197,7 +197,10 @@
     "errors": {
       "minInvestment": "La inversión mínima es {amount}",
       "exceedsCapacity": "El monto supera la capacidad restante de {amount}",
-      "insufficientBalance": "Saldo USDC insuficiente. Disponible: {amount}"
+      "insufficientBalance": "Saldo USDC insuficiente. Disponible: {amount}",
+      "invalidAmount": "Introduce un monto de financiación válido",
+      "maxInvestment": "La inversión máxima es {amount}",
+      "dustRemainder": "Esto dejaría sin financiar menos que el ticket mínimo. Financia el total restante de {amount} o deja al menos {min}."
     },
     "hint": {
       "minRemaining": "Mín: ${min} · Capacidad Restante: ${remaining}"

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -197,7 +197,10 @@
     "errors": {
       "minInvestment": "O investimento mínimo é {amount}",
       "exceedsCapacity": "O valor excede a capacidade restante de {amount}",
-      "insufficientBalance": "Saldo USDC insuficiente. Disponível: {amount}"
+      "insufficientBalance": "Saldo USDC insuficiente. Disponível: {amount}",
+      "invalidAmount": "Insira um valor de financiamento válido",
+      "maxInvestment": "O investimento máximo é {amount}",
+      "dustRemainder": "Isso deixaria menos que o ticket mínimo sem financiamento. Financie o total restante de {amount} ou deixe pelo menos {min}."
     },
     "hint": {
       "minRemaining": "Mín: ${min} · Capacidade Restante: ${remaining}"


### PR DESCRIPTION
Closes #576 
Closes #573 
Closes #575
Closes #572 