### PR TITLE
fix & test: resolve #671, #668, #667, and #669

### DIFF
--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -178,33 +178,6 @@ function DualSlider({
 }) {
   const t = useTranslations("marketplace");
   const [minVal, maxVal] = value;
-  const minValRef = useRef(minVal);
-  const maxValRef = useRef(maxVal);
-  const rangeRef = useRef<HTMLDivElement>(null);
-
-  const getPercent = useCallback(
-    (value: number) => Math.round(((value - min) / (max - min)) * 100),
-    [min, max]
-  );
-
-  useEffect(() => {
-    const minPercent = getPercent(minVal);
-    const maxPercent = getPercent(maxValRef.current);
-
-    if (rangeRef.current) {
-      rangeRef.current.style.left = `${minPercent}%`;
-      rangeRef.current.style.width = `${maxPercent - minPercent}%`;
-    }
-  }, [minVal, getPercent]);
-
-  useEffect(() => {
-    const minPercent = getPercent(minValRef.current);
-    const maxPercent = getPercent(maxVal);
-
-    if (rangeRef.current) {
-      rangeRef.current.style.width = `${maxPercent - minPercent}%`;
-    }
-  }, [maxVal, getPercent]);
 
   return (
     <div className="relative flex w-full flex-col gap-2">
@@ -214,49 +187,14 @@ function DualSlider({
           {minVal}% - {maxVal}%
         </span>
       </div>
-      <div className="relative h-6 flex items-center" role="group" aria-labelledby="apr-range-label">
-        <input
-          type="range"
-          min={min}
-          max={max}
-          value={minVal}
-          aria-label={`Minimum APR: ${minVal}%`}
-          aria-valuemin={min}
-          aria-valuemax={max}
-          aria-valuenow={minVal}
-          onChange={(event) => {
-            const val = Math.min(Number(event.target.value), maxVal - 1);
-            onChange([val, maxVal]);
-            minValRef.current = val;
-          }}
-          className="pointer-events-none absolute z-30 h-1 w-full appearance-none bg-transparent outline-none [&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:transition-all [&::-webkit-slider-thumb]:hover:scale-110 [&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-primary [&::-moz-range-thumb]:shadow"
-          style={{ zIndex: minVal > max - 100 ? "40" : undefined }}
-        />
-        <input
-          type="range"
-          min={min}
-          max={max}
-          value={maxVal}
-          aria-label={`Maximum APR: ${maxVal}%`}
-          aria-valuemin={min}
-          aria-valuemax={max}
-          aria-valuenow={maxVal}
-          onChange={(event) => {
-            const val = Math.max(Number(event.target.value), minVal + 1);
-            onChange([minVal, val]);
-            maxValRef.current = val;
-          }}
-          className="pointer-events-none absolute z-30 h-1 w-full appearance-none bg-transparent outline-none [&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:transition-all [&::-webkit-slider-thumb]:hover:scale-110 [&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-primary [&::-moz-range-thumb]:shadow"
-        />
-
-        <div className="relative w-full">
-          <div className="h-1.5 w-full rounded bg-zinc-800" />
-          <div
-            ref={rangeRef}
-            className="absolute top-0 h-1.5 rounded bg-primary"
-          />
-        </div>
-      </div>
+      <RangeSlider
+        min={min}
+        max={max}
+        step={1}
+        value={value}
+        onChange={onChange}
+        formatLabel={(v) => `${v}%`}
+      />
     </div>
   );
 }

--- a/components/layout/PageTransition.tsx
+++ b/components/layout/PageTransition.tsx
@@ -7,19 +7,19 @@ export function PageTransition({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const reduced = useReducedMotion();
 
-  const variants = reduced
-    ? { initial: {}, animate: {}, exit: {} }
-    : {
-        initial: { opacity: 0, y: 10 },
-        animate: { opacity: 1, y: 0 },
-        exit: { opacity: 0, y: -6 },
-      };
+  if (reduced) {
+    return <div key={pathname}>{children}</div>;
+  }
 
   return (
     <AnimatePresence mode="wait" initial={false}>
       <motion.div
         key={pathname}
-        variants={variants}
+        variants={{
+          initial: { opacity: 0, y: 10 },
+          animate: { opacity: 1, y: 0 },
+          exit: { opacity: 0, y: -6 },
+        }}
         initial="initial"
         animate="animate"
         exit="exit"

--- a/components/transactions/InProgressOverlay.tsx
+++ b/components/transactions/InProgressOverlay.tsx
@@ -24,7 +24,7 @@ import {
   useTransaction,
   getProviderSigningConfig,
 } from "@/hooks/useTransaction";
-import { cn } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 
 /**
@@ -51,6 +51,45 @@ export function InProgressOverlay() {
   const signingConfig = getProviderSigningConfig(
     ("provider" in txState && txState.provider) || provider
   );
+
+  const getAnnouncementText = () => {
+    if (isEscrowActive) {
+      if (escrowState.errorMessage) {
+        return `Escrow transaction failed: ${escrowState.errorMessage}`;
+      }
+      if (escrowState.step === "settled") {
+        return "Escrow Settlement Complete";
+      }
+      if (escrowState.step === "buyer_funding") {
+        return "Escrow step 1: Buyer Deposit in progress";
+      }
+      if (escrowState.step === "seller_transferring") {
+        return "Escrow step 2: Seller Position Transfer in progress";
+      }
+      return "Escrow transaction in progress";
+    }
+    if (isTimeoutStage) {
+      return "Transaction signing request timed out. Please extend time, retry, or cancel safely.";
+    }
+    if (isSigningStage) {
+      return `Waiting for transaction signature from ${signingConfig.providerName || "your wallet"}. Please approve the request on your device.`;
+    }
+    if (txState.status === "submitting") {
+      return "Submitting transaction to the network...";
+    }
+    if (txState.status === "confirmed") {
+      return "Transaction confirmed";
+    }
+    if (txState.status === "failed") {
+      return "Transaction failed";
+    }
+    if (txState.status && txState.status !== "idle") {
+      return `Transaction status: ${txState.status}`;
+    }
+    return "";
+  };
+
+  const announcementText = getAnnouncementText();
 
   useEffect(() => {
     if (!isSigningStage) return;
@@ -237,6 +276,8 @@ export function InProgressOverlay() {
       </div>
     );
   };
+
+  return (
     <AnimatePresence>
       {isOpen && (
         <motion.div
@@ -253,6 +294,17 @@ export function InProgressOverlay() {
           aria-labelledby="overlay-title"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm focus:outline-none"
         >
+          {/* Accessible Live Region for Screen Readers */}
+          <div
+            role="status"
+            aria-live="assertive"
+            aria-atomic="true"
+            className="sr-only"
+            data-testid="tx-overlay-announcement"
+          >
+            {announcementText}
+          </div>
+
           <motion.div
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}

--- a/components/transactions/__tests__/InProgressOverlay.test.tsx
+++ b/components/transactions/__tests__/InProgressOverlay.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InProgressOverlay } from "../InProgressOverlay";
+import { useUIStore } from "@/store/uiStore";
+
+// Mock framer-motion to simplify DOM output
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+  useReducedMotion: () => false,
+}));
+
+// Mock useTransaction hook and providers
+vi.mock("@/hooks/useTransaction", () => ({
+  useTransaction: () => ({
+    cancel: vi.fn(),
+    extendTimeout: vi.fn(),
+  }),
+  useSecondaryEscrowFlow: () => ({
+    escrowState: { step: "idle", attemptHistory: [] },
+    retryEscrow: vi.fn(),
+    resetEscrow: vi.fn(),
+  }),
+  getProviderSigningConfig: () => ({
+    providerName: "Freighter",
+    category: "extension",
+    timeoutMs: 60000,
+    tips: ["Check browser extension popup"],
+  }),
+}));
+
+vi.mock("@/store/walletStore", () => ({
+  useWalletStore: (selector: any) => selector({ provider: "freighter" }),
+}));
+
+vi.mock("@/store/transactionStore", () => ({
+  useTransactionStore: () => ({
+    escrowState: { attemptHistory: [] },
+  }),
+}));
+
+describe("InProgressOverlay - Accessibility & Live Regions", () => {
+  beforeEach(() => {
+    useUIStore.setState({
+      txState: { status: "idle" },
+    });
+  });
+
+  it("does not render when txState is idle", () => {
+    render(<InProgressOverlay />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders with role=dialog, aria-modal=true, and live region during signing stage", () => {
+    useUIStore.setState({
+      txState: {
+        status: "signing",
+        startedAt: Date.now(),
+        timeoutMs: 60000,
+      },
+    });
+
+    render(<InProgressOverlay />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+
+    const liveRegion = screen.getByTestId("tx-overlay-announcement");
+    expect(liveRegion).toBeInTheDocument();
+    expect(liveRegion).toHaveAttribute("role", "status");
+    expect(liveRegion).toHaveAttribute("aria-live", "assertive");
+    expect(liveRegion).toHaveTextContent(/Waiting for transaction signature/i);
+  });
+
+  it("announces timeout when txState status is timeout", () => {
+    useUIStore.setState({
+      txState: {
+        status: "timeout",
+      },
+    });
+
+    render(<InProgressOverlay />);
+
+    const liveRegion = screen.getByTestId("tx-overlay-announcement");
+    expect(liveRegion).toHaveTextContent(/signing request timed out/i);
+  });
+});

--- a/components/ui/animations.test.tsx
+++ b/components/ui/animations.test.tsx
@@ -16,8 +16,13 @@ vi.mock("framer-motion", async (importOriginal) => {
   };
 });
 
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/test-path"),
+}));
+
 import { useReducedMotion } from "framer-motion";
 import { SuccessCheckmark, SpinnerCircle, SpinnerDots, SpinnerPulse } from "./animations";
+import { PageTransition } from "@/components/layout/PageTransition";
 
 const mockUseReducedMotion = vi.mocked(useReducedMotion);
 
@@ -78,6 +83,28 @@ describe("animations — prefers-reduced-motion", () => {
       mockUseReducedMotion.mockReturnValue(true);
       const { container } = render(<SpinnerPulse />);
       expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+
+  describe("PageTransition", () => {
+    it("renders children with animated wrapper when motion is enabled", () => {
+      mockUseReducedMotion.mockReturnValue(false);
+      render(
+        <PageTransition>
+          <div data-testid="page-child">Content</div>
+        </PageTransition>
+      );
+      expect(screen.getByTestId("page-child")).toBeInTheDocument();
+    });
+
+    it("renders children without motion animation when reduced motion is preferred", () => {
+      mockUseReducedMotion.mockReturnValue(true);
+      render(
+        <PageTransition>
+          <div data-testid="page-child">Content</div>
+        </PageTransition>
+      );
+      expect(screen.getByTestId("page-child")).toBeInTheDocument();
     });
   });
 });

--- a/components/ui/range-slider.tsx
+++ b/components/ui/range-slider.tsx
@@ -137,6 +137,11 @@ export function RangeSlider({
           step={step}
           value={minVal}
           disabled={disabled}
+          aria-label={`Minimum value: ${formatLabel(minVal)}`}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={minVal}
+          aria-valuetext={formatLabel(minVal)}
           onChange={(event) => {
             const val = Math.min(Number(event.target.value), maxVal - step);
             onChange([val, maxVal]);
@@ -147,7 +152,6 @@ export function RangeSlider({
           onKeyDown={(e) => handleKeyDown(e, 'min')}
           className="pointer-events-none absolute z-30 h-1 w-full appearance-none bg-transparent outline-none [&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:transition-all [&::-webkit-slider-thumb]:hover:scale-110 focus:[&::-webkit-slider-thumb]:scale-110 focus:[&::-webkit-slider-thumb]:ring-2 focus:[&::-webkit-slider-thumb]:ring-primary/50 focus:[&::-webkit-slider-thumb]:ring-offset-2 [&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-primary [&::-moz-range-thumb]:shadow [&::-moz-range-thumb]:transition-all [&::-moz-range-thumb]:hover:scale-110 focus:[&::-moz-range-thumb]:scale-110 focus:[&::-moz-range-thumb]:ring-2 focus:[&::-moz-range-thumb]:ring-primary/50"
           style={{ zIndex: minVal > max - 100 ? "40" : undefined }}
-          aria-label={`Minimum value: ${formatLabel(minVal)}`}
         />
         
         {/* Max range input */}
@@ -158,6 +162,11 @@ export function RangeSlider({
           step={step}
           value={maxVal}
           disabled={disabled}
+          aria-label={`Maximum value: ${formatLabel(maxVal)}`}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={maxVal}
+          aria-valuetext={formatLabel(maxVal)}
           onChange={(event) => {
             const val = Math.max(Number(event.target.value), minVal + step);
             onChange([minVal, val]);
@@ -167,7 +176,6 @@ export function RangeSlider({
           onMouseUp={() => setIsDragging(null)}
           onKeyDown={(e) => handleKeyDown(e, 'max')}
           className="pointer-events-none absolute z-30 h-1 w-full appearance-none bg-transparent outline-none [&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:transition-all [&::-webkit-slider-thumb]:hover:scale-110 focus:[&::-webkit-slider-thumb]:scale-110 focus:[&::-webkit-slider-thumb]:ring-2 focus:[&::-webkit-slider-thumb]:ring-primary/50 focus:[&::-webkit-slider-thumb]:ring-offset-2 [&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-primary [&::-moz-range-thumb]:shadow [&::-moz-range-thumb]:transition-all [&::-moz-range-thumb]:hover:scale-110 focus:[&::-moz-range-thumb]:scale-110 focus:[&::-moz-range-thumb]:ring-2 focus:[&::-moz-range-thumb]:ring-primary/50"
-          aria-label={`Maximum value: ${formatLabel(maxVal)}`}
         />
 
         {/* Track */}

--- a/e2e/components/range-slider.spec.ts
+++ b/e2e/components/range-slider.spec.ts
@@ -74,6 +74,13 @@ test.describe("RangeSlider component — keyboard interactions", () => {
     expect(label).toMatch(/maximum value/i);
   });
 
+  test("thumbs expose formatted aria-valuetext", async ({ page }) => {
+    const minValuetext = await getMinThumb(page).getAttribute("aria-valuetext");
+    const maxValuetext = await getMaxThumb(page).getAttribute("aria-valuetext");
+    expect(minValuetext).toBe("0%");
+    expect(maxValuetext).toBe("50%");
+  });
+
   test("both thumbs are keyboard-focusable (tabIndex is not -1)", async ({
     page,
   }) => {

--- a/lib/__tests__/uploadScanResult.test.ts
+++ b/lib/__tests__/uploadScanResult.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { parseUploadRejection } from "@/lib/uploadScanResult";
+
+describe("parseUploadRejection", () => {
+  describe("non-scan errors and empty inputs", () => {
+    it("returns rejected: false when body is null or undefined", () => {
+      expect(parseUploadRejection(null)).toEqual({ rejected: false, reason: "" });
+      expect(parseUploadRejection(undefined)).toEqual({ rejected: false, reason: "" });
+    });
+
+    it("returns rejected: false when body has no error property", () => {
+      expect(parseUploadRejection({})).toEqual({ rejected: false, reason: "" });
+    });
+
+    it("returns rejected: false for unrelated error messages", () => {
+      expect(parseUploadRejection({ error: "File size exceeds limit" })).toEqual({
+        rejected: false,
+        reason: "",
+      });
+      expect(parseUploadRejection({ error: "Unauthorized access" })).toEqual({
+        rejected: false,
+        reason: "",
+      });
+    });
+  });
+
+  describe("JSON stats payload parsing", () => {
+    it("parses valid stats with malicious and suspicious flags", () => {
+      const result = parseUploadRejection({
+        error: 'Virus scan failed: {"malicious":2,"suspicious":1,"harmless":70}',
+      });
+
+      expect(result.rejected).toBe(true);
+      expect(result.stats).toEqual({ malicious: 2, suspicious: 1, harmless: 70 });
+      expect(result.reason).toMatchInlineSnapshot(
+        `"This file was flagged by 3 security vendor(s) and cannot be uploaded."`
+      );
+    });
+
+    it("handles stats with only malicious vendors", () => {
+      const result = parseUploadRejection({
+        error: 'Virus scan failed: {"malicious":1}',
+      });
+
+      expect(result.rejected).toBe(true);
+      expect(result.stats).toEqual({ malicious: 1 });
+      expect(result.reason).toMatchInlineSnapshot(
+        `"This file was flagged by 1 security vendor(s) and cannot be uploaded."`
+      );
+    });
+
+    it("handles stats with zero detections", () => {
+      const result = parseUploadRejection({
+        error: 'Virus scan failed: {"malicious":0,"suspicious":0}',
+      });
+
+      expect(result.rejected).toBe(true);
+      expect(result.stats).toEqual({ malicious: 0, suspicious: 0 });
+      expect(result.reason).toMatchInlineSnapshot(
+        `"This file was flagged by 0 security vendor(s) and cannot be uploaded."`
+      );
+    });
+  });
+
+  describe("plain-text error fallback", () => {
+    it("falls back to plain-text detail message", () => {
+      const result = parseUploadRejection({
+        error: "Virus scan failed: Service temporarily unavailable",
+      });
+
+      expect(result.rejected).toBe(true);
+      expect(result.stats).toBeUndefined();
+      expect(result.reason).toMatchInlineSnapshot(
+        `"Service temporarily unavailable"`
+      );
+    });
+
+    it("uses default fallback reason when detail is empty or whitespace", () => {
+      const emptyResult = parseUploadRejection({
+        error: "Virus scan failed:",
+      });
+      expect(emptyResult.rejected).toBe(true);
+      expect(emptyResult.reason).toMatchInlineSnapshot(
+        `"This file failed our security scan and cannot be uploaded."`
+      );
+
+      const whitespaceResult = parseUploadRejection({
+        error: "Virus scan failed:    ",
+      });
+      expect(whitespaceResult.rejected).toBe(true);
+      expect(whitespaceResult.reason).toMatchInlineSnapshot(
+        `"This file failed our security scan and cannot be uploaded."`
+      );
+    });
+  });
+
+  describe("malformed bodies and non-object JSON", () => {
+    it("falls back to raw string when detail is malformed JSON", () => {
+      const result = parseUploadRejection({
+        error: "Virus scan failed: {malformed: json",
+      });
+
+      expect(result.rejected).toBe(true);
+      expect(result.stats).toBeUndefined();
+      expect(result.reason).toMatchInlineSnapshot(`"{malformed: json"`);
+    });
+
+    it("falls back to raw string when JSON is a primitive number or null", () => {
+      const numResult = parseUploadRejection({
+        error: "Virus scan failed: 500",
+      });
+      expect(numResult.rejected).toBe(true);
+      expect(numResult.stats).toBeUndefined();
+      expect(numResult.reason).toMatchInlineSnapshot(`"500"`);
+
+      const nullResult = parseUploadRejection({
+        error: "Virus scan failed: null",
+      });
+      expect(nullResult.rejected).toBe(true);
+      expect(nullResult.stats).toBeUndefined();
+      expect(nullResult.reason).toMatchInlineSnapshot(`"null"`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR addresses four targeted improvements across testing, accessibility, reduced motion preferences, and live region announcements:

### 1. #671 Add unit tests for `lib/uploadScanResult.ts`
- Added colocated unit tests in `lib/__tests__/uploadScanResult.test.ts`.
- Covers JSON stats payloads (`malicious`, `suspicious`), plain-text error fallbacks, non-scan errors returning `rejected: false`, and malformed/empty JSON bodies.
- Snapshots user-facing reason strings.

### 2. #668 Fix marketplace APR dual-slider keyboard accessibility
- Enhanced `components/ui/range-slider.tsx` with `aria-valuetext`, `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` attributes on both thumbs.
- Refactored `app/marketplace/page.tsx` to reuse `RangeSlider` with formatted APR value text (`${v}%`) and independent arrow-key keyboard navigation.
- Added test coverage in `e2e/components/range-slider.spec.ts` asserting formatted `aria-valuetext` on both slider thumbs.

### 3. #667 Honor `prefers-reduced-motion` in `PageTransition`
- Updated `components/layout/PageTransition.tsx` to skip framer-motion route transitions and perform an instant route swap when `prefers-reduced-motion: reduce` is active.
- Preserves standard route transitions when reduced motion is disabled and avoids hydration mismatch.
- Added test coverage in `components/ui/animations.test.tsx`.

### 4. #669 Add aria-live announcements to the transaction `InProgressOverlay`
- Added assertive live region (`role="status"`, `aria-live="assertive"`) in `components/transactions/InProgressOverlay.tsx` to announce state transitions (signing, submitting, timeout, escrow steps, and confirmation) for screen readers.
- Fixed syntax and missing utility imports in `InProgressOverlay.tsx`.
- Added unit tests in `components/transactions/__tests__/InProgressOverlay.test.tsx`.

---

## Linked Issues

Closes #671
Closes #668
Closes #667
Closes #669