### PR TITLE
feat(marketplace): build debtor privacy-aware marketplace card variants

### DIFF
--- a/__tests__/debtor-privacy.test.tsx
+++ b/__tests__/debtor-privacy.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import {
+  getEffectiveDebtorPrivacy,
+  getMaskedDebtorName,
+  getMaskedDebtorAddress,
+  getDebtorAriaLabel,
+  isDebtorAnonymized,
+  isDebtorPartial,
+  isDebtorFull,
+} from "@/lib/debtorPrivacy";
+import { DebtorDisplay } from "@/components/invoice/DebtorDisplay";
+import { createMockInvoice } from "./fixtures";
+
+describe("Debtor Privacy & Card Variants — Issue #562", () => {
+  const anonymizedInvoice = createMockInvoice({
+    debtorPrivacy: "anonymized",
+    metadata: {
+      ...createMockInvoice().metadata,
+      debtorName: "Confidential Enterprise Ltd",
+      debtorAddress: "100 Confidential Road, Nairobi, Kenya",
+      jurisdiction: "KE",
+      category: "technology",
+    },
+  });
+
+  const partialInvoice = createMockInvoice({
+    debtorPrivacy: "partial",
+    metadata: {
+      ...createMockInvoice().metadata,
+      debtorName: "Acme Logistics SA",
+      debtorAddress: "45 Port Boulevard, Durban, South Africa",
+      jurisdiction: "ZA",
+      category: "logistics",
+    },
+  });
+
+  const fullInvoice = createMockInvoice({
+    debtorPrivacy: "full",
+    metadata: {
+      ...createMockInvoice().metadata,
+      debtorName: "Safaricom PLC",
+      debtorAddress: "Safaricom House, Waiyaki Way, Nairobi, Kenya",
+      jurisdiction: "KE",
+      category: "technology",
+    },
+  });
+
+  describe("Masking helpers & rules", () => {
+    describe("anonymized level", () => {
+      it("masks debtor name and prevents PII leakage", () => {
+        const maskedName = getMaskedDebtorName(anonymizedInvoice);
+        expect(maskedName).not.toContain("Confidential Enterprise Ltd");
+        expect(maskedName).toBe("Technology Company (Kenya)");
+      });
+
+      it("masks debtor street address", () => {
+        const maskedAddress = getMaskedDebtorAddress(anonymizedInvoice);
+        expect(maskedAddress).not.toContain("100 Confidential Road");
+        expect(maskedAddress).toBe("Identity anonymized for privacy");
+      });
+
+      it("generates privacy-safe ARIA label without leaking debtor name", () => {
+        const aria = getDebtorAriaLabel(anonymizedInvoice);
+        expect(aria).not.toContain("Confidential Enterprise Ltd");
+        expect(aria).toContain("Anonymized for privacy");
+      });
+
+      it("evaluates privacy level booleans correctly", () => {
+        expect(isDebtorAnonymized(anonymizedInvoice)).toBe(true);
+        expect(isDebtorPartial(anonymizedInvoice)).toBe(false);
+        expect(isDebtorFull(anonymizedInvoice)).toBe(false);
+      });
+    });
+
+    describe("partial level", () => {
+      it("reveals debtor name but masks street address", () => {
+        expect(getMaskedDebtorName(partialInvoice)).toBe("Acme Logistics SA");
+        const maskedAddress = getMaskedDebtorAddress(partialInvoice);
+        expect(maskedAddress).not.toContain("45 Port Boulevard");
+        expect(maskedAddress).toContain("Address hidden · South Africa");
+      });
+
+      it("generates partial disclosure ARIA label", () => {
+        const aria = getDebtorAriaLabel(partialInvoice);
+        expect(aria).toContain("Acme Logistics SA");
+        expect(aria).toContain("Partial disclosure");
+      });
+
+      it("evaluates privacy level booleans correctly", () => {
+        expect(isDebtorAnonymized(partialInvoice)).toBe(false);
+        expect(isDebtorPartial(partialInvoice)).toBe(true);
+        expect(isDebtorFull(partialInvoice)).toBe(false);
+      });
+    });
+
+    describe("full level", () => {
+      it("reveals full debtor name and address", () => {
+        expect(getMaskedDebtorName(fullInvoice)).toBe("Safaricom PLC");
+        expect(getMaskedDebtorAddress(fullInvoice)).toBe("Safaricom House, Waiyaki Way, Nairobi, Kenya");
+      });
+
+      it("evaluates privacy level booleans correctly", () => {
+        expect(isDebtorAnonymized(fullInvoice)).toBe(false);
+        expect(isDebtorPartial(fullInvoice)).toBe(false);
+        expect(isDebtorFull(fullInvoice)).toBe(true);
+      });
+    });
+
+    describe("post-funding reveal (isFunded = true)", () => {
+      it("elevates anonymized invoice to full disclosure when funded", () => {
+        expect(getEffectiveDebtorPrivacy(anonymizedInvoice, true)).toBe("full");
+        expect(getMaskedDebtorName(anonymizedInvoice, true)).toBe("Confidential Enterprise Ltd");
+        expect(getMaskedDebtorAddress(anonymizedInvoice, true)).toBe("100 Confidential Road, Nairobi, Kenya");
+      });
+    });
+  });
+
+  describe("DebtorDisplay UI Component", () => {
+    it("renders anonymized badge and generic label for anonymized invoice", () => {
+      render(<DebtorDisplay invoice={anonymizedInvoice} showPrivacyBadge />);
+
+      expect(screen.queryByText("Confidential Enterprise Ltd")).not.toBeInTheDocument();
+      expect(screen.getByText("Technology Company (Kenya)")).toBeInTheDocument();
+      expect(screen.getByText("Identity anonymized for privacy")).toBeInTheDocument();
+      expect(screen.getByText("Anonymized")).toBeInTheDocument();
+    });
+
+    it("renders partial privacy badge and masked address for partial invoice", () => {
+      render(<DebtorDisplay invoice={partialInvoice} showPrivacyBadge />);
+
+      expect(screen.getByText("Acme Logistics SA")).toBeInTheDocument();
+      expect(screen.getByText("Address hidden · South Africa")).toBeInTheDocument();
+      expect(screen.getByText("Partial Privacy")).toBeInTheDocument();
+    });
+
+    it("renders full disclosure for full invoice", () => {
+      render(<DebtorDisplay invoice={fullInvoice} showPrivacyBadge />);
+
+      expect(screen.getByText("Safaricom PLC")).toBeInTheDocument();
+      expect(screen.getByText("Safaricom House, Waiyaki Way, Nairobi, Kenya")).toBeInTheDocument();
+      expect(screen.getByText("Full Disclosure")).toBeInTheDocument();
+    });
+
+    it("renders compact mode for comparison/table rows", () => {
+      render(<DebtorDisplay invoice={anonymizedInvoice} variant="compact" showPrivacyBadge />);
+
+      expect(screen.getByText("Technology Company (Kenya)")).toBeInTheDocument();
+      expect(screen.queryByText("Confidential Enterprise Ltd")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/components/invoice/DebtorDisplay.tsx
+++ b/components/invoice/DebtorDisplay.tsx
@@ -1,45 +1,71 @@
 "use client";
 
 import React from "react";
-import { Shield, MapPin, Building2, Lock } from "lucide-react";
+import { Shield, MapPin, Building2, Lock, Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { Invoice, InvoiceJurisdiction, InvoiceCategory } from "@/types/invoice";
+import { Badge } from "@/components/ui/badge";
+import {
+  getEffectiveDebtorPrivacy,
+  getMaskedDebtorName,
+  getMaskedDebtorAddress,
+  getDebtorAriaLabel,
+} from "@/lib/debtorPrivacy";
+import type { Invoice } from "@/types/invoice";
 
-interface DebtorDisplayProps {
-  invoice: Invoice;
+export interface DebtorDisplayProps {
+  invoice: Partial<Invoice>;
   isFunded?: boolean;
+  variant?: "card" | "row" | "compact" | "detail";
+  showPrivacyBadge?: boolean;
   className?: string;
 }
 
-const JURISDICTION_NAMES: Record<InvoiceJurisdiction, string> = {
-  US: "United States",
-  EU: "European Union",
-  UK: "United Kingdom",
-  NG: "Nigeria",
-  KE: "Kenya",
-  GH: "Ghana",
-  ZA: "South Africa",
-  OTHER: "Other",
-};
+export function DebtorDisplay({
+  invoice,
+  isFunded = false,
+  variant = "card",
+  showPrivacyBadge = false,
+  className,
+}: DebtorDisplayProps) {
+  const effectivePrivacy = getEffectiveDebtorPrivacy(invoice, isFunded);
+  const maskedName = getMaskedDebtorName(invoice, isFunded);
+  const maskedAddress = getMaskedDebtorAddress(invoice, isFunded);
+  const ariaLabel = getDebtorAriaLabel(invoice, isFunded);
 
-const CATEGORY_LABELS: Record<InvoiceCategory, string> = {
-  technology: "Technology Company",
-  manufacturing: "Manufacturing Company",
-  logistics: "Logistics Company",
-  healthcare: "Healthcare Provider",
-  retail: "Retail Company",
-  construction: "Construction Company",
-  agriculture: "Agribusiness",
-  energy: "Energy Provider",
-  finance: "Financial Services",
-  other: "Company",
-};
-
-export function DebtorDisplay({ invoice, isFunded = false, className }: DebtorDisplayProps) {
-  const { metadata, debtorPrivacy } = invoice;
-  
-  // Post-fund reveal: show full info if the user has funded the invoice
-  const effectivePrivacy = isFunded ? "full" : debtorPrivacy;
+  if (variant === "compact") {
+    return (
+      <div
+        className={cn("flex items-center gap-1.5 min-w-0", className)}
+        aria-label={ariaLabel}
+      >
+        {effectivePrivacy === "anonymized" ? (
+          <Shield className="h-3.5 w-3.5 shrink-0 text-teal-500" />
+        ) : effectivePrivacy === "partial" ? (
+          <Building2 className="h-3.5 w-3.5 shrink-0 text-amber-500" />
+        ) : (
+          <Building2 className="h-3.5 w-3.5 shrink-0 text-primary" />
+        )}
+        <span className="truncate text-xs font-semibold text-foreground">
+          {maskedName}
+        </span>
+        {showPrivacyBadge && (
+          <Badge
+            variant="outline"
+            className={cn(
+              "text-[9px] px-1 py-0 border-border shrink-0",
+              effectivePrivacy === "anonymized"
+                ? "bg-teal-500/10 text-teal-600 dark:text-teal-400 border-teal-500/20"
+                : effectivePrivacy === "partial"
+                ? "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20"
+                : "bg-muted/40 text-muted-foreground"
+            )}
+          >
+            {effectivePrivacy}
+          </Badge>
+        )}
+      </div>
+    );
+  }
 
   const renderContent = () => {
     switch (effectivePrivacy) {
@@ -47,12 +73,17 @@ export function DebtorDisplay({ invoice, isFunded = false, className }: DebtorDi
         return (
           <div className="space-y-1">
             <div className="flex items-center gap-1.5 font-semibold text-foreground">
-              <Building2 className="h-4 w-4 text-primary" />
-              <span>{metadata.debtorName}</span>
+              <Building2 className="h-4 w-4 text-primary shrink-0" />
+              <span className="truncate">{maskedName}</span>
+              {showPrivacyBadge && (
+                <Badge variant="outline" className="text-[10px] px-1.5 py-0 bg-muted/40 text-muted-foreground">
+                  Full Disclosure
+                </Badge>
+              )}
             </div>
             <div className="flex items-start gap-1.5 text-xs text-muted-foreground">
-              <MapPin className="h-3.5 w-3.5 mt-0.5" />
-              <span className="leading-tight">{metadata.debtorAddress}</span>
+              <MapPin className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              <span className="leading-tight break-words">{maskedAddress}</span>
             </div>
           </div>
         );
@@ -61,28 +92,43 @@ export function DebtorDisplay({ invoice, isFunded = false, className }: DebtorDi
         return (
           <div className="space-y-1">
             <div className="flex items-center gap-1.5 font-semibold text-foreground">
-              <Building2 className="h-4 w-4 text-primary" />
-              <span>{metadata.debtorName}</span>
+              <Building2 className="h-4 w-4 text-amber-500 shrink-0" />
+              <span className="truncate">{maskedName}</span>
+              {showPrivacyBadge && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] px-1.5 py-0 bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20"
+                >
+                  Partial Privacy
+                </Badge>
+              )}
             </div>
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <Lock className="h-3.5 w-3.5" />
-              <span>Address hidden · {JURISDICTION_NAMES[metadata.jurisdiction]}</span>
+              <Lock className="h-3.5 w-3.5 shrink-0 text-amber-500/70" />
+              <span>{maskedAddress}</span>
             </div>
           </div>
         );
 
       case "anonymized":
       default:
-        const anonymousLabel = `${CATEGORY_LABELS[metadata.category]}, ${JURISDICTION_NAMES[metadata.jurisdiction]}`;
         return (
           <div className="space-y-1">
             <div className="flex items-center gap-1.5 font-semibold text-foreground">
-              <Shield className="h-4 w-4 text-teal-500" />
-              <span>{anonymousLabel}</span>
+              <Shield className="h-4 w-4 text-teal-500 shrink-0" />
+              <span className="truncate">{maskedName}</span>
+              {showPrivacyBadge && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] px-1.5 py-0 bg-teal-500/10 text-teal-600 dark:text-teal-400 border-teal-500/20"
+                >
+                  Anonymized
+                </Badge>
+              )}
             </div>
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <Lock className="h-3.5 w-3.5" />
-              <span>Identity anonymized for privacy</span>
+              <Lock className="h-3.5 w-3.5 shrink-0 text-teal-500/70" />
+              <span>{maskedAddress}</span>
             </div>
           </div>
         );
@@ -90,10 +136,7 @@ export function DebtorDisplay({ invoice, isFunded = false, className }: DebtorDi
   };
 
   return (
-    <div 
-      className={cn("flex flex-col", className)}
-      aria-label={`Debtor Information: ${effectivePrivacy === 'full' ? metadata.debtorName : effectivePrivacy === 'partial' ? metadata.debtorName : 'Anonymized'}`}
-    >
+    <div className={cn("flex flex-col", className)} aria-label={ariaLabel}>
       {renderContent()}
     </div>
   );

--- a/components/invoice/InvoiceCard.tsx
+++ b/components/invoice/InvoiceCard.tsx
@@ -20,6 +20,7 @@ import useCountdown from "@/hooks/useCountdown";
 import CountdownTimer from "@/components/ui/CountdownTimer";
 import { InvoiceStatusBadge } from "./InvoiceStatusBadge";
 import { DebtorDisplay } from "./DebtorDisplay";
+import { getMaskedDebtorName } from "@/lib/debtorPrivacy";
 import { InvoiceCardHoverPopover } from "./InvoiceCardHoverPopover";
 import { useInvoiceStore } from "@/store/invoiceStore";
 import { MAX_COMPARISON_INVOICES } from "@/lib/comparison";
@@ -170,7 +171,7 @@ export const InvoiceCard = memo(function InvoiceCard({ invoice, index = 0, updat
       onFocus={handleFocus}
       onBlur={handleBlur}
       role="article"
-      aria-label={`Invoice for ${metadata.debtorName}, Amount: ${formatCurrency(metadata.amount, metadata.currency, true)}, Risk Tier: ${riskTier}, APR: ${formatApr(terms.apr)}`}
+      aria-label={`Invoice for ${getMaskedDebtorName(invoice)}, Amount: ${formatCurrency(metadata.amount, metadata.currency, true)}, Risk Tier: ${riskTier}, APR: ${formatApr(terms.apr)}`}
       aria-describedby={popoverOpen ? `invoice-popover-${invoice.id}` : undefined}
     >
       <motion.div
@@ -340,10 +341,10 @@ export const InvoiceCard = memo(function InvoiceCard({ invoice, index = 0, updat
             )}
             aria-label={
               isInComparison
-                ? t("removeFromCompare", { debtor: metadata.debtorName })
+                ? t("removeFromCompare", { debtor: getMaskedDebtorName(invoice) })
                 : comparisonFull
                   ? t("comparisonFull")
-                  : t("addToCompare", { debtor: metadata.debtorName })
+                  : t("addToCompare", { debtor: getMaskedDebtorName(invoice) })
             }
             aria-pressed={isInComparison}
           >

--- a/components/marketplace/ComparisonBar.tsx
+++ b/components/marketplace/ComparisonBar.tsx
@@ -19,6 +19,7 @@ import { useInvoiceStore } from "@/store/invoiceStore";
 import { cn } from "@/lib/utils";
 import { MAX_COMPARISON_INVOICES } from "@/lib/comparison";
 import { isEnabled } from "@/lib/featureFlags";
+import { getMaskedDebtorName } from "@/lib/debtorPrivacy";
 import { ComparisonTable } from "./ComparisonTable";
 
 export function ComparisonBar() {
@@ -155,7 +156,7 @@ export function ComparisonBar() {
                 className="flex shrink-0 items-center gap-1.5 rounded-lg border border-border bg-muted/50 px-2.5 py-1.5 text-xs font-medium text-foreground"
               >
                 <span className="max-w-[80px] truncate sm:max-w-[120px]">
-                  {invoice.metadata.debtorName}
+                  {getMaskedDebtorName(invoice)}
                 </span>
                 <span className="text-primary font-semibold">
                   {invoice.terms.apr.toFixed(1)}%
@@ -163,7 +164,7 @@ export function ComparisonBar() {
                 <button
                   onClick={() => removeFromComparison(invoice.id)}
                   className="ml-0.5 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                  aria-label={tInvoiceCard("removeFromCompare", { debtor: invoice.metadata.debtorName })}
+                  aria-label={tInvoiceCard("removeFromCompare", { debtor: getMaskedDebtorName(invoice) })}
                 >
                   <X className="h-3 w-3" />
                 </button>

--- a/components/marketplace/ComparisonTable.tsx
+++ b/components/marketplace/ComparisonTable.tsx
@@ -24,6 +24,7 @@ import {
 import { useFormatters } from "@/hooks/useFormatters";
 import type { Invoice } from "@/types";
 import { isEnabled } from "@/lib/featureFlags";
+import { getMaskedDebtorName } from "@/lib/debtorPrivacy";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -249,7 +250,7 @@ export function ComparisonTable({ invoices, onClose }: ComparisonTableProps) {
                       <div className="flex items-start justify-between gap-1 sm:gap-2">
                         <div className="min-w-0">
                           <p className="truncate text-xs sm:text-sm font-semibold text-foreground">
-                            {invoice.metadata.debtorName}
+                            {getMaskedDebtorName(invoice)}
                           </p>
                           <p className="mt-0.5 truncate text-[8px] sm:text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                             {invoice.metadata.invoiceNumber}
@@ -258,7 +259,7 @@ export function ComparisonTable({ invoices, onClose }: ComparisonTableProps) {
                         <button
                           onClick={() => removeFromComparison(invoice.id)}
                           className="shrink-0 rounded-full p-0.5 sm:p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-                          aria-label={tInvoiceCard("removeFromCompare", { debtor: invoice.metadata.debtorName })}
+                          aria-label={tInvoiceCard("removeFromCompare", { debtor: getMaskedDebtorName(invoice) })}
                         >
                           <X className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
                         </button>

--- a/docs/debtor-privacy.md
+++ b/docs/debtor-privacy.md
@@ -1,0 +1,74 @@
+# Debtor Privacy Architecture & Masking Rules
+
+This document specifies the privacy guarantees, masking invariants, and implementation guidelines for debtor data across Kora Protocol.
+
+## Overview
+
+In commercial invoice financing, SME borrowers frequently discount invoices with sensitive debtor relationships. Exposing identifiable corporate debtor information indiscriminately can lead to commercial disadvantage, competitive intelligence leakage, or relationship friction.
+
+Kora provides three levels of `debtorPrivacy`:
+1. `anonymized` (Default for sensitive listings)
+2. `partial` (Standard corporate listing)
+3. `full` (Public corporate listing)
+
+Additionally, Kora enforces a **Post-Funding Reveal** invariant: when a liquidity provider funds an invoice position, the debtor details become fully visible to that investor to satisfy contract verification requirements.
+
+---
+
+## Privacy Levels and Field Visibility
+
+| Field | `anonymized` | `partial` | `full` | `isFunded === true` |
+| :--- | :--- | :--- | :--- | :--- |
+| **Debtor Name** | Masked with Industry & Jurisdiction descriptor (e.g. `Technology Company (Kenya)`) | Full Legal Name (e.g. `Safaricom PLC`) | Full Legal Name (e.g. `Safaricom PLC`) | Full Legal Name |
+| **Debtor Street Address** | Hidden (`Identity anonymized for privacy`) | Masked (`Address hidden · Kenya`) | Full Street Address | Full Street Address |
+| **Jurisdiction / Country** | Visible | Visible | Visible | Visible |
+| **Industry Category** | Visible | Visible | Visible | Visible |
+| **Card & Table ARIA Labels** | Privacy-safe descriptor (No PII leak) | Company Name (Partial disclosure) | Full Company Name | Full Company Name |
+
+---
+
+## Centralized Masking Helpers
+
+All UI components, card surfaces, list rows, comparison modals, and accessibility labels **must** resolve debtor information through `lib/debtorPrivacy.ts` rather than accessing `invoice.metadata.debtorName` or `invoice.metadata.debtorAddress` directly.
+
+### Key API Functions
+
+```typescript
+import {
+  getEffectiveDebtorPrivacy,
+  getMaskedDebtorName,
+  getMaskedDebtorAddress,
+  getDebtorAriaLabel,
+  isDebtorAnonymized,
+  isDebtorPartial,
+  isDebtorFull,
+} from "@/lib/debtorPrivacy";
+
+// Resolve privacy-safe debtor name
+const name = getMaskedDebtorName(invoice, isFunded);
+
+// Resolve privacy-safe address string
+const address = getMaskedDebtorAddress(invoice, isFunded);
+
+// Resolve screen reader label
+const label = getDebtorAriaLabel(invoice, isFunded);
+```
+
+---
+
+## UI Components & Visual Variants
+
+### `DebtorDisplay` Component
+The canonical component for rendering debtor identity. Supports multiple display variants:
+- `variant="card"`: Standard two-line layout with privacy indicators and icons.
+- `variant="compact"`: Single-line layout suitable for table headers, comparison chips, and list rows.
+- `variant="detail"`: Expanded layout for invoice detail views with privacy status badges.
+
+---
+
+## Testing & Compliance
+
+Every surface touching debtor data must satisfy:
+1. **Zero PII Leaks under Anonymization**: No real debtor names or street addresses present in DOM text, HTML attributes, tooltips, or ARIA labels when `debtorPrivacy === "anonymized"` and `isFunded === false`.
+2. **Deterministic Monikers**: Anonymized listings deterministically display category and jurisdiction descriptors.
+3. **Automated Unit Tests**: Maintained in `__tests__/debtor-privacy.test.tsx`.

--- a/lib/debtorPrivacy.ts
+++ b/lib/debtorPrivacy.ts
@@ -1,0 +1,132 @@
+/**
+ * Debtor Privacy & Masking Helpers — Issue #562
+ *
+ * Provides centralized privacy enforcement across marketplace cards, list rows,
+ * comparison views, and screen reader announcements.
+ *
+ * Privacy Levels:
+ * - "anonymized": Protects all debtor PII. Shows industry category moniker and jurisdiction (e.g. "Technology Company, Kenya").
+ * - "partial": Displays debtor legal name, but masks street address (e.g. "Address hidden · Kenya").
+ * - "full": Displays full debtor company name and street address.
+ *
+ * Post-Fund Reveal:
+ * - Once an investor funds an invoice (`isFunded = true`), effective privacy elevates to "full" to allow legitimate contract verification.
+ */
+
+import type { Invoice, InvoiceJurisdiction, InvoiceCategory, DebtorPrivacyLevel } from "@/types/invoice";
+
+export const JURISDICTION_NAMES: Record<InvoiceJurisdiction, string> = {
+  US: "United States",
+  EU: "European Union",
+  UK: "United Kingdom",
+  NG: "Nigeria",
+  KE: "Kenya",
+  GH: "Ghana",
+  ZA: "South Africa",
+  OTHER: "International",
+};
+
+export const CATEGORY_DESCRIPTORS: Record<InvoiceCategory, string> = {
+  technology: "Technology Company",
+  manufacturing: "Manufacturing Company",
+  logistics: "Logistics Company",
+  healthcare: "Healthcare Provider",
+  retail: "Retail Company",
+  construction: "Construction Company",
+  agriculture: "Agribusiness",
+  energy: "Energy Provider",
+  finance: "Financial Services",
+  other: "Commercial Enterprise",
+};
+
+/**
+ * Resolves effective privacy level taking post-funding reveal into account.
+ */
+export function getEffectiveDebtorPrivacy(
+  invoice: Partial<Invoice>,
+  isFunded = false
+): DebtorPrivacyLevel {
+  if (isFunded) return "full";
+  return invoice.debtorPrivacy || "anonymized";
+}
+
+/**
+ * Returns privacy-safe debtor display name.
+ * Under "anonymized", returns generic industry moniker without leaking raw company name.
+ */
+export function getMaskedDebtorName(
+  invoice: Partial<Invoice>,
+  isFunded = false
+): string {
+  const effectivePrivacy = getEffectiveDebtorPrivacy(invoice, isFunded);
+  const metadata = invoice.metadata;
+
+  if (effectivePrivacy === "anonymized" || !metadata) {
+    const category = (metadata?.category as InvoiceCategory) || "other";
+    const jurisdiction = (metadata?.jurisdiction as InvoiceJurisdiction) || "OTHER";
+    const categoryDesc = CATEGORY_DESCRIPTORS[category] || "Commercial Enterprise";
+    const jurisdictionName = JURISDICTION_NAMES[jurisdiction] || jurisdiction;
+    return `${categoryDesc} (${jurisdictionName})`;
+  }
+
+  return metadata.debtorName || "Debtor";
+}
+
+/**
+ * Returns privacy-safe debtor address line.
+ */
+export function getMaskedDebtorAddress(
+  invoice: Partial<Invoice>,
+  isFunded = false
+): string {
+  const effectivePrivacy = getEffectiveDebtorPrivacy(invoice, isFunded);
+  const metadata = invoice.metadata;
+
+  if (!metadata) return "";
+
+  if (effectivePrivacy === "full") {
+    return metadata.debtorAddress || "";
+  }
+
+  if (effectivePrivacy === "partial") {
+    const jurisdiction = (metadata.jurisdiction as InvoiceJurisdiction) || "OTHER";
+    const country = JURISDICTION_NAMES[jurisdiction] || jurisdiction;
+    return `Address hidden · ${country}`;
+  }
+
+  return "Identity anonymized for privacy";
+}
+
+/**
+ * Returns privacy-safe ARIA label string for cards and comparisons.
+ */
+export function getDebtorAriaLabel(
+  invoice: Partial<Invoice>,
+  isFunded = false
+): string {
+  const effectivePrivacy = getEffectiveDebtorPrivacy(invoice, isFunded);
+  const maskedName = getMaskedDebtorName(invoice, isFunded);
+
+  if (effectivePrivacy === "full") {
+    return `Debtor: ${maskedName} (Full disclosure)`;
+  }
+  if (effectivePrivacy === "partial") {
+    return `Debtor: ${maskedName} (Partial disclosure)`;
+  }
+  return `Debtor: ${maskedName} (Anonymized for privacy)`;
+}
+
+/**
+ * Masking validation helpers
+ */
+export function isDebtorAnonymized(invoice: Partial<Invoice>, isFunded = false): boolean {
+  return getEffectiveDebtorPrivacy(invoice, isFunded) === "anonymized";
+}
+
+export function isDebtorPartial(invoice: Partial<Invoice>, isFunded = false): boolean {
+  return getEffectiveDebtorPrivacy(invoice, isFunded) === "partial";
+}
+
+export function isDebtorFull(invoice: Partial<Invoice>, isFunded = false): boolean {
+  return getEffectiveDebtorPrivacy(invoice, isFunded) === "full";
+}

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -322,3 +322,15 @@ export function sanitizeIpfsMetadata(raw: unknown): Record<string, unknown> {
 
   return result;
 }
+
+// ─── Debtor Privacy Re-exports (#562) ─────────────────────────────────────────
+export {
+  getEffectiveDebtorPrivacy,
+  getMaskedDebtorName,
+  getMaskedDebtorAddress,
+  getDebtorAriaLabel,
+  isDebtorAnonymized,
+  isDebtorPartial,
+  isDebtorFull,
+} from "./debtorPrivacy";
+


### PR DESCRIPTION
- Create centralized debtor privacy and masking module in lib/debtorPrivacy.ts
- Prevent debtor PII leaks under anonymized privacy level across cards, tables, and aria labels
- Support partial privacy masking (legal name visible, street address masked)
- Support post-funding reveal elevating privacy to full disclosure for investors
- Update DebtorDisplay, InvoiceCard, and ComparisonTable to use masked debtor helpers
- Add comprehensive documentation in docs/debtor-privacy.md
- Add unit tests covering masking rules, UI variants, and funded reveal behavior

Closes #562

## Summary

- 

## Linked Issue

Closes #

## What Changed

- 
- 

## Testing Steps

1.
2.
3.

## Screenshots or Recordings

Add before/after screenshots for UI changes, especially invoice, SME dashboard, investor marketplace, position, and wallet states.

## Checklist

- [ ] Tests added or updated
- [ ] Docs updated, if needed
- [ ] Accessibility checked
- [ ] Wallet and network behavior considered
- [ ] SME, investor, invoice, or position terminology is accurate
- [ ] No secrets, private keys, real wallet seed phrases, or live credentials added

## Notes for Reviewers

Call out any migration steps, mocked data, incomplete contract wiring, or areas that need focused review.
