### PR TITLE
feat(secondary-market): implement secondary escrow settlement retry ledger UI (#591)

### DIFF
--- a/components/transactions/InProgressOverlay.tsx
+++ b/components/transactions/InProgressOverlay.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Loader2, X, AlertTriangle, CheckCircle2, ShieldCheck, ArrowRight } from "lucide-react";
+import { Loader2, X, AlertTriangle, CheckCircle2, ShieldCheck, ArrowRight, Clock, RotateCcw } from "lucide-react";
 import { useUIStore } from "@/store/uiStore";
 import { useTransactionStore } from "@/store/transactionStore";
 import { useSecondaryEscrowFlow } from "@/hooks/useTransaction";
-import { cn } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 
 /**
  * InProgressOverlay
@@ -113,7 +113,68 @@ export function InProgressOverlay() {
     );
   };
 
-  return (
+  // Retry ledger - shows attempt history for failed steps
+  const renderRetryLedger = () => {
+    const { escrowState: { attemptHistory } } = useTransactionStore();
+    if (!attemptHistory || attemptHistory.length === 0) return null;
+
+    return (
+      <div className="w-full space-y-2 pt-2 border-t border-border/30">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+            Retry History
+          </p>
+          <span className="text-xs text-muted-foreground">
+            {attemptHistory.length} attempt{attemptHistory.length > 1 ? "s" : ""}
+          </span>
+        </div>
+        <div className="space-y-1.5 max-h-32 overflow-y-auto">
+          {attemptHistory
+            .slice()
+            .reverse()
+            .map((attempt, index) => (
+              <div
+                key={`${attempt.step}-${attempt.attemptNumber}`}
+                className="flex items-center gap-2 p-2 rounded-lg border border-border/30 bg-muted/20"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5 text-xs">
+                    <span className="font-medium text-zinc-300">
+                      {attempt.step === "buyer_funding" ? "Buyer Funding" : "Seller Transfer"}
+                    </span>
+                    <span className="text-muted-foreground">Attempt #{attempt.attemptNumber}</span>
+                    {attempt.success ? (
+                      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-success/10 text-success border border-success/20">
+                        <span className="h-2.5 w-2.5 rounded-full bg-success" />
+                        Success
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-destructive/10 text-destructive border border-destructive/20">
+                        Failed
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                    <span>{formatDate(attempt.timestamp, "HH:mm:ss")}</span>
+                    {attempt.txHash && (
+                      <>
+                        <span>·</span>
+                        <span className="font-mono text-[9px]">{attempt.txHash.slice(0, 8)}...</span>
+                      </>
+                    )}
+                  </div>
+                </div>
+                {attempt.errorMessage && (
+                  <div className="mt-1 text-[10px] text-destructive/80 break-words">
+                    {attempt.errorMessage}
+                  </div>
+                )}
+              </div>
+            ))}
+        </div>
+      </div>
+    );
+  };
     <AnimatePresence>
       {isOpen && (
         <motion.div
@@ -181,7 +242,12 @@ export function InProgressOverlay() {
                   {escrowState.errorStep && (
                     <button
                       type="button"
-                      onClick={() => retryEscrow("mock_pos", "mock_buyer", "mock_seller", 5000)}
+                      onClick={() => {
+                        const ctx = escrowState.currentContext;
+                        if (ctx) {
+                          retryEscrow(ctx.positionId, ctx.buyerAddress, ctx.sellerAddress, ctx.amount);
+                        }
+                      }}
                       className={cn(
                         "flex-1 px-4 py-2.5 rounded-lg font-medium text-xs transition-all",
                         "bg-primary text-primary-foreground hover:bg-primary/90 hover:shadow-lg hover:shadow-primary/10",
@@ -192,6 +258,8 @@ export function InProgressOverlay() {
                     </button>
                   )}
                 </div>
+
+                {renderRetryLedger()}
               </>
             ) : (
               // Standard Transaction signing Overlay Content

--- a/store/transactionStore.ts
+++ b/store/transactionStore.ts
@@ -1,9 +1,9 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-// ─── Types ────────────────────────────────────────────────────────────────────
+// 🎯 Types ────────────────────────────────────────────────────────────
 
-export type TxType = "mint" | "fund" | "repay" | "claim";
+export type TxType = "mint" | "fund" | "repay" | "claim" | "transfer" | "escrow_fund" | "escrow_transfer";
 export type TxStatus = "confirmed" | "failed";
 
 export interface TxRecord {
@@ -31,15 +31,41 @@ export interface TxRecord {
   cancelNotes?: string;
 }
 
-// ─── Store interface ──────────────────────────────────────────────────────────
+// 🧩 Types ────────────────────────────────────────────────────────────
 
 export type EscrowStep = "idle" | "buyer_funding" | "buyer_funded" | "seller_transferring" | "seller_transferred" | "settled";
 
+export interface EscrowStepAttempt {
+  step: "buyer_funding" | "seller_transferring";
+  attemptNumber: number;
+  timestamp: string; // ISO 8601
+  success: boolean;
+  errorMessage?: string;
+  txHash?: string;
+  positionId?: string;
+  buyerAddress?: string;
+  sellerAddress?: string;
+  amount?: number;
+}
+
 export interface EscrowState {
-  step: EscrowStep;
+  step: "idle" | "buyer_funding" | "buyer_funded" | "seller_transferring" | "seller_transferred" | "settled";
   errorStep?: "buyer_funding" | "seller_transferring" | null;
   errorMessage?: string | null;
   txHash?: string | null;
+  /** Ledger of all escrow step attempts for retry history */
+  attemptHistory: EscrowStepAttempt[];
+  /** Current attempt being executed */
+  currentAttempt?: EscrowStepAttempt;
+  /** Total retry count for current flow */
+  totalRetryCount: number;
+  /** Position/buyer/seller context for retry */
+  currentContext?: {
+    positionId: string;
+    buyerAddress: string;
+    sellerAddress: string;
+    amount: number;
+  };
 }
 
 interface TransactionStore {
@@ -66,35 +92,154 @@ interface TransactionStore {
 
   /** Reset escrow state */
   resetEscrow: () => void;
+
+  /** Record an escrow step attempt in the history ledger */
+  recordEscrowAttempt: (attempt: EscrowStepAttempt) => void;
+
+  /** Set the current attempt being executed */
+  setCurrentAttempt: (attempt: EscrowStepAttempt | undefined) => void;
+
+  /** Increment total retry count */
+  incrementRetryCount: () => void;
+
+  /** Set the current escrow context (position/buyer/seller/amount) */
+  setEscrowContext: (context: { positionId: string; buyerAddress: string; sellerAddress: string; amount: number } | null) => void;
 }
 
-// ─── Store ────────────────────────────────────────────────────────────────────
+// 💾 Defaults ──────────────────────────────────────────────────────────
 
 const MAX_HISTORY = 200; // cap to avoid unbounded localStorage growth
 
-const DEFAULT_ESCROW_STATE: EscrowState = {
+const DEFAULT_ESCROW_STATE = {
   step: "idle",
   errorStep: null,
   errorMessage: null,
   txHash: null,
+  attemptHistory: [] as EscrowStepAttempt[],
+  currentAttempt: undefined,
+  totalRetryCount: 0,
+  currentContext: undefined as { positionId: string; buyerAddress: string; sellerAddress: string; amount: number } | undefined,
 };
+
+interface TransactionStore {
+  /** Ordered list of transactions — newest first */
+  transactions: TxRecord[];
+
+  /** Secondary Escrow State Machine state */
+  escrowState: {
+    step: "idle" | "buyer_funding" | "buyer_funded" | "seller_transferring" | "seller_transferred" | "settled";
+    errorStep?: "buyer_funding" | "seller_transferring" | null;
+    errorMessage?: string | null;
+    txHash?: string | null;
+    attemptHistory: EscrowStepAttempt[];
+    currentAttempt?: EscrowStepAttempt;
+    totalRetryCount: number;
+    currentContext?: {
+      positionId: string;
+      buyerAddress: string;
+      sellerAddress: string;
+      amount: number;
+    };
+  };
+
+  /** Add a new confirmed or failed transaction record */
+  addTransaction: (record: Omit<TxRecord, "timestamp"> & { timestamp?: string }) => void;
+
+  /** Remove a single transaction by hash */
+  removeTransaction: (hash: string) => void;
+
+  /** Wipe the entire history */
+  clearHistory: () => void;
+
+  /** Update escrow step */
+  setEscrowStep: (step: "idle" | "buyer_funding" | "buyer_funded" | "seller_transferring" | "seller_transferred" | "settled") => void;
+
+  /** Set escrow error step and message */
+  setEscrowError: (errorStep: "buyer_funding" | "seller_transferring" | null, message: string | null) => void;
+
+  /** Reset escrow state */
+  resetEscrow: () => void;
+
+  /** Record an escrow step attempt in the history ledger */
+  recordEscrowAttempt: (attempt: {
+    step: "buyer_funding" | "seller_transferring";
+    attemptNumber: number;
+    timestamp: string;
+    success: boolean;
+    errorMessage?: string;
+    txHash?: string;
+    positionId?: string;
+    buyerAddress?: string;
+    sellerAddress?: string;
+    amount?: number;
+  }) => void;
+
+  /** Set the current attempt being executed */
+  setCurrentAttempt: (attempt: {
+    step: "buyer_funding" | "seller_transferring";
+    attemptNumber: number;
+    timestamp: string;
+    success: boolean;
+    errorMessage?: string;
+    txHash?: string;
+    positionId?: string;
+    buyerAddress?: string;
+    sellerAddress?: string;
+    amount?: number;
+  } | undefined) => void;
+
+  /** Increment total retry count */
+  incrementRetryCount: () => void;
+
+  /** Set the current escrow context (position/buyer/seller/amount) */
+  setEscrowContext: (context: { positionId: string; buyerAddress: string; sellerAddress: string; amount: number } | null) => void;
+}
+
+// 💾 Defaults ──────────────────────────────────────────────────────────
+
+const MAX_HISTORY = 200; // cap to avoid unbounded localStorage growth
+
+const DEFAULT_ESCROW_STATE = {
+  step: "idle",
+  errorStep: null,
+  errorMessage: null,
+  txHash: null,
+  attemptHistory: [] as any[],
+  currentAttempt: undefined,
+  totalRetryCount: 0,
+  currentContext: undefined,
+};
+
+// 🏪 Store ────────────────────────────────────────────────────────────
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 export const useTransactionStore = create<TransactionStore>()(
   persist(
     (set) => ({
       transactions: [],
-      escrowState: DEFAULT_ESCROW_STATE,
+      escrowState: {
+        step: "idle",
+        errorStep: null,
+        errorMessage: null,
+        txHash: null,
+        attemptHistory: [],
+        currentAttempt: undefined,
+        totalRetryCount: 0,
+        currentContext: undefined,
+      },
 
       addTransaction: (record) =>
         set((s) => {
-          const entry: TxRecord = {
+          const entry = {
             ...record,
             timestamp: record.timestamp ?? new Date().toISOString(),
           };
           // Deduplicate by hash — replace if already exists (e.g. status update)
           const filtered = s.transactions.filter((t) => t.hash !== entry.hash);
           return {
-            transactions: [entry, ...filtered].slice(0, MAX_HISTORY),
+            transactions: [entry, ...filtered].slice(0, 200),
           };
         }),
 
@@ -111,7 +256,9 @@ export const useTransactionStore = create<TransactionStore>()(
             ...s.escrowState,
             step,
             // Clear error when transitioning out of error states or starting over
-            ...(step === "buyer_funding" || step === "seller_transferring" ? { errorStep: null, errorMessage: null } : {}),
+            ...(step === "buyer_funding" || step === "seller_transferring"
+              ? { errorStep: null, errorMessage: null }
+              : {}),
           },
         })),
 
@@ -124,7 +271,53 @@ export const useTransactionStore = create<TransactionStore>()(
           },
         })),
 
-      resetEscrow: () => set({ escrowState: DEFAULT_ESCROW_STATE }),
+      resetEscrow: () =>
+        set((s) => ({
+          escrowState: {
+            step: "idle",
+            errorStep: null,
+            errorMessage: null,
+            txHash: null,
+            attemptHistory: s.escrowState.attemptHistory,
+            currentAttempt: undefined,
+            totalRetryCount: s.escrowState.totalRetryCount,
+            currentContext: s.escrowState.currentContext,
+          },
+        })),
+
+      recordEscrowAttempt: (attempt) =>
+        set((s) => ({
+          escrowState: {
+            ...s.escrowState,
+            attemptHistory: [...s.escrowState.attemptHistory, attempt],
+            totalRetryCount: s.escrowState.totalRetryCount + 1,
+            currentAttempt: undefined,
+          },
+        })),
+
+      setCurrentAttempt: (attempt) =>
+        set((s) => ({
+          escrowState: {
+            ...s.escrowState,
+            currentAttempt: attempt,
+          },
+        })),
+
+      incrementRetryCount: () =>
+        set((s) => ({
+          escrowState: {
+            ...s.escrowState,
+            totalRetryCount: s.escrowState.totalRetryCount + 1,
+          },
+        })),
+
+      setEscrowContext: (context) =>
+        set((s) => ({
+          escrowState: {
+            ...s.escrowState,
+            currentContext: context ?? undefined,
+          },
+        })),
     }),
     {
       name: "kora-tx-history",


### PR DESCRIPTION
Fixes #591

Implements secondary escrow settlement retry ledger UI:

- Added retry ledger/step history showing all escrow step attempts
- Pass real position/buyer/seller params into retry (no more mock IDs)
- Show step ledger in overlay/drawer with attempt history
- Persist last escrow attempt in transaction store
- Display failed step highlighted in retry history
- Show attempt timestamps, tx hashes, and error messages

Changes:
- store/transactionStore.ts - Added attempt history ledger, current attempt tracking, retry count, and escrow context
- components/transactions/InProgressOverlay.tsx - Added retry ledger display, real params in retry button