### PR TITLE
feat(secondary-market): complete secondary market listing create flow from investor positions (#590)

### DIFF
--- a/components/invoice/ListPositionDialog.tsx
+++ b/components/invoice/ListPositionDialog.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { Tag } from "lucide-react";
+import { Tag, AlertCircle, CheckCircle, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -35,21 +37,37 @@ export function ListPositionDialog({
   onSubmit,
 }: ListPositionDialogProps) {
   const [askPrice, setAskPrice] = useState<string>("");
+  const [showValidation, setShowValidation] = useState(false);
   const { formatCurrency, formatPercentage } = useFormatters();
 
   if (!position) return null;
 
   const currency = position.invoice?.metadata.currency ?? "USDC";
+  const expectedReturn = position.expectedReturn;
   const parsedAsk = Number.parseFloat(askPrice);
   const askIsValid = Number.isFinite(parsedAsk) && parsedAsk > 0;
+
+  // Validation: ask price must be reasonable (not too low, not excessively high)
+  const minReasonablePrice = Math.max(1, expectedReturn * 0.1); // At least 10% of expected return
+  const maxReasonablePrice = expectedReturn * 2; // Max 200% of expected return
+  const priceIsReasonable = parsedAsk >= minReasonablePrice && parsedAsk <= maxReasonablePrice;
+
   const impliedDiscount = askIsValid
-    ? computeImpliedDiscount(parsedAsk, position.expectedReturn)
+    ? computeImpliedDiscount(parsedAsk, expectedReturn)
     : null;
 
+  // Validation states
+  const isAskPriceValid = askIsValid && priceIsReasonable;
+  const showValidationWarnings = showValidation || askPrice.length > 0;
+
   const handleSubmit = () => {
-    if (!askIsValid) return;
+    if (!isAskPriceValid) {
+      setShowValidation(true);
+      return;
+    }
     onSubmit(parsedAsk);
     setAskPrice("");
+    setShowValidation(false);
   };
 
   return (
@@ -76,31 +94,84 @@ export function ListPositionDialog({
             step="0.01"
             showUSDC={currency === "USDC"}
             error={
-              askPrice.length > 0 && !askIsValid
+              showValidationWarnings && askPrice.length > 0 && !askIsValid
                 ? "Enter a valid ask price greater than 0"
+                : showValidationWarnings && askIsValid && !priceIsReasonable
+                ? `Ask price must be between ${formatCurrency(Math.max(1, position.expectedReturn * 0.1), "USDC")} and ${formatCurrency(position.expectedReturn * 2, "USDC")}`
                 : undefined
             }
           />
 
           {impliedDiscount !== null && (
-            <div className="rounded-lg border border-border bg-muted/30 p-3">
-              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                Implied discount
+            <div
+              className={cn(
+                "rounded-lg border border-border bg-muted/30 p-3",
+                impliedDiscount >= 0
+                  ? "border-success/30 bg-success/5"
+                  : "border-warning/30 bg-warning/5"
+              )}
+            >
+              <div className="flex items-start gap-2">
+                {impliedDiscount >= 0 ? (
+                  <CheckCircle className="h-4 w-4 text-success mt-0.5 flex-shrink-0" />
+                ) : (
+                  <AlertCircle className="h-4 w-4 text-warning mt-0.5 flex-shrink-0" />
+                )}
+                <div className="flex-1">
+                  <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    Implied discount
+                  </p>
+                  <p
+                    className={
+                      impliedDiscount >= 0
+                        ? "mt-1 text-lg font-bold text-success"
+                        : "mt-1 text-lg font-bold text-warning"
+                    }
+                  >
+                    {formatPercentage(impliedDiscount * 100, 2)}
+                  </p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {impliedDiscount >= 0
+                      ? "Buyer receives a discount versus your expected return."
+                      : "You're asking above your expected return (premium)."}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Price range guidance */}
+          <div className="rounded-lg border border-border bg-muted/30 p-3">
+            <div className="flex items-center gap-2">
+              <Info className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+              <p className="text-xs text-muted-foreground">
+                Suggested range:{" "}
+                {formatCurrency(Math.max(1, position.expectedReturn * 0.1), "USDC")} -{" "}
+                {formatCurrency(position.expectedReturn * 2, "USDC")}
               </p>
-              <p
-                className={
-                  impliedDiscount >= 0
-                    ? "mt-1 text-lg font-bold text-success"
-                    : "mt-1 text-lg font-bold text-warning"
-                }
-              >
-                {formatPercentage(impliedDiscount * 100, 2)}
-              </p>
-              <p className="mt-0.5 text-xs text-muted-foreground">
-                {impliedDiscount >= 0
-                  ? "Buyer receives a discount versus your expected return."
-                  : "You're asking above your expected return."}
-              </p>
+            </div>
+          </div>
+
+          {/* Validation warnings */}
+          {showValidationWarnings && askPrice.length > 0 && !askIsValid && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+              <div className="flex items-center gap-2 text-xs text-destructive">
+                <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" />
+                <span>Please enter a valid ask price greater than 0</span>
+              </div>
+            </div>
+          )}
+
+          {showValidationWarnings && askIsValid && !priceIsReasonable && (
+            <div className="rounded-lg border border-warning/30 bg-warning/5 p-3">
+              <div className="flex items-center gap-2 text-xs text-warning">
+                <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" />
+                <span>
+                  Ask price should be between{" "}
+                  {formatCurrency(Math.max(1, expectedReturn * 0.1), "USDC")} and{" "}
+                  {formatCurrency(expectedReturn * 2, "USDC")}
+                </span>
+              </div>
             </div>
           )}
         </div>
@@ -109,7 +180,7 @@ export function ListPositionDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={handleSubmit} disabled={!askIsValid}>
+          <Button onClick={handleSubmit} disabled={!isAskPriceValid}>
             List for sale
           </Button>
         </DialogFooter>

--- a/components/invoice/__tests__/ListPositionDialog.test.tsx
+++ b/components/invoice/__tests__/ListPositionDialog.test.tsx
@@ -1,0 +1,320 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ListPositionDialog } from "@/components/invoice/ListPositionDialog";
+import type { InvestorPosition } from "@/types/invoice";
+
+// Mock the formatters hook
+jest.mock("@/hooks/useFormatters", () => ({
+  useFormatters: () => ({
+    formatCurrency: (value: number, currency = "USDC") => `${currency} ${value.toFixed(2)}`,
+    formatPercentage: (value: number, decimals = 2) => `${value.toFixed(decimals)}%`,
+  }),
+});
+
+// Mock the computeImpliedDiscount function
+jest.mock("@/types/invoice", () => ({
+  ...jest.requireActual("@/types/invoice"),
+  computeImpliedDiscount: (askPrice: number, expectedReturn: number) => {
+    if (expectedReturn <= 0) return 0;
+    return (expectedReturn - askPrice) / expectedReturn;
+  },
+});
+
+// Mock the UI components
+jest.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, onOpenChange, children }: any) => open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children, className }: any) => <div data-testid="dialog-content" className={className}>{children}</div>,
+  DialogHeader: ({ children }: any) => <div data-testid="dialog-header">{children}</div>,
+  DialogTitle: ({ children, className }: any) => <h2 data-testid="dialog-title" className={className}>{children}</h2>,
+  DialogDescription: ({ children }: any) => <p data-testid="dialog-description">{children}</p>,
+  DialogFooter: ({ children }: any) => <div data-testid="dialog-footer">{children}</div>,
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, disabled, variant, ...props }: any) => (
+    <button data-testid="button" onClick={onClick} disabled={disabled} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock("@/components/ui/number-input", () => ({
+  NumberInput: ({ value, onChange, error, ...props }: any) => (
+    <input
+      data-testid="number-input"
+      value={value}
+      onChange={onChange}
+      aria-invalid={!!error}
+      aria-describedby={error ? "error-message" : undefined}
+      {...props}
+    />
+  ),
+});
+
+jest.mock("@/hooks/useFormatters", () => ({
+  useFormatters: () => ({
+    formatCurrency: (value: number, currency = "USDC") => `${currency} ${value.toFixed(2)}`,
+    formatPercentage: (value: number, decimals = 2) => `${value.toFixed(2)}%`,
+  }),
+});
+
+const mockPosition = {
+  id: "pos_123",
+  invoiceId: "inv_123",
+  investedAmount: 1000,
+  expectedReturn: 1100,
+  yieldEarned: 100,
+  investedAt: "2024-01-01T00:00:00Z",
+  status: "active" as const,
+  invoice: {
+    id: "inv_123",
+    tokenId: "123",
+    contractAddress: "C123",
+    ipfsCid: "QmTest",
+    metadata: {
+      invoiceNumber: "INV-001",
+      issuerName: "Test Corp",
+      issuerAddress: "G...",
+      debtorName: "Debtor Inc",
+      debtorAddress: "G...",
+      amount: 1000,
+      currency: "USDC",
+      issueDate: "2024-01-01T00:00:00Z",
+      dueDate: "2025-01-01T00:00:00Z",
+      description: "Test invoice",
+      jurisdiction: "US",
+      category: "technology",
+      documentHash: "QmTest",
+      documentUrl: "https://example.com",
+    },
+    terms: {
+      discountRate: 0.1,
+      apr: 10,
+      financingAmount: 1000,
+      minInvestment: 100,
+      maxInvestment: 1000,
+      tenor: 365,
+      repaymentDate: "2025-01-01T00:00:00Z",
+    },
+    funding: {
+      totalRaised: 1000,
+      targetAmount: 1000,
+      fundingProgress: 1,
+      investorCount: 1,
+      remainingCapacity: 0,
+    },
+    riskTier: "A",
+    riskScore: 90,
+    debtorPrivacy: "full",
+    status: "active" as const,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    ownerAddress: "G...",
+  } as any,
+};
+
+describe("ListPositionDialog", () => {
+  const defaultProps = {
+    position: {
+      id: "pos_123",
+      invoiceId: "inv_123",
+      investedAmount: 1000,
+      expectedReturn: 1100,
+      yieldEarned: 100,
+      investedAt: "2024-01-01T00:00:00Z",
+      status: "active" as const,
+      invoice: {
+        id: "inv_123",
+        tokenId: "123",
+        contractAddress: "C123",
+        ipfsCid: "QmTest",
+        metadata: {
+          invoiceNumber: "INV-001",
+          issuerName: "Test Corp",
+          issuerAddress: "G...",
+          debtorName: "Debtor Inc",
+          debtorAddress: "G...",
+          amount: 1000,
+          currency: "USDC",
+          issueDate: "2024-01-01T00:00:00Z",
+          dueDate: "2025-01-01T00:00:00Z",
+          description: "Test invoice",
+          jurisdiction: "US",
+          category: "technology",
+          documentHash: "QmTest",
+          documentUrl: "https://example.com",
+        },
+        terms: {
+          discountRate: 0.1,
+          apr: 10,
+          financingAmount: 1000,
+          minInvestment: 100,
+          maxInvestment: 1000,
+          tenor: 365,
+          repaymentDate: "2025-01-01T00:00:00Z",
+        },
+        funding: {
+          totalRaised: 1000,
+          targetAmount: 1000,
+          fundingProgress: 1,
+          investorCount: 1,
+          remainingCapacity: 0,
+        },
+        riskTier: "A",
+        riskScore: 90,
+        debtorPrivacy: "full" as const,
+        status: "active" as const,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+        ownerAddress: "G...",
+      } as any,
+    },
+    open: true,
+    onOpenChange: jest.fn(),
+    onSubmit: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders dialog when open is true", () => {
+    render(<ListPositionDialog {...defaultProps} />);
+    expect(screen.getByTestId("dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("dialog-title")).toHaveTextContent("List position for sale");
+  });
+
+  it("does not render when position is null", () => {
+    render(<ListPositionDialog {...defaultProps} position={null} />);
+    expect(screen.queryByTestId("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders expected return in description", () => {
+    render(<ListPositionDialog {...defaultProps} />);
+    expect(screen.getByText("Expected return: USDC 1100.00")).toBeInTheDocument();
+  });
+
+  it("shows error when ask price is empty and user tries to submit", async () => {
+    const user = userEvent.setup();
+    render(<ListPositionDialog {...defaultProps} />);
+
+    const submitButton = screen.getByRole("button", { name: /list for sale/i });
+    await userEvent.click(submitButton);
+
+    // Should not call onSubmit
+    expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("shows error when ask price is invalid", async () => {
+    const user = userEvent.setup();
+    render(<ListPositionDialog {...defaultProps} />);
+
+    const input = screen.getByTestId("number-input");
+    await userEvent.type(input, "abc");
+    await userEvent.click(screen.getByRole("button", { name: /list for sale/i }));
+
+    expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("shows validation error when ask price is too low", async () => {
+    const user = userEvent.setup();
+    render(<ListPositionDialog {...defaultProps} />);
+
+    const input = screen.getByTestId("number-input");
+    await userEvent.type(input, "50"); // Too low (below 10% of expected return)
+    await userEvent.click(screen.getByRole("button", { name: /list for sale/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/must be between/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows warning when ask price is too high", async () => {
+    const user = userEvent.setup();
+    render(<ListPositionDialog {...defaultProps} />);
+
+    const input = screen.getByTestId("number-input");
+    await userEvent.type(input, "3000"); // Too high (above 200% of expected return)
+    await userEvent.click(screen.getByRole("button", { name: /list for sale/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/must be between/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows implied discount preview when valid price entered", async () => {
+    const user = userEvent.setup();
+    render(<ListPositionDialog {...defaultProps} />);
+
+    const input = screen.getByTestId("number-input");
+    await userEvent.type(input, "1000"); // Valid price, 9.09% discount
+
+    await waitFor(() => {
+      expect(screen.getByText("Implied discount")).toBeInTheDocument();
+      expect(screen.getByText("9.09%")).toBeInTheDocument();
+      expect(screen.getByText("Buyer receives a discount versus your expected return.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows premium warning when ask price above expected return", async () => {
+    const user = userEvent.setup();
+    render(<ListPositionDialog {...defaultProps} />);
+
+    const input = screen.getByTestId("number-input");
+    await userEvent.type(input, "1200"); // Above expected return (premium)
+
+    await waitFor(() => {
+      expect(screen.getByText("You're asking above your expected return (premium).")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onSubmit with parsed ask price when valid", async () => {
+    const user = userEvent.setup();
+    render(<ListPositionDialog {...defaultProps} />);
+
+    const input = screen.getByTestId("number-input");
+    await userEvent.type(input, "1000");
+    await userEvent.click(screen.getByRole("button", { name: /list for sale/i }));
+
+    await waitFor(() => {
+      expect(defaultProps.onSubmit).toHaveBeenCalledWith(1000);
+    });
+  });
+
+  it("shows suggested price range guidance", () => {
+    render(<ListPositionDialog {...defaultProps} />);
+    expect(screen.getByText(/Suggested range:/)).toBeInTheDocument();
+    expect(screen.getByText("USDC 110.00 - USDC 2200.00")).toBeInTheDocument();
+  });
+
+  it("closes dialog when cancel is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ListPositionDialog {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("clears ask price after successful submit", async () => {
+    const user = userEvent.setup();
+    render(<ListPositionDialog {...defaultProps} />);
+
+    const input = screen.getByTestId("number-input");
+    await userEvent.type(input, "1000");
+    await userEvent.click(screen.getByRole("button", { name: /list for sale/i }));
+
+    await waitFor(() => {
+      expect((screen.getByTestId("number-input") as HTMLInputElement).value).toBe("");
+    });
+  });
+
+  it("closes dialog on cancel", () => {
+    render(<ListPositionDialog {...defaultProps} />);
+    const cancelButton = screen.getByRole("button", { name: /cancel/i });
+    fireEvent.click(cancelButton);
+    expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
Fixes #590

Complete secondary market listing create flow from investor positions:

- Added ask price validation with reasonable range checks (10%-200% of expected return)
- Added implied discount preview with visual indicators (discount vs premium)
- Added price range guidance for sellers
- Improved validation UX with clear error/warning messages
- Added comprehensive unit tests for all validation scenarios

Changes:
- components/invoice/ListPositionDialog.tsx - Enhanced with validation, discount preview, price guidance
- components/invoice/__tests__/ListPositionDialog.test.tsx - Comprehensive test suite (14 tests)
- Added cn utility import for className composition