### PR TITLE
feat(analytics): derive analytics time-series from live positions

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -36,6 +36,7 @@ import {
   positionsToExportRows,
   portfolioExportFilename,
   portfolioPdfFilename,
+  resolveDateRangeBounds,
 } from "@/lib/portfolioExport";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import {
@@ -49,56 +50,10 @@ import {
 import type { PresetRange } from "@/components/analytics/DateRangePicker";
 import {
   aggregatePositions,
+  buildPortfolioTimeSeries,
   marketplacePathForAllocation,
   allocationToMarketplaceFilters,
 } from "@/lib/portfolioAllocation";
-
-// ── Mock analytics data (time-series history; risk uses live positions) ───────
-
-const PORTFOLIO_HISTORY = [
-  { month: "Jan", value: 0 },
-  { month: "Feb", value: 12000 },
-  { month: "Mar", value: 25000 },
-  { month: "Apr", value: 48000 },
-  { month: "May", value: 72000 },
-  { month: "Jun", value: 0 },
-  { month: "Jul", value: 25000 },
-  { month: "Aug", value: 48000 },
-  { month: "Sep", value: 72000 },
-  { month: "Oct", value: 115000 },
-  { month: "Nov", value: 170000 },
-  { month: "Dec", value: 210000 },
-];
-
-const YIELD_HISTORY = [
-  { month: "Jan", yield: 0 },
-  { month: "Feb", yield: 180 },
-  { month: "Mar", yield: 420 },
-  { month: "Apr", yield: 890 },
-  { month: "May", yield: 1200 },
-  { month: "Jun", yield: 0 },
-  { month: "Jul", yield: 420 },
-  { month: "Aug", yield: 890 },
-  { month: "Sep", yield: 1540 },
-  { month: "Oct", yield: 2800 },
-  { month: "Nov", yield: 4200 },
-  { month: "Dec", yield: 5600 },
-];
-
-const MONTHLY_RETURNS = [
-  { month: "Jan", return: 0 },
-  { month: "Feb", return: 1.5 },
-  { month: "Mar", return: 1.68 },
-  { month: "Apr", return: 1.85 },
-  { month: "May", return: 2.0 },
-  { month: "Jun", return: 0 },
-  { month: "Jul", return: 1.68 },
-  { month: "Aug", return: 1.85 },
-  { month: "Sep", return: 2.14 },
-  { month: "Oct", return: 2.43 },
-  { month: "Nov", return: 2.47 },
-  { month: "Dec", return: 2.6 },
-];
 
 // ── URL ↔ filter helpers ───────────────────────────────────────────────────────
 
@@ -150,21 +105,6 @@ function filtersToParams(filters: AnalyticsFilters): URLSearchParams {
     p.set("to", to.toISOString().split("T")[0]);
   }
   return p;
-}
-
-// ── Slice helpers — filter mock data by date range ────────────────────────────
-
-function sliceByRange<T>(data: T[], range: PresetRange | "custom"): T[] {
-  const counts: Record<string, number> = {
-    "7d": 1,
-    "30d": 2,
-    "90d": 4,
-    "1y": 12,
-    ytd: 5,
-    all: data.length,
-    custom: data.length,
-  };
-  return data.slice(-(counts[range] ?? data.length));
 }
 
 // ── Page ──────────────────────────────────────────────────────────────────────
@@ -238,15 +178,16 @@ function PortfolioAnalyticsInner() {
     }
   }, [positionsData, filters, formatCurrency, formatPercentage]);
 
-  // Slice chart series based on active date-range filters
-  const portfolio = useMemo(
-    () => sliceByRange(PORTFOLIO_HISTORY, filters.dateRange),
-    [filters.dateRange]
-  );
-  const yieldData = useMemo(
-    () => sliceByRange(YIELD_HISTORY, filters.dateRange),
-    [filters.dateRange]
-  );
+  // The same filtered live positions drive the charts, table, and exports.
+  // Explicit mock mode is handled by usePositions; an empty live portfolio
+  // produces a zero baseline instead of fabricated growth.
+  const { portfolio, yieldData, monthly } = useMemo(() => {
+    const { from, to } = resolveDateRangeBounds(
+      filters.dateRange,
+      filters.customDateRange
+    );
+    return buildPortfolioTimeSeries(filteredPositions, to ?? from ?? new Date());
+  }, [filteredPositions, filters.dateRange, filters.customDateRange]);
   const risk = useMemo(() => {
     const slices = aggregatePositions(filteredPositions, "riskTier").map((s) => ({
       name: s.name,
@@ -256,11 +197,6 @@ function PortfolioAnalyticsInner() {
     if (filters.riskTier === "all") return slices;
     return slices.filter((d) => d.name === filters.riskTier);
   }, [filteredPositions, filters.riskTier]);
-  const monthly = useMemo(
-    () => sliceByRange(MONTHLY_RETURNS, filters.dateRange),
-    [filters.dateRange]
-  );
-
   const totalInvested = filteredPositions.reduce(
     (sum, position) => sum + position.investedAmount,
     0

--- a/components/analytics/AnalyticsCharts.tsx
+++ b/components/analytics/AnalyticsCharts.tsx
@@ -34,7 +34,12 @@ import {
   largestConcentration,
   toTreemapSeries,
 } from "@/lib/portfolioTreemap";
-import type { AllocatablePosition } from "@/lib/portfolioAllocation";
+import type {
+  AllocatablePosition,
+  MonthlyReturnPoint,
+  PortfolioValuePoint,
+  YieldPoint,
+} from "@/lib/portfolioAllocation";
 import { BENCHMARK_DISCLOSURE, getBenchmarkConfig, type BenchmarkConfig } from "@/lib/benchmarks";
 
 const TOOLTIP_STYLE = {
@@ -50,10 +55,10 @@ const TOOLTIP_STYLE = {
 };
 
 interface AnalyticsChartsProps {
-  portfolio: Array<{ month: string; value: number }>;
-  yieldData: Array<{ month: string; yield: number }>;
+  portfolio: PortfolioValuePoint[];
+  yieldData: YieldPoint[];
   risk: Array<{ name: string; value: number; color: string }>;
-  monthly: Array<{ month: string; return: number }>;
+  monthly: MonthlyReturnPoint[];
   isLoading?: boolean;
   compact?: boolean;
   onExport?: (type: "portfolio" | "yield" | "risk" | "monthly") => void;
@@ -94,11 +99,11 @@ function ChartSkeleton({ height = 220 }: { height?: number }) {
 // pattern for a data graphic with a text alternative.
 
 /** Render a time series as a sentence: title, point count, then every value. */
-function describeSeries(
+function describeSeries<T extends object>(
   title: string,
-  rows: Array<Record<string, unknown>>,
-  labelKey: string,
-  valueKey: string,
+  rows: T[],
+  labelKey: keyof T,
+  valueKey: keyof T,
   format: (value: number) => string
 ): string {
   if (rows.length === 0) return `${title}. No data available.`;

--- a/lib/__tests__/portfolioAllocation.test.ts
+++ b/lib/__tests__/portfolioAllocation.test.ts
@@ -5,11 +5,69 @@
 import { describe, it, expect } from "vitest";
 import {
   aggregatePositions,
+  buildPortfolioTimeSeries,
   filterPositionsByAllocation,
   allocationToMarketplaceFilters,
   marketplacePathForAllocation,
   type AllocatablePosition,
 } from "../portfolioAllocation";
+
+function timeSeriesPosition(investedAt: string, investedAmount: number, expectedReturn: number) {
+  return { investedAt, investedAmount, expectedReturn };
+}
+
+describe("buildPortfolioTimeSeries", () => {
+  it("groups live positions by month and builds cumulative portfolio value", () => {
+    const series = buildPortfolioTimeSeries([
+      timeSeriesPosition("2026-02-10T00:00:00.000Z", 500, 550),
+      timeSeriesPosition("2026-01-15T00:00:00.000Z", 1000, 1100),
+      timeSeriesPosition("2026-02-20T00:00:00.000Z", 1500, 1650),
+    ]);
+
+    expect(series.portfolio).toEqual([
+      { month: "Jan 2026", value: 1000 },
+      { month: "Feb 2026", value: 3000 },
+    ]);
+    expect(series.yieldData).toEqual([
+      { month: "Jan 2026", yield: 100 },
+      { month: "Feb 2026", yield: 200 },
+    ]);
+    expect(series.monthly).toEqual([
+      { month: "Jan 2026", return: 10 },
+      { month: "Feb 2026", return: 10 },
+    ]);
+  });
+
+  it("returns a zero baseline instead of fake growth for an empty portfolio", () => {
+    expect(buildPortfolioTimeSeries([], new Date("2026-08-27T12:00:00.000Z"))).toEqual({
+      portfolio: [{ month: "Aug 2026", value: 0 }],
+      yieldData: [{ month: "Aug 2026", yield: 0 }],
+      monthly: [{ month: "Aug 2026", return: 0 }],
+    });
+  });
+
+  it("ignores invalid dates and non-positive investments", () => {
+    const series = buildPortfolioTimeSeries(
+      [
+        timeSeriesPosition("not-a-date", 1000, 1100),
+        timeSeriesPosition("2026-01-01T00:00:00.000Z", 0, 100),
+      ],
+      new Date("2026-03-01T00:00:00.000Z")
+    );
+
+    expect(series.portfolio).toEqual([{ month: "Mar 2026", value: 0 }]);
+  });
+
+  it("clamps negative or invalid expected yield to zero", () => {
+    const series = buildPortfolioTimeSeries([
+      timeSeriesPosition("2026-01-15T00:00:00.000Z", 1000, 900),
+      timeSeriesPosition("2026-01-20T00:00:00.000Z", 500, Number.NaN),
+    ]);
+
+    expect(series.yieldData).toEqual([{ month: "Jan 2026", yield: 0 }]);
+    expect(series.monthly).toEqual([{ month: "Jan 2026", return: 0 }]);
+  });
+});
 
 function pos(
   investedAmount: number,

--- a/lib/portfolioAllocation.ts
+++ b/lib/portfolioAllocation.ts
@@ -26,6 +26,33 @@ export interface AllocatablePosition {
   } | null;
 }
 
+/** Minimal live-position shape needed for the analytics time-series. */
+export interface TimeSeriesPosition extends AllocatablePosition {
+  investedAt: string;
+  expectedReturn: number;
+}
+
+export interface PortfolioValuePoint {
+  month: string;
+  value: number;
+}
+
+export interface YieldPoint {
+  month: string;
+  yield: number;
+}
+
+export interface MonthlyReturnPoint {
+  month: string;
+  return: number;
+}
+
+export interface PortfolioTimeSeries {
+  portfolio: PortfolioValuePoint[];
+  yieldData: YieldPoint[];
+  monthly: MonthlyReturnPoint[];
+}
+
 export interface AllocationSlice {
   name: string;
   value: number;
@@ -69,6 +96,76 @@ const CATEGORY_PALETTE: string[] = [
 
 function getCategoryColor(index: number): string {
   return CATEGORY_PALETTE[index % CATEGORY_PALETTE.length];
+}
+
+function monthKey(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function monthLabel(key: string): string {
+  const [year, month] = key.split("-").map(Number);
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(Date.UTC(year, month - 1, 1)));
+}
+
+/**
+ * Build the chart series from live positions grouped by their investment month.
+ * Portfolio value is cumulative; expected yield and return rate are monthly.
+ * Invalid dates and non-positive investments are ignored.
+ */
+export function buildPortfolioTimeSeries(
+  positions: TimeSeriesPosition[],
+  baselineDate: Date = new Date()
+): PortfolioTimeSeries {
+  const buckets = new Map<string, { invested: number; expectedYield: number }>();
+
+  for (const position of positions) {
+    const investedAt = new Date(position.investedAt);
+    const invested = Number(position.investedAmount);
+    const expectedReturn = Number(position.expectedReturn);
+
+    if (Number.isNaN(investedAt.getTime()) || !Number.isFinite(invested) || invested <= 0) {
+      continue;
+    }
+
+    const key = monthKey(investedAt);
+    const bucket = buckets.get(key) ?? { invested: 0, expectedYield: 0 };
+    bucket.invested += invested;
+    bucket.expectedYield += Number.isFinite(expectedReturn)
+      ? Math.max(0, expectedReturn - invested)
+      : 0;
+    buckets.set(key, bucket);
+  }
+
+  if (buckets.size === 0) {
+    const month = monthLabel(monthKey(baselineDate));
+    return {
+      portfolio: [{ month, value: 0 }],
+      yieldData: [{ month, yield: 0 }],
+      monthly: [{ month, return: 0 }],
+    };
+  }
+
+  let portfolioValue = 0;
+  const portfolio: PortfolioValuePoint[] = [];
+  const yieldData: YieldPoint[] = [];
+  const monthly: MonthlyReturnPoint[] = [];
+
+  for (const [key, bucket] of [...buckets.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const month = monthLabel(key);
+    portfolioValue += bucket.invested;
+    portfolio.push({ month, value: portfolioValue });
+    yieldData.push({ month, yield: bucket.expectedYield });
+    monthly.push({
+      month,
+      return: (bucket.expectedYield / bucket.invested) * 100,
+    });
+  }
+
+  return { portfolio, yieldData, monthly };
 }
 
 function dimensionKey(


### PR DESCRIPTION
## Summary

Replace the analytics page’s static portfolio history, yield history, and monthly return data with time-series derived from live investor positions.

## Changes

- Group live positions into monthly buckets using `investedAt`
- Calculate expected yield as `expectedReturn - investedAmount`
- Build cumulative monthly portfolio values
- Derive monthly return percentages from invested principal and expected yield
- Apply the existing date-range and portfolio filters to the chart series
- Show a zero baseline when the filtered portfolio is empty
- Keep mock data limited to the existing explicit mock-data mode
- Ensure rendered exports use the same filtered chart series
- Add unit tests for:
  - Monthly aggregation
  - Chronological ordering
  - Cumulative portfolio values
  - Expected-yield calculations
  - Empty portfolio behavior
  - Invalid position data

## Validation

- Changed-file ESLint passed
- Relevant tests passed: 46/46
- Confirmed the branch contains only the four intended analytics files

Repository-wide lint, type-check, tests, and build remain blocked by pre-existing unrelated errors, including malformed JSX, duplicate declarations, missing imports, missing test environment variables, and incomplete internationalization test setup.

## Screenshots

Not included because existing unrelated build errors prevent the application from compiling locally.

Closes #649