### PR TITLE
feat(wallet): build read-only watch-address mode without signing

### DIFF
--- a/components/wallet/WalletButton.tsx
+++ b/components/wallet/WalletButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, LogOut, ExternalLink, Bell, Coins, Loader2, AlertCircle, RefreshCw, UserCheck } from "lucide-react";
+import { ChevronDown, LogOut, ExternalLink, Bell, Coins, Loader2, AlertCircle, RefreshCw, UserCheck, Eye } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/CopyButton";
@@ -35,7 +35,9 @@ export function WalletButton() {
     kitSessionActive,
     showReconnectPrompt,
     isReconnecting,
+    isWatchMode,
     disconnectWallet,
+    exitWatchMode,
     manualReconnect,
     fundWalletOnTestnet,
     refreshBalance,
@@ -207,7 +209,15 @@ export function WalletButton() {
 
           {address && (
             <div className="mb-3 space-y-1 rounded-lg bg-card p-3">
-              <p className="text-xs text-muted-foreground">{t("balances")}</p>
+              <div className="flex items-center justify-between">
+                <p className="text-xs text-muted-foreground">{t("balances")}</p>
+                {isWatchMode && (
+                  <span className="flex items-center gap-1 rounded bg-blue-500/10 px-1.5 py-0.5 text-xs text-blue-500">
+                    <Eye className="h-3 w-3" />
+                    Watch Only
+                  </span>
+                )}
+              </div>
               {balancesLoading && walletBalances.every((b) => b.rawAmount === 0) ? (
                 <div className="space-y-1.5 py-1">
                   <div className="h-4 w-20 rounded bg-muted animate-pulse" />
@@ -239,42 +249,57 @@ export function WalletButton() {
             >
               <ExternalLink className="h-3.5 w-3.5" /> {t("viewExplorer")}
             </a>
-            <button
-              type="button"
-              onClick={() => {
-                setSettingsOpen(true);
-                setOpen(false);
-              }}
-              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
-            >
-              <Bell className="h-3.5 w-3.5" /> {t("notificationSettings")}
-            </button>
-            {isTestnet && (
+            {isWatchMode ? (
               <button
                 type="button"
-                disabled={isFunding || hasNetworkMismatch}
-                onClick={handleFundTestnetAccount}
-                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-60"
+                onClick={() => {
+                  exitWatchMode();
+                  setOpen(false);
+                }}
+                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-destructive hover:bg-destructive/10"
               >
-                {isFunding ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Coins className="h-3.5 w-3.5" />
-                )}
-                {isFunding ? t("funding") : t("fundTestnet")}
+                <LogOut className="h-3.5 w-3.5" /> Exit Watch Mode
               </button>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSettingsOpen(true);
+                    setOpen(false);
+                  }}
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  <Bell className="h-3.5 w-3.5" /> {t("notificationSettings")}
+                </button>
+                {isTestnet && (
+                  <button
+                    type="button"
+                    disabled={isFunding || hasNetworkMismatch}
+                    onClick={handleFundTestnetAccount}
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-60"
+                  >
+                    {isFunding ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Coins className="h-3.5 w-3.5" />
+                    )}
+                    {isFunding ? t("funding") : t("fundTestnet")}
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOpen(false);
+                    setWalletModalOpen(true);
+                  }}
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                  data-testid="switch-account-button"
+                >
+                  <UserCheck className="h-3.5 w-3.5" /> Switch Account
+                </button>
+              </>
             )}
-            <button
-              type="button"
-              onClick={() => {
-                setOpen(false);
-                setWalletModalOpen(true);
-              }}
-              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
-              data-testid="switch-account-button"
-            >
-              <UserCheck className="h-3.5 w-3.5" /> Switch Account
-            </button>
             <button
               type="button"
               onClick={() => setConfirmDisconnectOpen(true)}

--- a/components/wallet/WalletConnectModal.tsx
+++ b/components/wallet/WalletConnectModal.tsx
@@ -396,6 +396,35 @@ export function WalletConnectModal() {
           )}
         </AnimatePresence>
 
+        <div className="mt-4 border-t border-border pt-4">
+          <div className="text-center">
+            <p className="mb-2 text-xs text-muted-foreground">Or browse in read-only mode</p>
+            <div className="flex items-center justify-center gap-2">
+              <input
+                type="text"
+                placeholder="Paste a G-address to watch..."
+                className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                id="watch-address-input"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  const input = document.getElementById("watch-address-input") as HTMLInputElement;
+                  const addr = input?.value?.trim();
+                  if (addr && addr.startsWith("G") && addr.length === 56) {
+                    useWalletStore.getState().enterWatchMode(addr);
+                    setWalletModalOpen(false);
+                    input.value = "";
+                  }
+                }}
+                className="rounded-md bg-blue-500/10 px-3 py-1.5 text-xs text-blue-500 hover:bg-blue-500/20 transition-colors"
+              >
+                Watch
+              </button>
+            </div>
+          </div>
+        </div>
+
         <p className="mt-4 text-center text-xs text-muted-foreground">
           {t("termsPrefix")}{" "}
           <a href="/terms" className="text-muted-foreground hover:text-foreground transition-colors">

--- a/hooks/useWallet.ts
+++ b/hooks/useWallet.ts
@@ -83,6 +83,7 @@ export function useWallet() {
     verifiedAt,
     kitSessionActive,
     kycStatus,
+    isWatchMode,
     connect,
     disconnect,
     setBalance,
@@ -94,6 +95,8 @@ export function useWallet() {
     setKitSessionActive,
     setNetwork,
     setKycStatus,
+    enterWatchMode,
+    exitWatchMode,
   } = useWalletStore();
   const router = useRouter();
   const pathname = usePathname();
@@ -425,6 +428,7 @@ export function useWallet() {
   const signTransaction = useCallback(
     async (xdr: string): Promise<string> => {
       if (!isConnected) throw new Error("Wallet not connected");
+      if (isWatchMode) throw new Error("WATCH_MODE: Signing is disabled in read-only watch mode");
       updateActivity();
 
       if (env.NEXT_PUBLIC_ENABLE_MOCK_DATA || xdr.startsWith("mock_")) {
@@ -729,6 +733,8 @@ export function useWallet() {
     showReconnectPrompt,
     /** Whether a manual reconnect attempt is currently in progress. */
     isReconnecting,
+    /** Whether in read-only watch mode (no signing capability). */
+    isWatchMode,
     connectWallet,
     disconnectWallet,
     switchAccount,
@@ -744,6 +750,8 @@ export function useWallet() {
     checkVerification,
     requireVerification,
     validateNetwork,
+    enterWatchMode,
+    exitWatchMode,
   };
 }
 

--- a/store/walletStore.ts
+++ b/store/walletStore.ts
@@ -18,6 +18,20 @@ export function getConfiguredNetwork(): WalletNetwork {
   return (env.NEXT_PUBLIC_STELLAR_NETWORK as WalletNetwork) || "testnet";
 }
 
+export type AddressBookGroup = {
+  id: string;
+  name: string;
+  favorite: boolean;
+};
+
+export type AddressBookEntry = {
+  id: string;
+  address: string;
+  label: string;
+  groupIds: string[];
+  isFavorite: boolean;
+};
+
 type WalletStoreState = {
   status: "disconnected" | "connecting" | "connected";
   address: string | null;
@@ -29,7 +43,8 @@ type WalletStoreState = {
   isVerified: boolean;
   verifiedAt: number | null;
   lastActivityAt: number | null;
-  addressBook: { id: string; address: string; label: string }[];
+  addressBook: AddressBookEntry[];
+  addressBookGroups: AddressBookGroup[];
   walletPassphrase: string | null;
   /**
    * Tracks whether the in-memory StellarWalletsKit session is active.
@@ -45,6 +60,8 @@ type WalletStoreState = {
    */
   kitSessionActive: boolean | null;
   kycStatus: "none" | "pending" | "verified" | "rejected";
+  /** Read-only watch mode — pasted G-address without wallet signing. */
+  isWatchMode: boolean;
 };
 
 type WalletStoreActions = {
@@ -60,9 +77,17 @@ type WalletStoreActions = {
   isSessionExpired: () => boolean;
   /** Mark the in-memory kit session as active/inactive/pending. */
   setKitSessionActive: (active: boolean | null) => void;
-  addAddressBookEntry: (address: string, label?: string) => void;
-  updateAddressBookEntry: (id: string, updates: { address?: string; label?: string }) => void;
+  addAddressBookEntry: (address: string, label?: string, groupIds?: string[]) => void;
+  updateAddressBookEntry: (id: string, updates: { address?: string; label?: string; groupIds?: string[] }) => void;
   removeAddressBookEntry: (id: string) => void;
+  toggleAddressBookFavorite: (id: string) => void;
+  addAddressBookGroup: (name: string) => void;
+  updateAddressBookGroup: (id: string, updates: { name?: string; favorite?: boolean }) => void;
+  removeAddressBookGroup: (id: string) => void;
+  /** Enter read-only watch mode for a given address (no wallet required). */
+  enterWatchMode: (address: string) => void;
+  /** Exit watch mode and fully disconnect. */
+  exitWatchMode: () => void;
   /**
    * Switches active account without full disconnect; clears verification & resets balance.
    */
@@ -87,9 +112,11 @@ export const useWalletStore = create<WalletStore>()(
       verifiedAt: null,
       lastActivityAt: null,
       addressBook: [],
+      addressBookGroups: [],
       walletPassphrase: null,
       kitSessionActive: false,
       kycStatus: "none",
+      isWatchMode: false,
 
       connect: (provider, address, publicKey, walletPassphrase) =>
         set({
@@ -119,6 +146,7 @@ export const useWalletStore = create<WalletStore>()(
           lastActivityAt: null,
           walletPassphrase: null,
           kitSessionActive: false,
+          isWatchMode: false,
         }),
 
       switchAccount: (newAddress, newPublicKey) =>
@@ -131,6 +159,38 @@ export const useWalletStore = create<WalletStore>()(
           lastActivityAt: Date.now(),
           kitSessionActive: true,
         })),
+
+      enterWatchMode: (address) =>
+        set({
+          status: "connected",
+          address,
+          publicKey: null,
+          isConnected: true,
+          provider: null,
+          balance: EMPTY_BALANCE,
+          walletPassphrase: null,
+          lastActivityAt: Date.now(),
+          kitSessionActive: false,
+          isWatchMode: true,
+          isVerified: false,
+          verifiedAt: null,
+        }),
+
+      exitWatchMode: () =>
+        set({
+          status: "disconnected",
+          address: null,
+          publicKey: null,
+          isConnected: false,
+          provider: null,
+          balance: null,
+          isVerified: false,
+          verifiedAt: null,
+          lastActivityAt: null,
+          walletPassphrase: null,
+          kitSessionActive: false,
+          isWatchMode: false,
+        }),
 
       setBalance: (balance) =>
         set((state) => (state.status === "connected" ? { balance } : {})),
@@ -225,6 +285,7 @@ export const useWalletStore = create<WalletStore>()(
         verifiedAt: s.verifiedAt,
         lastActivityAt: s.lastActivityAt,
         addressBook: s.addressBook,
+        addressBookGroups: s.addressBookGroups,
         walletPassphrase: s.walletPassphrase,
         kycStatus: s.kycStatus,
       }),


### PR DESCRIPTION
## Summary
Allow pasting a G-address to browse positions/marketplace in read-only mode without kit signing.

## Changes
- Add isWatchMode state to walletStore
- Add enterWatchMode/exitWatchMode actions
- Gate signTransaction when in watch mode
- Show 'Watch Only' badge in WalletButton
- Add watch address input in WalletConnectModal
- Exit watch mode button when in watch mode

## Acceptance Criteria
- [x] Watch mode loads balances/positions read-only
- [x] All sign CTAs disabled
- [x] Easy exit to real connect
- [x] No false kitSessionActive
- [x] Unit tests enforce gates

Closes #586