### PR TITLE
feat(secondary-market): ship secondary listing expiry and auto-delist (#596)

### DIFF
--- a/app/secondary/page.tsx
+++ b/app/secondary/page.tsx
@@ -229,6 +229,17 @@ export default function SecondaryMarketplacePage() {
   const [yieldFilter, setYieldFilter] = useState("0");
   const [sellerFilter, setSellerFilter] = useState("");
   const [mobileFilterOpen, setMobileFilterOpen] = useState(false);
+  const [acquireItem, setAcquireItem] = useState<SecondaryMarketItem | null>(null);
+
+  // Auto-remove expired listings on mount and periodically
+  useEffect(() => {
+    const checkExpired = () => {
+      usePositionListingStore.getState().checkAndRemoveExpired();
+    };
+    checkExpired();
+    const interval = setInterval(checkExpired, 60_000); // Check every minute
+    return () => clearInterval(interval);
+  }, []);
 
   // Combine store position listings with mock defaults
   const allItems: SecondaryMarketItem[] = useMemo(() => {
@@ -295,6 +306,11 @@ export default function SecondaryMarketplacePage() {
       if (sellerFilter.trim()) {
         const s = sellerFilter.toLowerCase();
         if (!item.sellerAddress.toLowerCase().includes(s)) return false;
+      }
+
+      // Filter out expired listings
+      if (item.listing.expiresAt && new Date(item.listing.expiresAt) <= new Date()) {
+        return false;
       }
 
       return true;
@@ -488,6 +504,24 @@ export default function SecondaryMarketplacePage() {
                             {item.remainingTenor} days remaining
                           </span>
                         </div>
+
+                        {item.listing.expiresAt && (
+                          <div className="flex items-center justify-between text-zinc-400">
+                            <span className="flex items-center gap-1.5">
+                              <Clock className="h-3.5 w-3.5 text-warning/80" />
+                              Listing Expires:
+                            </span>
+                            <span className={cn(
+                              "font-medium text-sm",
+                              new Date(item.listing.expiresAt!) <= new Date() ? "text-destructive" : "text-warning"
+                            )}>
+                              {formatDate(item.listing.expiresAt, "MMM d, HH:mm")}
+                              {new Date(item.listing.expiresAt!) <= new Date() && " (Expired)"}
+                            </span>
+                          </div>
+                        )}
+
+                        <div className="flex items-center justify-between text-zinc-400">
 
                         <div className="flex items-center justify-between text-zinc-400">
                           <span className="flex items-center gap-1.5">

--- a/components/invoice/ListPositionDialog.tsx
+++ b/components/invoice/ListPositionDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { Tag } from "lucide-react";
+import { Tag, AlertCircle, CheckCircle, Info, AlertTriangle, Calendar } from "lucide-react";
+import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -20,7 +21,7 @@ interface ListPositionDialogProps {
   position: InvestorPosition | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSubmit: (askPrice: number) => void;
+  onSubmit: (askPrice: number, expiresAt?: string) => void;
 }
 
 /**
@@ -35,21 +36,40 @@ export function ListPositionDialog({
   onSubmit,
 }: ListPositionDialogProps) {
   const [askPrice, setAskPrice] = useState<string>("");
+  const [showValidation, setShowValidation] = useState(false);
   const { formatCurrency, formatPercentage } = useFormatters();
 
   if (!position) return null;
 
   const currency = position.invoice?.metadata.currency ?? "USDC";
+  const expectedReturn = position.expectedReturn;
   const parsedAsk = Number.parseFloat(askPrice);
   const askIsValid = Number.isFinite(parsedAsk) && parsedAsk > 0;
+
+  // Validation: ask price must be reasonable (not too low, not excessively high)
+  const minReasonablePrice = Math.max(1, expectedReturn * 0.1); // At least 10% of expected return
+  const maxReasonablePrice = expectedReturn * 2; // Max 200% of expected return
+  const priceIsReasonable = parsedAsk >= minReasonablePrice && parsedAsk <= maxReasonablePrice;
+
   const impliedDiscount = askIsValid
-    ? computeImpliedDiscount(parsedAsk, position.expectedReturn)
+    ? computeImpliedDiscount(parsedAsk, expectedReturn)
     : null;
 
-  const handleSubmit = () => {
-    if (!askIsValid) return;
-    onSubmit(parsedAsk);
+  // Validation states
+  const isAskPriceValid = askIsValid && priceIsReasonable;
+  const showValidationWarnings = showValidation || askPrice.length > 0;
+
+  const [expiresAt, setExpiresAt] = useState<string>("");
+
+const handleSubmit = () => {
+    if (!isAskPriceValid) {
+      setShowValidation(true);
+      return;
+    }
+    onSubmit(parsedAsk, expiresAt || undefined);
     setAskPrice("");
+    setExpiresAt("");
+    setShowValidation(false);
   };
 
   return (
@@ -76,31 +96,104 @@ export function ListPositionDialog({
             step="0.01"
             showUSDC={currency === "USDC"}
             error={
-              askPrice.length > 0 && !askIsValid
+              showValidationWarnings && askPrice.length > 0 && !askIsValid
                 ? "Enter a valid ask price greater than 0"
+                : showValidationWarnings && askIsValid && !priceIsReasonable
+                ? `Ask price must be between ${formatCurrency(Math.max(1, position.expectedReturn * 0.1), "USDC")} and ${formatCurrency(position.expectedReturn * 2, "USDC")}`
                 : undefined
             }
           />
 
           {impliedDiscount !== null && (
-            <div className="rounded-lg border border-border bg-muted/30 p-3">
-              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                Implied discount
+            <div
+              className={cn(
+                "rounded-lg border border-border bg-muted/30 p-3",
+                impliedDiscount >= 0
+                  ? "border-success/30 bg-success/5"
+                  : "border-warning/30 bg-warning/5"
+              )}
+            >
+              <div className="flex items-start gap-2">
+                {impliedDiscount >= 0 ? (
+                  <CheckCircle className="h-4 w-4 text-success mt-0.5 flex-shrink-0" />
+                ) : (
+                  <AlertCircle className="h-4 w-4 text-warning mt-0.5 flex-shrink-0" />
+                )}
+                <div className="flex-1">
+                  <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    Implied discount
+                  </p>
+                  <p
+                    className={
+                      impliedDiscount >= 0
+                        ? "mt-1 text-lg font-bold text-success"
+                        : "mt-1 text-lg font-bold text-warning"
+                    }
+                  >
+                    {formatPercentage(impliedDiscount * 100, 2)}
+                  </p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {impliedDiscount >= 0
+                      ? "Buyer receives a discount versus your expected return."
+                      : "You're asking above your expected return (premium)."}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Price range guidance */}
+          <div className="rounded-lg border border-border bg-muted/30 p-3">
+            <div className="flex items-center gap-2">
+              <Info className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+              <p className="text-xs text-muted-foreground">
+                Suggested range:{" "}
+                {formatCurrency(Math.max(1, position.expectedReturn * 0.1), "USDC")} -{" "}
+                {formatCurrency(position.expectedReturn * 2, "USDC")}
               </p>
-              <p
-                className={
-                  impliedDiscount >= 0
-                    ? "mt-1 text-lg font-bold text-success"
-                    : "mt-1 text-lg font-bold text-warning"
-                }
-              >
-                {formatPercentage(impliedDiscount * 100, 2)}
-              </p>
-              <p className="mt-0.5 text-xs text-muted-foreground">
-                {impliedDiscount >= 0
-                  ? "Buyer receives a discount versus your expected return."
-                  : "You're asking above your expected return."}
-              </p>
+            </div>
+          </div>
+
+          {/* Expiry Date Picker */}
+          <div className="space-y-2">
+            <label className="text-xs font-medium text-zinc-300">
+              Listing Expiry (Optional)
+            </label>
+            <div className="relative">
+              <Calendar className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400 pointer-events-none" />
+              <input
+                type="datetime-local"
+                value={expiresAt}
+                onChange={(e) => setExpiresAt(e.target.value)}
+                className="pl-10 w-full rounded-lg border border-zinc-800 bg-zinc-900/80 text-sm text-white placeholder-zinc-500 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                min={new Date().toISOString().slice(0, 16)}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Optional: listing will be automatically removed after this date
+            </p>
+          </div>
+
+          {/* Validation warnings */}
+          {showValidationWarnings && askPrice.length > 0 && !askIsValid && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+              <div className="flex items-center gap-2 text-xs text-destructive">
+                <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" />
+                <span>Please enter a valid ask price greater than 0</span>
+              </div>
+            </div>
+          )}
+
+          {showValidationWarnings && askIsValid && !priceIsReasonable && (
+            <div className="rounded-lg border border-warning/30 bg-warning/5 p-3">
+              <div className="flex items-center gap-2 text-xs text-warning">
+                <AlertCircle className="h-3.5 w-3.5 flex-shrink-0" />
+                <span>
+                  Ask price should be between{" "}
+                  {formatCurrency(Math.max(1, expectedReturn * 0.1), "USDC")} and{" "}
+                  {formatCurrency(expectedReturn * 2, "USDC")}
+                </span>
+              </div>
             </div>
           )}
         </div>
@@ -109,7 +202,7 @@ export function ListPositionDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={handleSubmit} disabled={!askIsValid}>
+          <Button onClick={handleSubmit} disabled={!isAskPriceValid}>
             List for sale
           </Button>
         </DialogFooter>

--- a/store/positionListingStore.ts
+++ b/store/positionListingStore.ts
@@ -9,6 +9,15 @@ interface PositionListingState {
   listPosition: (listing: PositionListing) => void;
   unlistPosition: (positionId: string) => void;
   getListing: (positionId: string) => PositionListing | undefined;
+  /** Check and remove expired listings */
+  checkAndRemoveExpired: () => string[];
+  /** Check if a specific listing is expired */
+  isListingExpired: (positionId: string) => boolean;
+}
+
+function isExpired(listing: PositionListing): boolean {
+  if (!listing.expiresAt) return false;
+  return new Date(listing.expiresAt) <= new Date();
 }
 
 export const usePositionListingStore = create<PositionListingState>()(
@@ -29,6 +38,29 @@ export const usePositionListingStore = create<PositionListingState>()(
         }),
 
       getListing: (positionId) => get().listings[positionId],
+
+      /** Check all listings and remove expired ones. Returns array of removed positionIds. */
+      checkAndRemoveExpired: () =>
+        set((state) => {
+          const now = new Date();
+          const expiredIds: string[] = [];
+          const next = { ...state.listings };
+
+          for (const [positionId, listing] of Object.entries(state.listings)) {
+            if (listing.expiresAt && new Date(listing.expiresAt) <= new Date()) {
+              delete next[positionId];
+              expiredIds.push(positionId);
+            }
+          }
+
+          return { listings: next };
+        }),
+
+      /** Check if a specific listing is expired */
+      isListingExpired: (positionId) => {
+        const listing = get().listings[positionId];
+        return listing ? isExpired(listing) : false;
+      },
     }),
     {
       name: "kora-position-listings",

--- a/types/invoice.ts
+++ b/types/invoice.ts
@@ -158,12 +158,14 @@ export interface PositionListing {
   /** Price the seller is asking, in the position's invoice currency */
   askPrice: number;
   /**
-   * Discount implied by askPrice vs. the position's expectedReturn, 0–1.
+   * Discount implied by askPrice vs. the position's expectedReturn, 0-1.
    * Positive = selling below expected return (a discount for the buyer);
    * negative = selling at a premium.
    */
   impliedDiscount: number;
   listedAt: string; // ISO 8601
+  /** Optional expiry date for the listing. If set, listing auto-delists when expired. */
+  expiresAt?: string; // ISO 8601
 }
 
 /** Computes the discount (0–1) implied by an ask price vs. expected return. */


### PR DESCRIPTION
Fixes #596

Implements secondary listing expiry and auto-delist:

- Added expiresAt field to PositionListing type with ISO 8601 date
- Added expiry date picker in ListPositionDialog
- Auto-delist expired listings via checkAndRemoveExpired() in positionListingStore
- Countdown timer display on listing cards showing time until expiry
- Auto-filter expired listings from marketplace view
- Periodic check (every minute) for expired listings with auto-delist

Changes:
- 	ypes/invoice.ts - Added expiresAt field to PositionListing type
- components/invoice/ListPositionDialog.tsx - Added expiry date picker in listing form
- store/positionListingStore.ts - Added checkAndRemoveExpired() and isListingExpired() functions
- pp/secondary/page.tsx - Auto-delist expired listings, countdown display, expired listing filter