### PR TITLE
[659] Add visible breadcrumb navigation on invoice detail

### DIFF
--- a/app/marketplace/[id]/InvoiceDetailClient.tsx
+++ b/app/marketplace/[id]/InvoiceDetailClient.tsx
@@ -69,6 +69,7 @@ import {
 } from "@/hooks/useUsdcBalance";
 import { PrintLayout, PrintButton } from "@/components/ui/print-layout";
 import { InvoiceOrderBookDepth } from "@/components/invoice/InvoiceOrderBookDepth";
+import { Breadcrumb } from "@/components/ui/breadcrumb";
 
 export default function InvoiceDetailClient({ id }: { id: string }) {
   const t = useTranslations("invoiceDetail");
@@ -366,12 +367,13 @@ Stellar Testnet Transaction Hash: ${txHash}`);
       {/* JSON-LD is rendered server-side in page.tsx for crawler-friendly SEO */}
       <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
         <div className="mb-6 flex items-center justify-between">
-          <Link
-            href="/marketplace"
-            className="inline-flex items-center gap-2 text-sm text-zinc-500 hover:text-zinc-300"
-          >
-            <ArrowLeft className="h-4 w-4" /> {t("backToMarketplace")}
-          </Link>
+          <Breadcrumb
+            items={[
+              { label: "Home", href: "/" },
+              { label: "Marketplace", href: "/marketplace" },
+              { label: metadata.invoiceNumber },
+            ]}
+          />
           <PrintButton label="Print / Save PDF" />{" "}
         </div>
 

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
+  items: BreadcrumbItem[];
+}
+
+export function Breadcrumb({ items, className, ...props }: BreadcrumbProps) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn("flex items-center gap-1.5 text-sm", className)}
+      {...props}
+    >
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        return (
+          <React.Fragment key={item.label}>
+            {index > 0 && (
+              <ChevronRight className="h-3.5 w-3.5 text-zinc-600" />
+            )}
+            {item.href && !isLast ? (
+              <Link
+                href={item.href}
+                className="text-zinc-500 hover:text-zinc-300 transition-colors"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span
+                className={cn(
+                  isLast
+                    ? "font-medium text-zinc-300"
+                    : "text-zinc-500"
+                )}
+              >
+                {item.label}
+              </span>
+            )}
+          </React.Fragment>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
Closes #659

This PR adds a visible breadcrumb navigation to the invoice detail page, replacing the simple 'Back to Marketplace' link.

Changes:
- Created a new reusable Breadcrumb component at components/ui/breadcrumb.tsx
- The breadcrumb displays: Home > Marketplace > [Invoice Number]
- Each breadcrumb item (except the current page) is a clickable link
- The current page is displayed as bold text
- Styled with chevron separators between items