### PR TITLE
feat(secondary-market,analytics): acquire simulation preview, fee disclosure, concentration alerts, vintage cohorts

### DIFF
--- a/__tests__/concentration-risk.test.ts
+++ b/__tests__/concentration-risk.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Portfolio concentration risk alerts (issue #604).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_CONCENTRATION_THRESHOLDS,
+  SNOOZE_DURATIONS_MS,
+  concentrationKey,
+  evaluateConcentration,
+  filterActiveAlerts,
+  type ConcentrationPosition,
+} from "@/lib/concentrationRisk";
+
+function position(
+  investedAmount: number,
+  opts: { debtor?: string; jurisdiction?: string; riskTier?: string } = {}
+): ConcentrationPosition {
+  return {
+    investedAmount,
+    invoice: {
+      riskTier: opts.riskTier ?? "AAA",
+      metadata: {
+        jurisdiction: opts.jurisdiction ?? "US",
+        debtorName: opts.debtor ?? "Debtor",
+      },
+    },
+  };
+}
+
+describe("evaluateConcentration", () => {
+  it("returns nothing for an empty portfolio", () => {
+    expect(evaluateConcentration([])).toEqual([]);
+  });
+
+  it("returns nothing when every bucket is under threshold", () => {
+    // Four debtors at 25% each — at, not above, the debtor threshold.
+    const positions = ["A", "B", "C", "D"].map((d, i) =>
+      position(1000, {
+        debtor: d,
+        jurisdiction: ["US", "EU", "UK", "NG"][i],
+        riskTier: ["AAA", "AA", "A", "BBB"][i],
+      })
+    );
+
+    expect(evaluateConcentration(positions)).toEqual([]);
+  });
+
+  it("flags a single debtor above the threshold", () => {
+    const positions = [
+      position(7000, { debtor: "Acme", jurisdiction: "US" }),
+      position(3000, { debtor: "Other", jurisdiction: "EU" }),
+    ];
+
+    const alerts = evaluateConcentration(positions);
+    const debtor = alerts.find((a) => a.dimension === "debtor");
+
+    expect(debtor).toBeDefined();
+    expect(debtor!.name).toBe("Acme");
+    expect(debtor!.percent).toBeCloseTo(70, 5);
+    expect(debtor!.value).toBe(7000);
+  });
+
+  it("is exclusive at the boundary — exactly at threshold does not alert", () => {
+    // 25% debtor threshold; this debtor is exactly 25%.
+    const positions = [
+      position(2500, { debtor: "Acme" }),
+      position(2500, { debtor: "B" }),
+      position(2500, { debtor: "C" }),
+      position(2500, { debtor: "D" }),
+    ];
+
+    expect(
+      evaluateConcentration(positions).some((a) => a.dimension === "debtor")
+    ).toBe(false);
+  });
+
+  it("escalates to critical at 1.5x the threshold", () => {
+    const positions = [
+      position(9000, { debtor: "Acme" }),
+      position(1000, { debtor: "Other" }),
+    ];
+
+    const debtor = evaluateConcentration(positions).find(
+      (a) => a.dimension === "debtor"
+    );
+    // 90% >= 25 * 1.5
+    expect(debtor!.severity).toBe("critical");
+  });
+
+  it("stays a warning just below the critical multiple", () => {
+    const positions = [
+      position(3000, { debtor: "Acme" }),
+      position(7000, { debtor: "Other" }),
+    ];
+    // Alerts are sorted worst-first, so select the bucket by name rather than
+    // taking the first debtor alert — "Other" at 70% is also present.
+    const acme = evaluateConcentration(positions).find(
+      (a) => a.dimension === "debtor" && a.name === "Acme"
+    );
+    // 30% is over the 25 threshold but under the 37.5 critical multiple.
+    expect(acme!.severity).toBe("warning");
+  });
+
+  it("flags jurisdiction and risk tier on their own thresholds", () => {
+    const positions = [
+      position(6000, { debtor: "A", jurisdiction: "US", riskTier: "AAA" }),
+      position(4000, { debtor: "B", jurisdiction: "US", riskTier: "AAA" }),
+    ];
+
+    const alerts = evaluateConcentration(positions);
+    // 100% in one jurisdiction (>40) and one tier (>50)
+    expect(alerts.some((a) => a.dimension === "jurisdiction")).toBe(true);
+    expect(alerts.some((a) => a.dimension === "riskTier")).toBe(true);
+  });
+
+  it("sorts the worst concentration first", () => {
+    const positions = [
+      position(9500, { debtor: "Acme", jurisdiction: "US", riskTier: "AAA" }),
+      position(500, { debtor: "B", jurisdiction: "EU", riskTier: "BB" }),
+    ];
+
+    const alerts = evaluateConcentration(positions);
+    for (let i = 1; i < alerts.length; i++) {
+      expect(alerts[i - 1].percent).toBeGreaterThanOrEqual(alerts[i].percent);
+    }
+  });
+
+  it("ignores positions with no invested amount", () => {
+    const positions = [
+      position(0, { debtor: "Ghost" }),
+      position(-100, { debtor: "Negative" }),
+      position(1000, { debtor: "Real" }),
+    ];
+
+    const alerts = evaluateConcentration(positions);
+    expect(alerts.every((a) => a.name !== "Ghost")).toBe(true);
+    expect(alerts.every((a) => a.name !== "Negative")).toBe(true);
+  });
+
+  it("buckets missing metadata under Unknown rather than dropping it", () => {
+    const positions: ConcentrationPosition[] = [
+      { investedAmount: 9000, invoice: null },
+      position(1000, { debtor: "Real" }),
+    ];
+
+    const alerts = evaluateConcentration(positions);
+    expect(alerts.some((a) => a.name === "Unknown")).toBe(true);
+  });
+
+  it("treats a zero threshold as disabling that dimension", () => {
+    const positions = [
+      position(9000, { debtor: "Acme" }),
+      position(1000, { debtor: "Other" }),
+    ];
+
+    const alerts = evaluateConcentration(positions, {
+      ...DEFAULT_CONCENTRATION_THRESHOLDS,
+      debtor: 0,
+    });
+
+    expect(alerts.some((a) => a.dimension === "debtor")).toBe(false);
+  });
+
+  it("honours custom thresholds", () => {
+    const positions = [
+      position(3000, { debtor: "Acme" }),
+      position(7000, { debtor: "Other" }),
+    ];
+
+    const strict = evaluateConcentration(positions, {
+      ...DEFAULT_CONCENTRATION_THRESHOLDS,
+      debtor: 10,
+    });
+    expect(strict.filter((a) => a.dimension === "debtor")).toHaveLength(2);
+  });
+
+  it("keys alerts by dimension and bucket, not by percentage", () => {
+    // A dismissal must survive the number moving.
+    const first = evaluateConcentration([
+      position(7000, { debtor: "Acme" }),
+      position(3000, { debtor: "B" }),
+    ]).find((a) => a.dimension === "debtor")!;
+
+    const later = evaluateConcentration([
+      position(8000, { debtor: "Acme" }),
+      position(2000, { debtor: "B" }),
+    ]).find((a) => a.dimension === "debtor")!;
+
+    expect(first.key).toBe(later.key);
+    expect(first.percent).not.toBe(later.percent);
+  });
+});
+
+describe("filterActiveAlerts", () => {
+  const alerts = evaluateConcentration([
+    position(7000, { debtor: "Acme" }),
+    position(3000, { debtor: "Other" }),
+  ]);
+
+  it("passes everything through by default", () => {
+    expect(filterActiveAlerts(alerts, [], [])).toHaveLength(alerts.length);
+  });
+
+  it("drops a dismissed alert", () => {
+    const key = concentrationKey("debtor", "Acme");
+    const remaining = filterActiveAlerts(alerts, [key], []);
+    expect(remaining.some((a) => a.key === key)).toBe(false);
+  });
+
+  it("hides a snoozed alert until its expiry", () => {
+    const key = concentrationKey("debtor", "Acme");
+    const now = 1_000_000;
+    const snoozes = [{ key, until: now + SNOOZE_DURATIONS_MS.day }];
+
+    expect(filterActiveAlerts(alerts, [], snoozes, now).some((a) => a.key === key)).toBe(
+      false
+    );
+  });
+
+  it("shows it again once the snooze expires", () => {
+    const key = concentrationKey("debtor", "Acme");
+    const now = 1_000_000;
+    const snoozes = [{ key, until: now }];
+
+    // Boundary: at `until` the snooze is over.
+    expect(filterActiveAlerts(alerts, [], snoozes, now).some((a) => a.key === key)).toBe(
+      true
+    );
+  });
+
+  it("does not let one snooze hide an unrelated alert", () => {
+    const snoozes = [{ key: concentrationKey("debtor", "Acme"), until: 2_000_000 }];
+    const remaining = filterActiveAlerts(alerts, [], snoozes, 1_000_000);
+    expect(remaining.some((a) => a.dimension === "jurisdiction")).toBe(true);
+  });
+});

--- a/__tests__/secondary-fee-disclosure.test.tsx
+++ b/__tests__/secondary-fee-disclosure.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Fee disclosure rendering (issue #597).
+ *
+ * The component must not do arithmetic of its own — every figure it shows comes
+ * from `computeAcquisitionFees`. These assert what a buyer actually reads.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// next-intl needs a provider; substituting the real catalog keeps the assertions
+// about user-visible copy rather than about translation keys.
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace: string) => {
+    const messages: Record<string, Record<string, string>> = {
+      secondaryFees: {
+        title: "Fee schedule",
+        subtitle: "All fees are disclosed before you confirm.",
+        subtotal: "Position price",
+        protocolFee: "Protocol fee ({rate})",
+        marketFee: "Marketplace fee ({rate})",
+        totalFees: "Total fees ({rate})",
+        total: "You pay",
+        noFees: "No fees apply to this acquisition.",
+        listingNote: "Buyer pays {rate} in fees on top of the ask price.",
+      },
+    };
+    return (key: string, values?: Record<string, string | number>) => {
+      let out = messages[namespace]?.[key] ?? key;
+      for (const [k, v] of Object.entries(values ?? {})) {
+        out = out.replace(`{${k}}`, String(v));
+      }
+      return out;
+    };
+  },
+}));
+
+import { FeeDisclosure } from "@/components/secondary/FeeDisclosure";
+import { computeAcquisitionFees } from "@/lib/secondaryFees";
+
+const SCHEDULE = { protocolBps: 50, marketBps: 25 };
+
+describe("FeeDisclosure", () => {
+  it("shows each fee line and the total the buyer pays", () => {
+    render(<FeeDisclosure fees={computeAcquisitionFees(10_000, SCHEDULE)} />);
+
+    expect(screen.getByText("Position price")).toBeDefined();
+    expect(screen.getByText("Protocol fee (0.5%)")).toBeDefined();
+    expect(screen.getByText("Marketplace fee (0.25%)")).toBeDefined();
+    expect(screen.getByText("You pay")).toBeDefined();
+  });
+
+  it("shows a total that equals price plus fees", () => {
+    const fees = computeAcquisitionFees(10_000, SCHEDULE);
+    render(<FeeDisclosure fees={fees} />);
+
+    // 10,000 + 50 + 25
+    expect(screen.getByTestId("fee-total").textContent).toContain("10,075");
+  });
+
+  it("states plainly when no fees apply rather than rendering an empty table", () => {
+    render(
+      <FeeDisclosure
+        fees={computeAcquisitionFees(10_000, { protocolBps: 0, marketBps: 0 })}
+      />
+    );
+
+    expect(screen.getByTestId("fee-disclosure-none")).toBeDefined();
+    expect(screen.queryByTestId("fee-disclosure")).toBeNull();
+  });
+
+  it("omits a fee line whose rate is zero", () => {
+    render(
+      <FeeDisclosure
+        fees={computeAcquisitionFees(10_000, { protocolBps: 50, marketBps: 0 })}
+      />
+    );
+
+    expect(screen.getByText("Protocol fee (0.5%)")).toBeDefined();
+    expect(screen.queryByText(/Marketplace fee/)).toBeNull();
+  });
+
+  it("renders a one-line summary in the inline variant", () => {
+    render(
+      <FeeDisclosure
+        variant="inline"
+        fees={computeAcquisitionFees(10_000, SCHEDULE)}
+      />
+    );
+
+    expect(screen.getByTestId("fee-disclosure-inline").textContent).toContain("0.75%");
+  });
+});

--- a/__tests__/secondary-fees.test.ts
+++ b/__tests__/secondary-fees.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Secondary market fee schedule (issue #597).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  applyBps,
+  computeAcquisitionFees,
+  formatBps,
+  getFeeSchedule,
+} from "@/lib/secondaryFees";
+
+const SCHEDULE = { protocolBps: 50, marketBps: 25 }; // 0.5% + 0.25%
+
+describe("applyBps", () => {
+  it("applies a basis-point rate", () => {
+    expect(applyBps(10_000, 50)).toBe(50); // 0.5% of 10,000
+    expect(applyBps(10_000, 25)).toBe(25);
+  });
+
+  it("rounds to cents", () => {
+    expect(applyBps(4850, 50)).toBe(24.25);
+  });
+
+  it.each([
+    ["zero amount", 0, 50],
+    ["zero rate", 1000, 0],
+    ["negative amount", -100, 50],
+    ["negative rate", 1000, -50],
+  ])("returns 0 for %s", (_label, amount, bps) => {
+    expect(applyBps(amount, bps)).toBe(0);
+  });
+
+  it("never yields NaN for non-finite input", () => {
+    expect(applyBps(Number.NaN, 50)).toBe(0);
+    expect(applyBps(1000, Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe("computeAcquisitionFees", () => {
+  it("breaks a price down into protocol and market fees", () => {
+    const fees = computeAcquisitionFees(10_000, SCHEDULE);
+
+    expect(fees.subtotal).toBe(10_000);
+    expect(fees.protocolFee).toBe(50);
+    expect(fees.marketFee).toBe(25);
+    expect(fees.totalFees).toBe(75);
+    expect(fees.total).toBe(10_075);
+    expect(fees.totalBps).toBe(75);
+  });
+
+  it("always reconciles: the parts add up to the disclosed total", () => {
+    // The property that matters for a fee *disclosure*. Rounding each figure
+    // independently would let a breakdown miss its own total by a cent.
+    for (const price of [4850, 1234.56, 99.99, 7, 0.03, 123456.78]) {
+      const fees = computeAcquisitionFees(price, SCHEDULE);
+      expect(fees.protocolFee + fees.marketFee).toBeCloseTo(fees.totalFees, 10);
+      expect(fees.subtotal + fees.totalFees).toBeCloseTo(fees.total, 10);
+    }
+  });
+
+  it("charges nothing when both rates are zero", () => {
+    const fees = computeAcquisitionFees(10_000, { protocolBps: 0, marketBps: 0 });
+    expect(fees.totalFees).toBe(0);
+    expect(fees.total).toBe(10_000);
+  });
+
+  it("clamps a rate above 100% rather than charging it", () => {
+    const fees = computeAcquisitionFees(1000, { protocolBps: 50_000, marketBps: 0 });
+    expect(fees.schedule.protocolBps).toBe(10_000);
+    expect(fees.protocolFee).toBe(1000);
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -500],
+    ["NaN", Number.NaN],
+  ])("returns an all-zero breakdown for a %s price instead of NaN", (_l, price) => {
+    const fees = computeAcquisitionFees(price as number, SCHEDULE);
+    expect(fees.subtotal).toBe(0);
+    expect(fees.total).toBe(0);
+    expect(Number.isNaN(fees.total)).toBe(false);
+  });
+
+  it("treats a negative configured rate as zero", () => {
+    const fees = computeAcquisitionFees(1000, { protocolBps: -10, marketBps: 25 });
+    expect(fees.protocolFee).toBe(0);
+    expect(fees.marketFee).toBe(2.5);
+  });
+});
+
+describe("formatBps", () => {
+  it.each([
+    [50, "0.5%"],
+    [25, "0.25%"],
+    [100, "1%"],
+    [0, "0%"],
+    [10_000, "100%"],
+  ])("renders %i bps as %s", (bps, expected) => {
+    expect(formatBps(bps)).toBe(expected);
+  });
+});
+
+describe("getFeeSchedule", () => {
+  it("reads the configured rates", () => {
+    expect(
+      getFeeSchedule({
+        NEXT_PUBLIC_SECONDARY_PROTOCOL_FEE_BPS: 50,
+        NEXT_PUBLIC_SECONDARY_MARKET_FEE_BPS: 25,
+      })
+    ).toEqual({ protocolBps: 50, marketBps: 25 });
+  });
+
+  it("clamps out-of-range configuration", () => {
+    expect(
+      getFeeSchedule({
+        NEXT_PUBLIC_SECONDARY_PROTOCOL_FEE_BPS: 99_999,
+        NEXT_PUBLIC_SECONDARY_MARKET_FEE_BPS: -1,
+      })
+    ).toEqual({ protocolBps: 10_000, marketBps: 0 });
+  });
+});

--- a/__tests__/vintage-cohorts.test.ts
+++ b/__tests__/vintage-cohorts.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Vintage cohort analytics (issue #605).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildVintageCohorts,
+  cohortsToExportRows,
+  formatMonthLabel,
+  monthRange,
+  vintageMonthKey,
+  type CohortPosition,
+} from "@/lib/vintageCohorts";
+
+function pos(
+  fundedAt: string | null,
+  investedAmount: number,
+  extra: { apr?: number | null; status?: string } = {}
+): CohortPosition {
+  return { fundedAt, investedAmount, apr: extra.apr ?? null, status: extra.status ?? "active" };
+}
+
+describe("vintageMonthKey", () => {
+  it("buckets by UTC year and month", () => {
+    expect(vintageMonthKey("2026-03-15T12:00:00.000Z")).toBe("2026-03");
+  });
+
+  it("zero-pads single-digit months so keys sort lexically", () => {
+    expect(vintageMonthKey("2026-01-05T00:00:00.000Z")).toBe("2026-01");
+  });
+
+  it("buckets in UTC, not local time", () => {
+    // Late-UTC on the last day of a month must not slide into the next one
+    // depending on where the reader happens to be.
+    expect(vintageMonthKey("2026-03-31T23:59:59.000Z")).toBe("2026-03");
+    expect(vintageMonthKey("2026-04-01T00:00:00.000Z")).toBe("2026-04");
+  });
+
+  it.each([["empty", ""], ["garbage", "not-a-date"]])(
+    "returns null for %s input",
+    (_l, value) => {
+      expect(vintageMonthKey(value)).toBeNull();
+    }
+  );
+});
+
+describe("formatMonthLabel", () => {
+  it("renders a readable label", () => {
+    expect(formatMonthLabel("2026-03")).toBe("Mar 2026");
+    expect(formatMonthLabel("2026-12")).toBe("Dec 2026");
+  });
+
+  it("passes malformed input through unchanged", () => {
+    expect(formatMonthLabel("nonsense")).toBe("nonsense");
+    expect(formatMonthLabel("2026-13")).toBe("2026-13");
+  });
+});
+
+describe("monthRange", () => {
+  it("covers an inclusive span", () => {
+    expect(monthRange("2026-01", "2026-04")).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2026-04",
+    ]);
+  });
+
+  it("rolls over a year boundary", () => {
+    expect(monthRange("2025-11", "2026-02")).toEqual([
+      "2025-11",
+      "2025-12",
+      "2026-01",
+      "2026-02",
+    ]);
+  });
+
+  it("returns a single month when both ends match", () => {
+    expect(monthRange("2026-05", "2026-05")).toEqual(["2026-05"]);
+  });
+
+  it("returns nothing for a reversed range rather than looping forever", () => {
+    expect(monthRange("2026-05", "2026-01")).toEqual([]);
+  });
+});
+
+describe("buildVintageCohorts", () => {
+  it("returns nothing when no position has a funding date", () => {
+    expect(buildVintageCohorts([pos(null, 1000)])).toEqual([]);
+  });
+
+  it("groups positions by funding month", () => {
+    const cohorts = buildVintageCohorts([
+      pos("2026-01-10T00:00:00Z", 1000),
+      pos("2026-01-20T00:00:00Z", 2000),
+      pos("2026-02-05T00:00:00Z", 500),
+    ]);
+
+    expect(cohorts).toHaveLength(2);
+    expect(cohorts[0].month).toBe("2026-01");
+    expect(cohorts[0].positionCount).toBe(2);
+    expect(cohorts[0].totalInvested).toBe(3000);
+    expect(cohorts[1].month).toBe("2026-02");
+  });
+
+  it("orders cohorts oldest first", () => {
+    const cohorts = buildVintageCohorts([
+      pos("2026-05-01T00:00:00Z", 100),
+      pos("2026-01-01T00:00:00Z", 100),
+    ]);
+    expect(cohorts[0].month).toBe("2026-01");
+    expect(cohorts[cohorts.length - 1].month).toBe("2026-05");
+  });
+
+  it("emits empty months between cohorts so gaps stay visible", () => {
+    const cohorts = buildVintageCohorts([
+      pos("2026-01-01T00:00:00Z", 1000),
+      pos("2026-04-01T00:00:00Z", 1000),
+    ]);
+
+    expect(cohorts.map((c) => c.month)).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2026-04",
+    ]);
+    expect(cohorts[1].isEmpty).toBe(true);
+    expect(cohorts[1].positionCount).toBe(0);
+    expect(cohorts[1].defaultRate).toBe(0);
+  });
+
+  it("can omit empty months on request", () => {
+    const cohorts = buildVintageCohorts(
+      [pos("2026-01-01T00:00:00Z", 1000), pos("2026-04-01T00:00:00Z", 1000)],
+      { includeEmptyMonths: false }
+    );
+    expect(cohorts.map((c) => c.month)).toEqual(["2026-01", "2026-04"]);
+  });
+
+  it("weights APR by invested amount, not by position count", () => {
+    // A large low-yield position must dominate a tiny high-yield one.
+    const cohorts = buildVintageCohorts([
+      pos("2026-01-01T00:00:00Z", 99_000, { apr: 8 }),
+      pos("2026-01-15T00:00:00Z", 1_000, { apr: 20 }),
+    ]);
+
+    // Simple mean would be 14; weighted is ~8.12.
+    expect(cohorts[0].weightedApr).toBeCloseTo(8.12, 2);
+  });
+
+  it("reports a null APR when no position carries one", () => {
+    const cohorts = buildVintageCohorts([pos("2026-01-01T00:00:00Z", 1000)]);
+    expect(cohorts[0].weightedApr).toBeNull();
+  });
+
+  it("computes a default rate from terminal statuses", () => {
+    const cohorts = buildVintageCohorts([
+      pos("2026-01-01T00:00:00Z", 1000, { status: "defaulted" }),
+      pos("2026-01-02T00:00:00Z", 1000, { status: "repaid" }),
+      pos("2026-01-03T00:00:00Z", 1000, { status: "active" }),
+      pos("2026-01-04T00:00:00Z", 1000, { status: "written_off" }),
+    ]);
+
+    expect(cohorts[0].defaultedCount).toBe(2);
+    expect(cohorts[0].defaultRate).toBeCloseTo(50, 5);
+  });
+
+  it("matches default statuses case-insensitively", () => {
+    const cohorts = buildVintageCohorts([
+      pos("2026-01-01T00:00:00Z", 1000, { status: "DEFAULTED" }),
+    ]);
+    expect(cohorts[0].defaultedCount).toBe(1);
+  });
+
+  it("excludes positions with an unparseable funding date", () => {
+    const cohorts = buildVintageCohorts([
+      pos("2026-01-01T00:00:00Z", 1000),
+      pos("not-a-date", 5000),
+    ]);
+
+    // The bad row must not distort the cohort it would have landed in.
+    expect(cohorts).toHaveLength(1);
+    expect(cohorts[0].totalInvested).toBe(1000);
+  });
+});
+
+describe("investedAt alias", () => {
+  it("accepts investedAt, the field name InvestorPosition actually uses", () => {
+    const cohorts = buildVintageCohorts([
+      { investedAmount: 1000, investedAt: "2026-01-10T00:00:00Z", status: "active" },
+    ]);
+    expect(cohorts).toHaveLength(1);
+    expect(cohorts[0].month).toBe("2026-01");
+  });
+
+  it("prefers fundedAt when a caller supplies both", () => {
+    const cohorts = buildVintageCohorts([
+      {
+        investedAmount: 1000,
+        fundedAt: "2026-05-01T00:00:00Z",
+        investedAt: "2026-01-01T00:00:00Z",
+        status: "active",
+      },
+    ]);
+    expect(cohorts[0].month).toBe("2026-05");
+  });
+});
+
+describe("cohortsToExportRows", () => {
+  it("flattens cohorts for CSV export", () => {
+    const cohorts = buildVintageCohorts([
+      pos("2026-01-01T00:00:00Z", 1000, { apr: 10, status: "defaulted" }),
+    ]);
+    const rows = cohortsToExportRows(cohorts);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      vintageMonth: "2026-01",
+      vintageLabel: "Jan 2026",
+      positionCount: 1,
+      totalInvested: 1000,
+      weightedApr: "10.00",
+      defaultedCount: 1,
+      defaultRatePercent: "100.00",
+    });
+  });
+
+  it("exports an empty string rather than null for a missing APR", () => {
+    const cohorts = buildVintageCohorts([pos("2026-01-01T00:00:00Z", 1000)]);
+    expect(cohortsToExportRows(cohorts)[0].weightedApr).toBe("");
+  });
+});

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { useTranslations } from "next-intl";
 import { PrintButton, PrintLayout } from "@/components/ui/print-layout";
 import { exportCsv, exportPdf } from "@/lib/export";
+import { VintageCohortTable } from "@/components/analytics/VintageCohortTable";
 import {
   PORTFOLIO_EXPORT_HEADERS,
   filterPositionsForExport,
@@ -271,6 +272,22 @@ function PortfolioAnalyticsInner() {
     );
   }, [exportRows, hasExportData]);
 
+  /**
+   * Issue #605: cohorts export on their own axis. They are one row per month,
+   * not per position, so they cannot share the position CSV's headers.
+   */
+  const handleExportCohorts = useCallback(
+    (rows: Array<Record<string, string | number>>) => {
+      if (rows.length === 0) return;
+      exportCsv(
+        rows as Record<string, unknown>[],
+        portfolioExportFilename().replace(/\.csv$/, "-vintage-cohorts.csv"),
+        Object.keys(rows[0])
+      );
+    },
+    []
+  );
+
   const handleExportPdf = useCallback(() => {
     if (!hasExportData) return;
     void exportPdf("analytics-report", portfolioPdfFilename());
@@ -345,6 +362,15 @@ function PortfolioAnalyticsInner() {
             risk={risk}
             isLoading={positionsQuery.isLoading}
             onRiskSegmentClick={handleRiskSegmentClick}
+          />
+
+          {/* Issue #605: cohorts are built from the *filtered* positions, so the
+              vintage view respects the same date-range and risk filters as every
+              other panel on this page. */}
+          <VintageCohortTable
+            className="mt-10 rounded-xl border border-zinc-800 p-4"
+            positions={filteredPositions}
+            onExport={handleExportCohorts}
           />
 
           {/* Filtered positions — included in PDF/print layout */}

--- a/app/dashboard/investor/page.tsx
+++ b/app/dashboard/investor/page.tsx
@@ -14,6 +14,7 @@ import { useWallet } from "@/hooks/useWallet";
 import { useFormatters } from "@/hooks/useFormatters";
 import { useUIStore, useInvoiceStore, usePositionListingStore, DEFAULT_FILTERS } from "@/store";
 import { usePositions } from "@/hooks/usePositions";
+import { ConcentrationRiskAlerts } from "@/components/analytics/ConcentrationRiskAlerts";
 import { useTransaction } from "@/hooks/useTransaction";
 import { useTxSimulation } from "@/hooks/useTxSimulation";
 import { useTranslations } from "next-intl";
@@ -455,6 +456,11 @@ export default function InvestorDashboardPage() {
           </motion.div>
         ))}
       </div>
+
+      {/* Issue #604: the donut shows how the portfolio splits; this says when a
+          split has become a risk. Sits directly above it so the warning and the
+          chart it refers to are read together. */}
+      <ConcentrationRiskAlerts className="mb-6" positions={donutPositions} />
 
       <motion.div
         initial={{ opacity: 0, y: 12 }}

--- a/app/secondary/page.tsx
+++ b/app/secondary/page.tsx
@@ -19,6 +19,12 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import EmptyState from "@/components/ui/EmptyState";
+import { TxSimulationPreview } from "@/components/invoice/TxSimulationPreview";
+import { FeeDisclosure } from "@/components/secondary/FeeDisclosure";
+import { useAcquirePositionFlow } from "@/hooks/useTransaction";
+import { useWallet } from "@/hooks/useWallet";
+import { env } from "@/lib/env";
+import { computeAcquisitionFees, getFeeSchedule } from "@/lib/secondaryFees";
 import { usePositionListingStore } from "@/store/positionListingStore";
 import { useInvoiceStore } from "@/store/invoiceStore";
 import { MOCK_INVOICES } from "@/services/mockData";
@@ -221,6 +227,14 @@ const MOCK_SECONDARY_LISTINGS: SecondaryMarketItem[] = [
 ];
 
 export default function SecondaryMarketplacePage() {
+  // Issue #594: acquire runs through the same simulation gate as fund/transfer.
+  const { acquirePosition, simulationDialogProps } = useAcquirePositionFlow();
+  const { publicKey } = useWallet();
+
+  // Issue #597: one schedule, read from validated env, shared by every figure
+  // on this page.
+  const feeSchedule = useMemo(() => getFeeSchedule(env), []);
+
   const { listings: storeListings } = usePositionListingStore();
   const { invoices } = useInvoiceStore();
 
@@ -510,12 +524,23 @@ export default function SecondaryMarketplacePage() {
                         </div>
                       </div>
 
+                      {/* Issue #597: disclose fees before the buyer confirms. */}
+                      <FeeDisclosure
+                        className="mt-3 rounded-md border border-zinc-800 bg-zinc-900/40 p-2.5"
+                        fees={computeAcquisitionFees(item.listing.askPrice, feeSchedule)}
+                      />
+
                       {/* Action Button */}
                       <Button
                         className="w-full mt-3 bg-primary text-primary-foreground hover:bg-primary/90 font-medium text-xs h-9"
                         onClick={() => {
-                          alert(`Transfer position flow initiated for ${item.positionId}`);
+                          void acquirePosition(
+                            item.positionId,
+                            publicKey ?? "",
+                            item.sellerAddress
+                          );
                         }}
+                        disabled={!publicKey}
                       >
                         Acquire Position
                         <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
@@ -527,6 +552,10 @@ export default function SecondaryMarketplacePage() {
             })}
           </div>
         )}
+
+        {/* Issue #594: preview before signing; the dialog blocks proceed when
+            the simulation fails. */}
+        <TxSimulationPreview {...simulationDialogProps} />
 
         {/* Mobile Filter Bottom Sheet */}
         <BottomSheet

--- a/components/analytics/ConcentrationRiskAlerts.tsx
+++ b/components/analytics/ConcentrationRiskAlerts.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+/**
+ * Concentration risk banner (issue #604).
+ *
+ * The allocation chart already shows *how* a portfolio splits; it shows a 70%
+ * slice exactly as calmly as a 7% one. This surfaces the split as a warning
+ * once it crosses the investor's configured threshold.
+ *
+ * All evaluation lives in `lib/concentrationRisk`. This component only renders
+ * and wires the dismiss/snooze actions.
+ */
+
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { AlertTriangle, X } from "lucide-react";
+
+import {
+  SNOOZE_DURATIONS_MS,
+  evaluateConcentration,
+  filterActiveAlerts,
+  type ConcentrationPosition,
+} from "@/lib/concentrationRisk";
+import { useSettingsStore } from "@/store/settingsStore";
+import { Button } from "@/components/ui/button";
+
+interface ConcentrationRiskAlertsProps {
+  positions: ConcentrationPosition[];
+  className?: string;
+}
+
+export function ConcentrationRiskAlerts({
+  positions,
+  className,
+}: ConcentrationRiskAlertsProps) {
+  const t = useTranslations("concentrationRisk");
+  const concentration = useSettingsStore((s) => s.concentration);
+  const dismiss = useSettingsStore((s) => s.dismissConcentrationAlert);
+  const snooze = useSettingsStore((s) => s.snoozeConcentrationAlert);
+
+  const alerts = useMemo(() => {
+    const evaluated = evaluateConcentration(positions, concentration.thresholds);
+    return filterActiveAlerts(
+      evaluated,
+      concentration.dismissedKeys,
+      concentration.snoozes
+    );
+  }, [positions, concentration]);
+
+  if (alerts.length === 0) return null;
+
+  return (
+    <section
+      className={className}
+      aria-label={t("title")}
+      data-testid="concentration-risk-alerts"
+    >
+      <ul className="space-y-2">
+        {alerts.map((alert) => (
+          <li
+            key={alert.key}
+            role="alert"
+            data-testid={`concentration-alert-${alert.key}`}
+            className={
+              alert.severity === "critical"
+                ? "flex items-start gap-3 rounded-md border border-red-900/60 bg-red-950/30 p-3"
+                : "flex items-start gap-3 rounded-md border border-amber-900/60 bg-amber-950/20 p-3"
+            }
+          >
+            <AlertTriangle
+              aria-hidden="true"
+              className={
+                alert.severity === "critical"
+                  ? "mt-0.5 h-4 w-4 shrink-0 text-red-400"
+                  : "mt-0.5 h-4 w-4 shrink-0 text-amber-400"
+              }
+            />
+
+            <div className="min-w-0 flex-1">
+              <p className="text-sm text-zinc-100">
+                {t(alert.dimension, {
+                  name: alert.name,
+                  percent: alert.percent.toFixed(1),
+                })}
+              </p>
+              <p className="text-xs text-zinc-400">
+                {t("thresholdNote", { threshold: alert.threshold })}
+              </p>
+
+              <div className="mt-2 flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={() => snooze(alert.key, SNOOZE_DURATIONS_MS.day)}
+                >
+                  {t("snoozeDay")}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={() => snooze(alert.key, SNOOZE_DURATIONS_MS.week)}
+                >
+                  {t("snoozeWeek")}
+                </Button>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => dismiss(alert.key)}
+              aria-label={t("dismiss")}
+              className="shrink-0 rounded p-1 text-zinc-400 hover:text-zinc-200"
+            >
+              <X aria-hidden="true" className="h-4 w-4" />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default ConcentrationRiskAlerts;

--- a/components/analytics/VintageCohortTable.tsx
+++ b/components/analytics/VintageCohortTable.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+/**
+ * Vintage cohort table (issue #605).
+ *
+ * Grouping logic lives in `lib/vintageCohorts`; this renders the rows and
+ * exposes the CSV export.
+ */
+
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
+
+import {
+  buildVintageCohorts,
+  cohortsToExportRows,
+  type CohortPosition,
+} from "@/lib/vintageCohorts";
+import { formatCurrency } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+interface VintageCohortTableProps {
+  positions: CohortPosition[];
+  /** Receives flattened rows ready for CSV. */
+  onExport?: (rows: Array<Record<string, string | number>>) => void;
+  className?: string;
+}
+
+export function VintageCohortTable({
+  positions,
+  onExport,
+  className,
+}: VintageCohortTableProps) {
+  const t = useTranslations("vintageCohorts");
+
+  const cohorts = useMemo(() => buildVintageCohorts(positions), [positions]);
+
+  if (cohorts.length === 0) {
+    return (
+      <p className={className} data-testid="vintage-cohorts-empty">
+        {t("noData")}
+      </p>
+    );
+  }
+
+  return (
+    <section className={className} data-testid="vintage-cohorts">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium text-zinc-100">{t("title")}</h3>
+          <p className="text-xs text-zinc-500">{t("subtitle")}</p>
+        </div>
+        {onExport && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => onExport(cohortsToExportRows(cohorts))}
+          >
+            {t("export")}
+          </Button>
+        )}
+      </div>
+
+      {/* Wide table scrolls inside its own container rather than the page. */}
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[520px] text-xs">
+          <caption className="sr-only">{t("title")}</caption>
+          <thead>
+            <tr className="border-b border-zinc-800 text-left text-zinc-400">
+              <th scope="col" className="py-2 pr-3 font-medium">{t("month")}</th>
+              <th scope="col" className="py-2 pr-3 text-right font-medium">{t("positions")}</th>
+              <th scope="col" className="py-2 pr-3 text-right font-medium">{t("invested")}</th>
+              <th scope="col" className="py-2 pr-3 text-right font-medium">{t("weightedApr")}</th>
+              <th scope="col" className="py-2 text-right font-medium">{t("defaultRate")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cohorts.map((cohort) => (
+              <tr
+                key={cohort.month}
+                data-testid={`cohort-row-${cohort.month}`}
+                className={
+                  cohort.isEmpty
+                    ? "border-b border-zinc-900 text-zinc-600"
+                    : "border-b border-zinc-900 text-zinc-200"
+                }
+              >
+                <th scope="row" className="py-2 pr-3 text-left font-normal">
+                  {cohort.label}
+                </th>
+                {cohort.isEmpty ? (
+                  <td className="py-2 text-zinc-600" colSpan={4}>
+                    {t("empty")}
+                  </td>
+                ) : (
+                  <>
+                    <td className="py-2 pr-3 text-right font-mono">{cohort.positionCount}</td>
+                    <td className="py-2 pr-3 text-right font-mono">
+                      {formatCurrency(cohort.totalInvested)}
+                    </td>
+                    <td className="py-2 pr-3 text-right font-mono">
+                      {cohort.weightedApr === null ? "—" : `${cohort.weightedApr.toFixed(2)}%`}
+                    </td>
+                    <td className="py-2 text-right font-mono">
+                      {cohort.defaultRate.toFixed(1)}%
+                    </td>
+                  </>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export default VintageCohortTable;

--- a/components/secondary/FeeDisclosure.tsx
+++ b/components/secondary/FeeDisclosure.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Secondary market fee disclosure (issue #597).
+ *
+ * Renders the breakdown returned by `lib/secondaryFees` — it does no
+ * arithmetic of its own, so the figures shown and the figures charged cannot
+ * diverge.
+ */
+
+import { useTranslations } from "next-intl";
+
+import { formatBps, type FeeBreakdown } from "@/lib/secondaryFees";
+import { formatCurrency } from "@/lib/utils";
+
+interface FeeDisclosureProps {
+  fees: FeeBreakdown;
+  /** Compact single-line form for listing cards. */
+  variant?: "full" | "inline";
+  className?: string;
+}
+
+export function FeeDisclosure({
+  fees,
+  variant = "full",
+  className,
+}: FeeDisclosureProps) {
+  const t = useTranslations("secondaryFees");
+
+  if (fees.totalBps === 0) {
+    return (
+      <p className={className} data-testid="fee-disclosure-none">
+        {t("noFees")}
+      </p>
+    );
+  }
+
+  if (variant === "inline") {
+    return (
+      <p className={className} data-testid="fee-disclosure-inline">
+        {t("listingNote", { rate: formatBps(fees.totalBps) })}
+      </p>
+    );
+  }
+
+  return (
+    <div className={className} data-testid="fee-disclosure">
+      <h4 className="text-xs font-medium text-zinc-300">{t("title")}</h4>
+      <p className="text-[11px] text-zinc-500">{t("subtitle")}</p>
+
+      <dl className="mt-2 space-y-1 text-xs">
+        <div className="flex items-center justify-between">
+          <dt className="text-zinc-400">{t("subtotal")}</dt>
+          <dd className="font-mono text-zinc-200">{formatCurrency(fees.subtotal)}</dd>
+        </div>
+
+        {fees.schedule.protocolBps > 0 && (
+          <div className="flex items-center justify-between">
+            <dt className="text-zinc-400">
+              {t("protocolFee", { rate: formatBps(fees.schedule.protocolBps) })}
+            </dt>
+            <dd className="font-mono text-zinc-200">
+              {formatCurrency(fees.protocolFee)}
+            </dd>
+          </div>
+        )}
+
+        {fees.schedule.marketBps > 0 && (
+          <div className="flex items-center justify-between">
+            <dt className="text-zinc-400">
+              {t("marketFee", { rate: formatBps(fees.schedule.marketBps) })}
+            </dt>
+            <dd className="font-mono text-zinc-200">
+              {formatCurrency(fees.marketFee)}
+            </dd>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between border-t border-zinc-800 pt-1 font-medium">
+          <dt className="text-zinc-200">{t("total")}</dt>
+          <dd className="font-mono text-zinc-100" data-testid="fee-total">
+            {formatCurrency(fees.total)}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+export default FeeDisclosure;

--- a/hooks/useTransaction.ts
+++ b/hooks/useTransaction.ts
@@ -392,6 +392,49 @@ export function useTransferPositionFlow() {
   };
 }
 
+/**
+ * Acquiring a listed position on the secondary market (issue #594).
+ *
+ * Funding already ran every transaction through
+ * "build -> simulate -> preview -> sign -> submit". Secondary acquire did not:
+ * the Acquire button on `app/secondary` was a placeholder `alert()`, so the one
+ * flow where a buyer commits capital against *someone else's* position had the
+ * weakest pre-signature safety of any flow in the app.
+ *
+ * This reuses the same gate rather than adding a parallel one, so acquire
+ * inherits the timeout handling, the readable simulation errors and the
+ * block-on-failure behaviour already proven for fund/transfer.
+ */
+export function useAcquirePositionFlow() {
+  const tx = useTransaction();
+  const { simulationDialogProps, onSimulationPreview } = useTxSimulation();
+
+  const acquirePosition = useCallback(
+    async (positionId: string, buyerAddress: string, sellerAddress: string) => {
+      const { prepareTransferPosition } = await import(
+        "@/services/invoiceService"
+      );
+      return tx.execute(
+        () => prepareTransferPosition(positionId, buyerAddress, sellerAddress),
+        {
+          onSimulationPreview,
+          successMessage: "Position acquired successfully!",
+          txType: "acquire",
+          txDescription: `Acquire position ${positionId}`,
+        }
+      );
+    },
+    [tx, onSimulationPreview]
+  );
+
+  return {
+    acquirePosition,
+    simulationDialogProps,
+    status: tx.status,
+    error: tx.error,
+  };
+}
+
 export function useSecondaryEscrowFlow() {
   const { escrowState, setEscrowStep, setEscrowError, resetEscrow } = useTransactionStore();
   const tx = useTransaction();

--- a/lib/concentrationRisk.ts
+++ b/lib/concentrationRisk.ts
@@ -1,0 +1,175 @@
+/**
+ * Portfolio concentration risk alerts (issue #604).
+ *
+ * `portfolioAllocation` already computes how a portfolio splits across risk
+ * tiers, jurisdictions and debtors. What it does not do is tell the investor
+ * when a split has become dangerous — the allocation chart shows a 70% slice
+ * exactly as calmly as it shows a 7% one.
+ *
+ * This evaluates a portfolio against configured thresholds and returns the
+ * breaches. It is deliberately pure: no toasts, no store access, no clock
+ * beyond what the caller passes in, so the thresholds can be tested exactly.
+ */
+
+export type ConcentrationDimension = "debtor" | "jurisdiction" | "riskTier";
+
+export interface ConcentrationThresholds {
+  /** Percent of portfolio value above which a single debtor is flagged. */
+  debtor: number;
+  /** Percent above which a single jurisdiction is flagged. */
+  jurisdiction: number;
+  /** Percent above which a single risk tier is flagged. */
+  riskTier: number;
+}
+
+/**
+ * Defaults chosen to be actionable rather than merely conservative: a single
+ * debtor at 25% of a private-credit book is a genuine single-name risk, while
+ * jurisdiction and tier concentration are common and only interesting higher up.
+ */
+export const DEFAULT_CONCENTRATION_THRESHOLDS: ConcentrationThresholds = {
+  debtor: 25,
+  jurisdiction: 40,
+  riskTier: 50,
+};
+
+export interface ConcentrationPosition {
+  investedAmount: number;
+  invoice?: {
+    riskTier?: string;
+    metadata?: {
+      jurisdiction?: string;
+      debtorName?: string;
+    };
+  } | null;
+}
+
+export interface ConcentrationAlert {
+  dimension: ConcentrationDimension;
+  /** The concentrated value, e.g. "Acme Corp" or "US". */
+  name: string;
+  /** Share of portfolio value, as a percentage. */
+  percent: number;
+  /** Threshold that was exceeded. */
+  threshold: number;
+  /** Currency value concentrated in this bucket. */
+  value: number;
+  /** Stable identity for dismissal/snooze, independent of the percentage. */
+  key: string;
+  severity: "warning" | "critical";
+}
+
+/** A breach at or beyond 1.5x its threshold is treated as critical. */
+const CRITICAL_MULTIPLIER = 1.5;
+
+const UNKNOWN = "Unknown";
+
+function bucketOf(
+  position: ConcentrationPosition,
+  dimension: ConcentrationDimension
+): string {
+  const invoice = position.invoice;
+  if (!invoice) return UNKNOWN;
+  if (dimension === "riskTier") return invoice.riskTier || UNKNOWN;
+  if (dimension === "jurisdiction") return invoice.metadata?.jurisdiction || UNKNOWN;
+  return invoice.metadata?.debtorName || UNKNOWN;
+}
+
+/** Stable alert identity: dimension + bucket, never the percentage. */
+export function concentrationKey(
+  dimension: ConcentrationDimension,
+  name: string
+): string {
+  return `${dimension}:${name}`;
+}
+
+/**
+ * Evaluate a portfolio and return every threshold breach, worst first.
+ *
+ * Positions with no positive invested amount are ignored: they contribute
+ * nothing to concentration and would only distort the denominator.
+ */
+export function evaluateConcentration(
+  positions: ConcentrationPosition[],
+  thresholds: ConcentrationThresholds = DEFAULT_CONCENTRATION_THRESHOLDS
+): ConcentrationAlert[] {
+  const funded = positions.filter(
+    (p) => Number.isFinite(p.investedAmount) && p.investedAmount > 0
+  );
+
+  const total = funded.reduce((sum, p) => sum + p.investedAmount, 0);
+  if (total <= 0) return [];
+
+  const dimensions: ConcentrationDimension[] = [
+    "debtor",
+    "jurisdiction",
+    "riskTier",
+  ];
+
+  const alerts: ConcentrationAlert[] = [];
+
+  for (const dimension of dimensions) {
+    const threshold = thresholds[dimension];
+    // A non-positive threshold disables the dimension rather than flagging
+    // everything, which is the intuitive reading of "0 = off".
+    if (!Number.isFinite(threshold) || threshold <= 0) continue;
+
+    const totals = new Map<string, number>();
+    for (const position of funded) {
+      const bucket = bucketOf(position, dimension);
+      totals.set(bucket, (totals.get(bucket) ?? 0) + position.investedAmount);
+    }
+
+    for (const [name, value] of totals) {
+      const percent = (value / total) * 100;
+      if (percent <= threshold) continue;
+
+      alerts.push({
+        dimension,
+        name,
+        percent,
+        threshold,
+        value,
+        key: concentrationKey(dimension, name),
+        severity:
+          percent >= threshold * CRITICAL_MULTIPLIER ? "critical" : "warning",
+      });
+    }
+  }
+
+  return alerts.sort((a, b) => b.percent - a.percent);
+}
+
+export interface SnoozeEntry {
+  key: string;
+  /** Epoch ms after which the alert becomes visible again. */
+  until: number;
+}
+
+/**
+ * Drop alerts the investor has dismissed or snoozed.
+ *
+ * Snoozes are compared against a caller-supplied `now` so the filter stays
+ * pure and the expiry boundary is testable.
+ */
+export function filterActiveAlerts(
+  alerts: ConcentrationAlert[],
+  dismissedKeys: string[],
+  snoozes: SnoozeEntry[],
+  now: number = Date.now()
+): ConcentrationAlert[] {
+  const dismissed = new Set(dismissedKeys);
+  const snoozedUntil = new Map(snoozes.map((s) => [s.key, s.until]));
+
+  return alerts.filter((alert) => {
+    if (dismissed.has(alert.key)) return false;
+    const until = snoozedUntil.get(alert.key);
+    return until === undefined || now >= until;
+  });
+}
+
+/** Common snooze durations offered in the UI. */
+export const SNOOZE_DURATIONS_MS = {
+  day: 24 * 60 * 60 * 1000,
+  week: 7 * 24 * 60 * 60 * 1000,
+} as const;

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -113,6 +113,29 @@ const clientSchema = z.object({
     .string()
     .transform((v) => parseInt(v, 10))
     .default("10000"),
+
+  // ─── Secondary market fees (issue #597) ────────────────────────────────────
+  // Expressed in basis points so the config carries no rounding of its own:
+  // 100 bps = 1%. Both are capped at 10_000 bps (100%) — a fee schedule that
+  // could exceed the trade value is a misconfiguration, not a business choice.
+
+  /** Protocol fee on a secondary acquisition, in basis points. */
+  NEXT_PUBLIC_SECONDARY_PROTOCOL_FEE_BPS: z
+    .string()
+    .transform((v) => Number.parseInt(v, 10))
+    .refine((v) => Number.isFinite(v) && v >= 0 && v <= 10_000, {
+      message: "Protocol fee must be between 0 and 10000 bps",
+    })
+    .default("50"),
+
+  /** Marketplace/venue fee on a secondary acquisition, in basis points. */
+  NEXT_PUBLIC_SECONDARY_MARKET_FEE_BPS: z
+    .string()
+    .transform((v) => Number.parseInt(v, 10))
+    .refine((v) => Number.isFinite(v) && v >= 0 && v <= 10_000, {
+      message: "Market fee must be between 0 and 10000 bps",
+    })
+    .default("25"),
 });
 
 // ─── Server-only schema ───────────────────────────────────────────────────────
@@ -150,6 +173,10 @@ const clientEnv = {
   NEXT_PUBLIC_ENABLE_MOCK_DATA: process.env.NEXT_PUBLIC_ENABLE_MOCK_DATA,
   NEXT_PUBLIC_ENABLE_DEVTOOLS: process.env.NEXT_PUBLIC_ENABLE_DEVTOOLS,
   NEXT_PUBLIC_KYC_FUND_THRESHOLD: process.env.NEXT_PUBLIC_KYC_FUND_THRESHOLD,
+  NEXT_PUBLIC_SECONDARY_PROTOCOL_FEE_BPS:
+    process.env.NEXT_PUBLIC_SECONDARY_PROTOCOL_FEE_BPS,
+  NEXT_PUBLIC_SECONDARY_MARKET_FEE_BPS:
+    process.env.NEXT_PUBLIC_SECONDARY_MARKET_FEE_BPS,
 };
 
 // ─── Parse & validate ─────────────────────────────────────────────────────────

--- a/lib/secondaryFees.ts
+++ b/lib/secondaryFees.ts
@@ -1,0 +1,125 @@
+/**
+ * Secondary market fee schedule (issue #597).
+ *
+ * Fees are disclosed before a trade is confirmed, so the numbers on screen and
+ * the numbers charged must come from one place. This module is that place: it
+ * owns the arithmetic, and the UI only formats what it returns.
+ *
+ * ## Why basis points, and why integers
+ *
+ * Rates are configured in basis points (100 bps = 1%) rather than as decimal
+ * percentages, because `0.5%` in a float config is a rounding argument waiting
+ * to happen. All rounding is deliberate and happens once, at the end.
+ *
+ * Money is rounded to cents with `Math.round`, and the **total is derived by
+ * addition of the rounded parts**, never rounded separately. If the parts were
+ * rounded independently of the total, a disclosed breakdown could fail to add
+ * up to the disclosed total by a cent — which is exactly the kind of detail
+ * that destroys trust in a fee disclosure.
+ */
+
+export interface FeeSchedule {
+  /** Protocol fee, basis points. */
+  protocolBps: number;
+  /** Marketplace/venue fee, basis points. */
+  marketBps: number;
+}
+
+export interface FeeBreakdown {
+  /** Price of the position itself, before fees. */
+  subtotal: number;
+  /** Protocol fee in currency units. */
+  protocolFee: number;
+  /** Marketplace fee in currency units. */
+  marketFee: number;
+  /** protocolFee + marketFee. */
+  totalFees: number;
+  /** subtotal + totalFees — what the buyer actually pays. */
+  total: number;
+  /** Combined rate in basis points, for display. */
+  totalBps: number;
+  /** The schedule these figures were computed from. */
+  schedule: FeeSchedule;
+}
+
+const BPS_DIVISOR = 10_000;
+
+/** Round to cents. Kept in one place so every figure rounds identically. */
+function toCents(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * Apply a basis-point rate to an amount.
+ *
+ * Exported for testing: the bps→currency step is where a fee disclosure most
+ * plausibly goes wrong, so it is worth pinning on its own.
+ */
+export function applyBps(amount: number, bps: number): number {
+  if (!Number.isFinite(amount) || !Number.isFinite(bps)) return 0;
+  if (amount <= 0 || bps <= 0) return 0;
+  return toCents((amount * bps) / BPS_DIVISOR);
+}
+
+/**
+ * Compute the full fee breakdown for an acquisition.
+ *
+ * A non-finite or negative price yields an all-zero breakdown rather than
+ * `NaN`, so a malformed listing cannot render "$NaN" into a disclosure.
+ */
+export function computeAcquisitionFees(
+  askPrice: number,
+  schedule: FeeSchedule
+): FeeBreakdown {
+  const safePrice =
+    Number.isFinite(askPrice) && askPrice > 0 ? toCents(askPrice) : 0;
+
+  const protocolBps = normaliseBps(schedule.protocolBps);
+  const marketBps = normaliseBps(schedule.marketBps);
+
+  const protocolFee = applyBps(safePrice, protocolBps);
+  const marketFee = applyBps(safePrice, marketBps);
+
+  // Sum the rounded parts so the breakdown always reconciles with the total.
+  const totalFees = toCents(protocolFee + marketFee);
+
+  return {
+    subtotal: safePrice,
+    protocolFee,
+    marketFee,
+    totalFees,
+    total: toCents(safePrice + totalFees),
+    totalBps: protocolBps + marketBps,
+    schedule: { protocolBps, marketBps },
+  };
+}
+
+/** Clamp a configured rate into [0, 10000] bps. */
+function normaliseBps(bps: number): number {
+  if (!Number.isFinite(bps) || bps <= 0) return 0;
+  return Math.min(Math.round(bps), BPS_DIVISOR);
+}
+
+/**
+ * Render a basis-point rate as a percentage string.
+ *
+ * Trailing zeros are trimmed so 50 bps reads "0.5%", not "0.50%", while 25 bps
+ * still reads "0.25%".
+ */
+export function formatBps(bps: number): string {
+  const safe = normaliseBps(bps);
+  const percent = safe / 100;
+  const fixed = percent.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+  return `${fixed === "" ? "0" : fixed}%`;
+}
+
+/** Read the configured schedule from validated env. */
+export function getFeeSchedule(source: {
+  NEXT_PUBLIC_SECONDARY_PROTOCOL_FEE_BPS: number;
+  NEXT_PUBLIC_SECONDARY_MARKET_FEE_BPS: number;
+}): FeeSchedule {
+  return {
+    protocolBps: normaliseBps(source.NEXT_PUBLIC_SECONDARY_PROTOCOL_FEE_BPS),
+    marketBps: normaliseBps(source.NEXT_PUBLIC_SECONDARY_MARKET_FEE_BPS),
+  };
+}

--- a/lib/vintageCohorts.ts
+++ b/lib/vintageCohorts.ts
@@ -1,0 +1,196 @@
+/**
+ * Vintage cohort analytics (issue #605).
+ *
+ * Private-credit books are read by *vintage*: positions funded in the same
+ * month share an underwriting environment, so comparing March's yield to
+ * September's is how you see whether underwriting is drifting. The analytics
+ * page already had date filters but no way to group by funding month.
+ *
+ * Pure module: dates in, cohort rows out. No charts, no store, no clock unless
+ * the caller supplies one.
+ */
+
+export interface CohortPosition {
+  investedAmount: number;
+  /**
+   * ISO timestamp of when the position was funded.
+   *
+   * The issue specifies `fundedAt`, but `InvestorPosition` in `types/invoice.ts`
+   * calls the same instant `investedAt`. Both are accepted so the module works
+   * against the real data without renaming a shared type, and `fundedAt` wins
+   * if a caller supplies both.
+   */
+  fundedAt?: string | null;
+  /** Alias for `fundedAt`, matching `InvestorPosition`. */
+  investedAt?: string | null;
+  /** Annualised percentage rate, if known. */
+  apr?: number | null;
+  /** Terminal state, used to derive the default proxy. */
+  status?: string | null;
+}
+
+export interface CohortRow {
+  /** Sortable cohort id, `YYYY-MM`. */
+  month: string;
+  /** Display label, e.g. "Mar 2026". */
+  label: string;
+  positionCount: number;
+  totalInvested: number;
+  /** Invested-amount-weighted APR; null when no position carries an APR. */
+  weightedApr: number | null;
+  /** Positions in a defaulted state. */
+  defaultedCount: number;
+  /** defaultedCount / positionCount, as a percentage. */
+  defaultRate: number;
+  /** True when the month falls inside the range but has no positions. */
+  isEmpty: boolean;
+}
+
+/** Statuses treated as a default proxy. */
+const DEFAULTED_STATUSES = new Set(["defaulted", "default", "written_off", "charged_off"]);
+
+const MONTH_LABELS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/**
+ * Bucket key for a funding date, in UTC.
+ *
+ * UTC deliberately: bucketing in local time would move a position between
+ * cohorts depending on the viewer's timezone, so two people could read the same
+ * portfolio differently.
+ */
+export function vintageMonthKey(iso: string): string | null {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return null;
+  const d = new Date(ms);
+  const month = `${d.getUTCMonth() + 1}`.padStart(2, "0");
+  return `${d.getUTCFullYear()}-${month}`;
+}
+
+/** "2026-03" -> "Mar 2026". */
+export function formatMonthLabel(month: string): string {
+  const [year, m] = month.split("-");
+  const index = Number.parseInt(m, 10) - 1;
+  if (!year || Number.isNaN(index) || index < 0 || index > 11) return month;
+  return `${MONTH_LABELS[index]} ${year}`;
+}
+
+/** Every month from `first` to `last` inclusive, so gaps stay visible. */
+export function monthRange(first: string, last: string): string[] {
+  const [fy, fm] = first.split("-").map(Number);
+  const [ly, lm] = last.split("-").map(Number);
+  if (!fy || !fm || !ly || !lm) return [];
+
+  const months: string[] = [];
+  let year = fy;
+  let month = fm;
+  // Guard against a reversed range producing an unbounded loop.
+  while (year < ly || (year === ly && month <= lm)) {
+    months.push(`${year}-${`${month}`.padStart(2, "0")}`);
+    month += 1;
+    if (month > 12) {
+      month = 1;
+      year += 1;
+    }
+  }
+  return months;
+}
+
+export interface CohortOptions {
+  /**
+   * Emit months with no positions between the first and last cohort.
+   *
+   * On by default: a gap month is information — it usually means origination
+   * stopped — and hiding it makes a sparse book look continuous.
+   */
+  includeEmptyMonths?: boolean;
+}
+
+/**
+ * Group positions into vintage cohorts, oldest first.
+ *
+ * Positions with a missing or unparseable `fundedAt` are excluded rather than
+ * bucketed into a placeholder cohort, which would silently distort every
+ * comparison.
+ */
+export function buildVintageCohorts(
+  positions: CohortPosition[],
+  options: CohortOptions = {}
+): CohortRow[] {
+  const { includeEmptyMonths = true } = options;
+
+  const buckets = new Map<string, CohortPosition[]>();
+
+  for (const position of positions) {
+    const fundedAt = position.fundedAt ?? position.investedAt;
+    if (!fundedAt) continue;
+    const key = vintageMonthKey(fundedAt);
+    if (!key) continue;
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(position);
+    else buckets.set(key, [position]);
+  }
+
+  if (buckets.size === 0) return [];
+
+  const present = Array.from(buckets.keys()).sort();
+  const months = includeEmptyMonths
+    ? monthRange(present[0], present[present.length - 1])
+    : present;
+
+  return months.map((month) => {
+    const bucket = buckets.get(month) ?? [];
+
+    const totalInvested = bucket.reduce(
+      (sum, p) => sum + (Number.isFinite(p.investedAmount) ? p.investedAmount : 0),
+      0
+    );
+
+    // Weight APR by invested amount: a $1m position at 8% should not be
+    // averaged against a $1k position at 20% as though they were equals.
+    let weightedApr: number | null = null;
+    const withApr = bucket.filter(
+      (p) => typeof p.apr === "number" && Number.isFinite(p.apr) && p.investedAmount > 0
+    );
+    if (withApr.length > 0) {
+      const weightTotal = withApr.reduce((sum, p) => sum + p.investedAmount, 0);
+      if (weightTotal > 0) {
+        weightedApr =
+          withApr.reduce((sum, p) => sum + (p.apr as number) * p.investedAmount, 0) /
+          weightTotal;
+      }
+    }
+
+    const defaultedCount = bucket.filter((p) =>
+      DEFAULTED_STATUSES.has((p.status ?? "").toLowerCase())
+    ).length;
+
+    return {
+      month,
+      label: formatMonthLabel(month),
+      positionCount: bucket.length,
+      totalInvested,
+      weightedApr,
+      defaultedCount,
+      defaultRate: bucket.length > 0 ? (defaultedCount / bucket.length) * 100 : 0,
+      isEmpty: bucket.length === 0,
+    };
+  });
+}
+
+/** Flatten cohorts into CSV rows for portfolio export. */
+export function cohortsToExportRows(
+  cohorts: CohortRow[]
+): Array<Record<string, string | number>> {
+  return cohorts.map((c) => ({
+    vintageMonth: c.month,
+    vintageLabel: c.label,
+    positionCount: c.positionCount,
+    totalInvested: c.totalInvested,
+    weightedApr: c.weightedApr === null ? "" : c.weightedApr.toFixed(2),
+    defaultedCount: c.defaultedCount,
+    defaultRatePercent: c.defaultRate.toFixed(2),
+  }));
+}

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -859,5 +859,41 @@
       "companyNameMinLength": "يجب أن يتكون اسم الشركة من حرفين على الأقل",
       "walletAddressInvalid": "تنسيق مفتاح Stellar العام غير صالح"
     }
+  },
+  "secondaryFees": {
+    "title": "جدول الرسوم",
+    "subtitle": "تُعرض جميع الرسوم قبل التأكيد.",
+    "subtotal": "سعر المركز",
+    "protocolFee": "رسوم البروتوكول ({rate})",
+    "marketFee": "رسوم السوق ({rate})",
+    "totalFees": "إجمالي الرسوم ({rate})",
+    "total": "المبلغ المستحق",
+    "noFees": "لا توجد رسوم على هذا الاستحواذ.",
+    "listingNote": "يدفع المشتري {rate} رسومًا فوق السعر المطلوب."
+  },
+  "concentrationRisk": {
+    "title": "مخاطر التركّز",
+    "debtor": "يمثل {name} نسبة {percent}% من محفظتك",
+    "jurisdiction": "يمثل {name} نسبة {percent}% من محفظتك",
+    "riskTier": "تمثل الفئة {name} نسبة {percent}% من محفظتك",
+    "thresholdNote": "أعلى من حد التنبيه {threshold}%.",
+    "dismiss": "تجاهل",
+    "snoozeDay": "تأجيل يوم واحد",
+    "snoozeWeek": "تأجيل أسبوع",
+    "settings": "ضبط الحدود",
+    "critical": "حرج",
+    "warning": "تحذير"
+  },
+  "vintageCohorts": {
+    "title": "مجموعات حسب شهر التمويل",
+    "subtitle": "المراكز مجمّعة حسب شهر تمويلها.",
+    "month": "الدفعة",
+    "positions": "المراكز",
+    "invested": "المستثمر",
+    "weightedApr": "العائد السنوي المرجّح",
+    "defaultRate": "معدل التعثر",
+    "empty": "لا توجد مراكز ممولة هذا الشهر",
+    "noData": "لا توجد مراكز ممولة للتجميع بعد.",
+    "export": "تصدير المجموعات"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -308,7 +308,7 @@
       "subtitleRejected": "Your previous verification attempt was unsuccessful. Please re-submit with a clear, uncropped document.",
       "ctaNone": "Start Verification",
       "ctaRejected": "Re-verify Business",
-      "ctaPending": "Checking verification status\u2026",
+      "ctaPending": "Checking verification status…",
       "backToWizard": "Go Back",
       "whatYouNeed": "What you will need:",
       "needIdDoc": "Government-issued ID or business registration document",
@@ -874,5 +874,41 @@
       "companyNameMinLength": "Company name must be at least 2 characters",
       "walletAddressInvalid": "Invalid Stellar public key format"
     }
+  },
+  "secondaryFees": {
+    "title": "Fee schedule",
+    "subtitle": "All fees are disclosed before you confirm.",
+    "subtotal": "Position price",
+    "protocolFee": "Protocol fee ({rate})",
+    "marketFee": "Marketplace fee ({rate})",
+    "totalFees": "Total fees ({rate})",
+    "total": "You pay",
+    "noFees": "No fees apply to this acquisition.",
+    "listingNote": "Buyer pays {rate} in fees on top of the ask price."
+  },
+  "concentrationRisk": {
+    "title": "Concentration risk",
+    "debtor": "{name} is {percent}% of your portfolio",
+    "jurisdiction": "{name} is {percent}% of your portfolio",
+    "riskTier": "Tier {name} is {percent}% of your portfolio",
+    "thresholdNote": "Above your {threshold}% alert threshold.",
+    "dismiss": "Dismiss",
+    "snoozeDay": "Snooze 1 day",
+    "snoozeWeek": "Snooze 1 week",
+    "settings": "Adjust thresholds",
+    "critical": "Critical",
+    "warning": "Warning"
+  },
+  "vintageCohorts": {
+    "title": "Vintage cohorts",
+    "subtitle": "Positions grouped by the month they were funded.",
+    "month": "Vintage",
+    "positions": "Positions",
+    "invested": "Invested",
+    "weightedApr": "Weighted APR",
+    "defaultRate": "Default rate",
+    "empty": "No positions funded this month",
+    "noData": "No funded positions to group yet.",
+    "export": "Export cohorts"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -859,5 +859,41 @@
       "companyNameMinLength": "El nombre de la empresa debe tener al menos 2 caracteres",
       "walletAddressInvalid": "Formato de clave pública de Stellar inválido"
     }
+  },
+  "secondaryFees": {
+    "title": "Esquema de comisiones",
+    "subtitle": "Todas las comisiones se muestran antes de confirmar.",
+    "subtotal": "Precio de la posición",
+    "protocolFee": "Comisión del protocolo ({rate})",
+    "marketFee": "Comisión del mercado ({rate})",
+    "totalFees": "Comisiones totales ({rate})",
+    "total": "Total a pagar",
+    "noFees": "Esta adquisición no tiene comisiones.",
+    "listingNote": "El comprador paga {rate} en comisiones sobre el precio solicitado."
+  },
+  "concentrationRisk": {
+    "title": "Riesgo de concentración",
+    "debtor": "{name} representa el {percent}% de tu cartera",
+    "jurisdiction": "{name} representa el {percent}% de tu cartera",
+    "riskTier": "El nivel {name} representa el {percent}% de tu cartera",
+    "thresholdNote": "Por encima de tu umbral de alerta del {threshold}%.",
+    "dismiss": "Descartar",
+    "snoozeDay": "Posponer 1 día",
+    "snoozeWeek": "Posponer 1 semana",
+    "settings": "Ajustar umbrales",
+    "critical": "Crítico",
+    "warning": "Advertencia"
+  },
+  "vintageCohorts": {
+    "title": "Cohortes por añada",
+    "subtitle": "Posiciones agrupadas por el mes en que se financiaron.",
+    "month": "Añada",
+    "positions": "Posiciones",
+    "invested": "Invertido",
+    "weightedApr": "TAE ponderada",
+    "defaultRate": "Tasa de impago",
+    "empty": "Ninguna posición financiada este mes",
+    "noData": "Aún no hay posiciones financiadas para agrupar.",
+    "export": "Exportar cohortes"
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -851,5 +851,41 @@
       "companyNameMinLength": "O nome da empresa deve ter pelo menos 2 caracteres",
       "walletAddressInvalid": "Formato de chave pública Stellar inválido"
     }
+  },
+  "secondaryFees": {
+    "title": "Tabela de taxas",
+    "subtitle": "Todas as taxas são exibidas antes da confirmação.",
+    "subtotal": "Preço da posição",
+    "protocolFee": "Taxa do protocolo ({rate})",
+    "marketFee": "Taxa do mercado ({rate})",
+    "totalFees": "Taxas totais ({rate})",
+    "total": "Total a pagar",
+    "noFees": "Esta aquisição não possui taxas.",
+    "listingNote": "O comprador paga {rate} em taxas sobre o preço pedido."
+  },
+  "concentrationRisk": {
+    "title": "Risco de concentração",
+    "debtor": "{name} representa {percent}% da sua carteira",
+    "jurisdiction": "{name} representa {percent}% da sua carteira",
+    "riskTier": "O nível {name} representa {percent}% da sua carteira",
+    "thresholdNote": "Acima do seu limite de alerta de {threshold}%.",
+    "dismiss": "Dispensar",
+    "snoozeDay": "Adiar 1 dia",
+    "snoozeWeek": "Adiar 1 semana",
+    "settings": "Ajustar limites",
+    "critical": "Crítico",
+    "warning": "Aviso"
+  },
+  "vintageCohorts": {
+    "title": "Safras por mês",
+    "subtitle": "Posições agrupadas pelo mês em que foram financiadas.",
+    "month": "Safra",
+    "positions": "Posições",
+    "invested": "Investido",
+    "weightedApr": "APR ponderada",
+    "defaultRate": "Taxa de inadimplência",
+    "empty": "Nenhuma posição financiada neste mês",
+    "noData": "Ainda não há posições financiadas para agrupar.",
+    "export": "Exportar safras"
   }
 }

--- a/store/settingsStore.ts
+++ b/store/settingsStore.ts
@@ -5,6 +5,13 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+import {
+  DEFAULT_CONCENTRATION_THRESHOLDS,
+  SNOOZE_DURATIONS_MS,
+  type ConcentrationThresholds,
+  type SnoozeEntry,
+} from "@/lib/concentrationRisk";
+
 export type MaturityReminderDays = 1 | 3 | 7;
 export type Persona = "investor" | "sme";
 
@@ -38,6 +45,25 @@ export const DEFAULT_TOUR_SETTINGS: TourSettings = {
 
 const TOUR_STORAGE_KEY = "kora-tour-done";
 
+/**
+ * Concentration alert state (issue #604).
+ *
+ * Dismissals and snoozes are keyed by `dimension:bucket`, not by percentage, so
+ * a dismissal survives the number moving. Otherwise every recomputation would
+ * resurrect an alert the investor had already acknowledged.
+ */
+export interface ConcentrationSettings {
+  thresholds: ConcentrationThresholds;
+  dismissedKeys: string[];
+  snoozes: SnoozeEntry[];
+}
+
+export const DEFAULT_CONCENTRATION_SETTINGS: ConcentrationSettings = {
+  thresholds: DEFAULT_CONCENTRATION_THRESHOLDS,
+  dismissedKeys: [],
+  snoozes: [],
+};
+
 interface SettingsStore {
   notifications: NotificationPrefs;
   setNotifications: (prefs: Partial<NotificationPrefs>) => void;
@@ -46,6 +72,11 @@ interface SettingsStore {
   setTourSettings: (settings: Partial<TourSettings>) => void;
   resetTourSettings: () => void;
   restartTour: (persona?: Persona) => void;
+  concentration: ConcentrationSettings;
+  setConcentrationThresholds: (thresholds: Partial<ConcentrationThresholds>) => void;
+  dismissConcentrationAlert: (key: string) => void;
+  snoozeConcentrationAlert: (key: string, durationMs?: number) => void;
+  resetConcentrationAlerts: () => void;
 }
 
 export const useSettingsStore = create<SettingsStore>()(
@@ -80,6 +111,39 @@ export const useSettingsStore = create<SettingsStore>()(
         }
         set({ tour: DEFAULT_TOUR_SETTINGS });
       },
+      concentration: DEFAULT_CONCENTRATION_SETTINGS,
+      setConcentrationThresholds: (thresholds) =>
+        set((s) => ({
+          concentration: {
+            ...s.concentration,
+            thresholds: { ...s.concentration.thresholds, ...thresholds },
+          },
+        })),
+      dismissConcentrationAlert: (key) =>
+        set((s) => ({
+          concentration: {
+            ...s.concentration,
+            dismissedKeys: s.concentration.dismissedKeys.includes(key)
+              ? s.concentration.dismissedKeys
+              : [...s.concentration.dismissedKeys, key],
+          },
+        })),
+      snoozeConcentrationAlert: (key, durationMs = SNOOZE_DURATIONS_MS.day) =>
+        set((s) => ({
+          concentration: {
+            ...s.concentration,
+            // Replace any existing snooze for this key rather than stacking, so
+            // snoozing twice does not silently double the delay.
+            snoozes: [
+              ...s.concentration.snoozes.filter((entry) => entry.key !== key),
+              { key, until: Date.now() + durationMs },
+            ],
+          },
+        })),
+      resetConcentrationAlerts: () =>
+        set((s) => ({
+          concentration: { ...s.concentration, dismissedKeys: [], snoozes: [] },
+        })),
       restartTour: (persona) => {
         if (typeof window !== "undefined") {
           try {


### PR DESCRIPTION
## Description

Four assigned issues across Secondary Market and Analytics. They share a spine — the fee schedule from #597 is disclosed in the acquire flow from #594 — so they are proposed together.

> **Reviewer note:** each issue suggests its own branch, and these split cleanly into four if you'd prefer. Say the word.

| Issue | Area | What landed |
| --- | --- | --- |
| #594 | Secondary Market | Acquire runs through the existing simulation gate |
| #597 | Secondary Market | Env-configurable fee schedule, disclosed before confirm |
| #604 | Analytics | Concentration alerts with dismiss/snooze |
| #605 | Analytics | Vintage cohort table + export |

## Linked Issue

Closes #594
Closes #597
Closes #604
Closes #605

---

## #594 — Secondary acquire-position simulation preview

The Acquire button was a placeholder:

```tsx
onClick={() => {
  alert(`Transfer position flow initiated for ${item.positionId}`);
}}
```

So the one flow where a buyer commits capital against **someone else's** position had the weakest pre-signature safety in the app, while funding and transfer both had a simulation gate.

`useAcquirePositionFlow` reuses that same gate rather than adding a parallel one, so acquire inherits the 10-second simulation timeout, the readable error mapping and the block-on-failure behaviour already proven for fund/transfer. `TxSimulationPreview` already refuses to proceed when a simulation errors (`canProceed = !isSimulating && !hasError`), and `useTransaction` still skips simulation for `mock_` XDRs, so the mock path is unaffected.

- ✅ Preview shown before sign · ✅ Failure blocks submit · ✅ Fees visible · ✅ Mock XDR path works

## #597 — Secondary market fee schedule disclosure

`lib/secondaryFees` owns the arithmetic; the UI only formats what it returns, so the figures shown and the figures charged cannot diverge.

Two decisions worth reviewing:

**Basis points, not float percentages.** `0.5%` in a float config is a rounding argument waiting to happen. Rates are integers in bps, validated and clamped to `[0, 10000]` — a fee schedule that could exceed the trade value is a misconfiguration, not a business choice.

**The breakdown always reconciles.** Money is rounded once, and the total is derived by *adding the rounded parts* rather than rounding separately. If the parts were rounded independently, a disclosed breakdown could miss its own total by a cent — precisely the detail that destroys trust in a fee disclosure. There's a test asserting this across a range of awkward prices.

```
NEXT_PUBLIC_SECONDARY_PROTOCOL_FEE_BPS  default 50   (0.5%)
NEXT_PUBLIC_SECONDARY_MARKET_FEE_BPS    default 25   (0.25%)
```

## #604 — Concentration risk alerts

The allocation donut already shows *how* a portfolio splits; it shows a 70% slice exactly as calmly as a 7% one. `lib/concentrationRisk` evaluates debtor / jurisdiction / risk-tier concentration against configurable thresholds and returns the breaches, worst first.

**Alerts are keyed by `dimension:bucket`, never by percentage.** A dismissal has to survive the number moving — otherwise every recomputation resurrects an alert the investor already acknowledged. There's a test asserting the key is stable while the percentage changes.

Other deliberate choices: the threshold comparison is **exclusive** (exactly at threshold does not alert), a breach at ≥1.5× escalates to `critical`, and a **zero threshold disables that dimension** rather than flagging everything — the intuitive reading of "0 = off". Thresholds, dismissals and snoozes persist via `settingsStore`; snoozing twice replaces rather than stacks, so it can't silently double the delay.

## #605 — Vintage cohort analytics

`lib/vintageCohorts` groups positions by funding month.

- **APR is weighted by invested amount**, not position count — a $1m position at 8% should not be averaged against a $1k position at 20% as equals.
- **Bucketing is UTC.** Local-time bucketing would move a position between cohorts depending on the reader's timezone, so two people could read the same portfolio differently.
- **Empty months are emitted**, not hidden: a gap usually means origination stopped, and hiding it makes a sparse book look continuous.
- Cohorts are built from the **already-filtered** positions, so the view respects the page's existing date-range filters. Export is on its own axis (one row per month, so it can't share the position CSV's headers).

### ⚠️ Field-name mismatch in the issue

The issue says to bucket by `fundedAt`, but `InvestorPosition` in `types/invoice.ts` calls that same instant **`investedAt`**. Rather than rename a shared type from an analytics feature, the module accepts either (`fundedAt` wins if both are present), with tests for both.

## i18n

All three new sections added to **en, es, pt-BR and ar** in full key and ICU-placeholder parity.

`scripts/check-i18n-parity.js` already fails on `main` (47 pre-existing mismatches, mostly `network.*`). This branch leaves that count **unchanged at 47** — verified by diffing the reported mismatches before and after — so nothing here adds to it.

---

## Test Plan

**70 new tests, all passing.**

```
__tests__/secondary-fees.test.ts             22 passed
__tests__/vintage-cohorts.test.ts            26 passed
__tests__/concentration-risk.test.ts         17 passed
__tests__/secondary-fee-disclosure.test.tsx   5 passed
```

| | `main` | this branch |
| --- | --- | --- |
| Passing | 868 | **938** (+70) |
| Failing | 222 | **222** (unchanged) |

The failing set is identical and pre-existing — verified by diffing the failing-file lists against a clean tree. One apparent difference was a stack frame moving from `lib/env.ts:233` to `:261` because this branch adds ~28 lines above it; same failure, same cause (required `NEXT_PUBLIC_STELLAR_*` vars are unset in the test env).

- `npm run type-check` — 3 errors, **unchanged from `main`**, none in files this PR adds or touches (all in `services/invoiceService.ts`).
- `npm run lint` — **0 errors**; my files produce no warnings either.

### Not done / not verified

- **Screenshots.** The issues ask for them on UI changes and I have not attached any — no browser in this environment. `app/secondary`, the investor dashboard banner and the analytics cohort table all change visibly and deserve a look before merge.
- **`npm run build`.** Not run here; relying on CI.
- **Docs.** #597 lists "Docs updated" and `docs/architecture.md` is untouched — the new env vars are documented in `lib/env.ts` inline instead. Happy to add an architecture section if you want it in this PR.
- `pnpm-lock.yaml` was generated locally (npm's git-dep install is broken on this machine) and is **deliberately not committed** — the repo stays on `package-lock.json`.
