### PR TITLE
[636] Replace SME dashboard hardcoded repayment rate stats

### DIFF
--- a/app/dashboard/sme/page.tsx
+++ b/app/dashboard/sme/page.tsx
@@ -107,6 +107,15 @@ function SMEStatsGrid({ address }: { address: string }) {
     (inv: Invoice) => inv.ownerAddress === address
   );
 
+  const fundedInvoices = myInvoices.filter((i) =>
+    ["fully_funded", "active", "repaid", "defaulted"].includes(i.status)
+  );
+  const repaidInvoices = myInvoices.filter((i) => i.status === "repaid");
+  const repaymentRate =
+    fundedInvoices.length > 0
+      ? Math.round((repaidInvoices.length / fundedInvoices.length) * 100)
+      : 0;
+
   const stats = [
     {
       label: "Total Financed",
@@ -131,9 +140,9 @@ function SMEStatsGrid({ address }: { address: string }) {
     },
     {
       label: "Repayment Rate",
-      value: "100%",
-      change: "All-time",
-      changePositive: true,
+      value: `${repaymentRate}%`,
+      change: `${repaidInvoices.length}/${fundedInvoices.length} repaid`,
+      changePositive: repaymentRate >= 80,
       icon: <CheckCircle2 className="h-4 w-4" />,
     },
   ];


### PR DESCRIPTION
Closes #636

This PR replaces the hardcoded '100%' repayment rate stat on the SME dashboard with a dynamically calculated value based on actual invoice data.

Changes:
- Computed repayment rate as: (repaid invoices / funded invoices) * 100
- Funded invoices are defined as those with status: fully_funded, active, repaid, or defaulted
- Repayment rate is displayed as a percentage with a subtitle showing the actual count (e.g., '3/5 repaid')
- The changePositive indicator shows green when rate >= 80%, orange/red otherwise