### PR TITLE
[647] Add a toast when copying the marketplace filter share link

### DIFF
--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -39,6 +39,7 @@ import {
   MarketplaceAprHistogram,
   MarketplaceRiskDistribution,
 } from "@/components/analytics/Charts";
+import { toast } from "sonner";
 import { exportCsv } from "@/lib/export";
 import {
   marketplaceInvoicesToExportRows,
@@ -696,7 +697,11 @@ function MarketplaceContent() {
               <span>Export CSV</span>
             </button>
             <button
-              onClick={() => { navigator.clipboard?.writeText(window.location.href); }}
+              onClick={() => {
+                navigator.clipboard?.writeText(window.location.href).then(() => {
+                  toast.success(t("shareFiltersCopied"));
+                });
+              }}
               aria-label="Copy marketplace filter link to clipboard"
               className="rounded-lg border border-zinc-800 px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-900"
             >

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -125,6 +125,7 @@
     "subtitle": "جارٍ اكتشاف الصفقات...",
     "showing": "عرض {count} فاتورة مدرجة",
     "shareFilters": "مشاركة الفلاتر",
+    "shareFiltersCopied": "تم نسخ رابط الفلتر إلى الحافظة",
     "searchPlaceholder": "ابحث بالمدين أو رقم الفاتورة أو الجهة القضائية…",
     "clearSearch": "مسح البحث",
     "filters": "الفلاتر",

--- a/messages/en.json
+++ b/messages/en.json
@@ -125,6 +125,7 @@
     "subtitle": "Discovering deals...",
     "showing": "Showing {count} listed invoices",
     "shareFilters": "Share Filters",
+    "shareFiltersCopied": "Filter link copied to clipboard",
     "searchPlaceholder": "Search by debtor, invoice number, or jurisdiction…",
     "clearSearch": "Clear search",
     "filters": "Filters",

--- a/messages/es.json
+++ b/messages/es.json
@@ -125,6 +125,7 @@
     "subtitle": "Descubriendo oportunidades...",
     "showing": "Mostrando {count} facturas listadas",
     "shareFilters": "Compartir Filtros",
+    "shareFiltersCopied": "Enlace de filtro copiado al portapapeles",
     "searchPlaceholder": "Buscar por deudor, número de factura o jurisdicción…",
     "clearSearch": "Limpiar búsqueda",
     "filters": "Filtros",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -125,6 +125,7 @@
     "subtitle": "Descobrindo oportunidades...",
     "showing": "Exibindo {count} faturas listadas",
     "shareFilters": "Compartilhar Filtros",
+    "shareFiltersCopied": "Link do filtro copiado para a área de transferência",
     "searchPlaceholder": "Buscar por devedor, número de fatura ou jurisdição…",
     "clearSearch": "Limpar busca",
     "filters": "Filtros",


### PR DESCRIPTION
Closes #647

This PR adds a toast notification when the marketplace filter share link is copied to the clipboard.

Changes:
- Added 	oast.success() call after 
avigator.clipboard.writeText() succeeds in the marketplace page
- Added shareFiltersCopied translation key to all 4 locale files (en, ar, es, pt-BR)