### PR TITLE
feat(command-palette): add Secondary Market and Analytics coverage

### DIFF
--- a/components/command/CommandPalette.tsx
+++ b/components/command/CommandPalette.tsx
@@ -8,6 +8,7 @@ import {
   Store,
   LayoutDashboard,
   BarChart3,
+  ArrowLeftRight,
   PlusCircle,
   History,
   Wallet,
@@ -51,6 +52,12 @@ function HighlightMatch({ text, query }: { text: string; query: string }) {
 
 const PAGE_COMMANDS = [
   { id: "page-marketplace", label: "Marketplace", href: "/marketplace", icon: Store },
+  {
+    id: "page-secondary",
+    label: "Secondary Market",
+    href: "/secondary",
+    icon: ArrowLeftRight,
+  },
   { id: "page-invest", label: "Investor Dashboard", href: "/dashboard/investor", icon: BarChart3 },
   { id: "page-sme", label: "My Invoices", href: "/dashboard/sme", icon: LayoutDashboard },
   { id: "page-create", label: "Create Invoice", href: "/invoice/create", icon: PlusCircle },

--- a/components/command/__tests__/CommandPalette.test.tsx
+++ b/components/command/__tests__/CommandPalette.test.tsx
@@ -107,6 +107,22 @@ vi.mock("@/hooks/useInvoices", () => ({
   useInvoices: () => ({ data: { data: mockInvoices } }),
 }));
 
+vi.mock("@/hooks/useFormatters", () => ({
+  useFormatters: () => ({
+    formatCurrency: (value: number) => String(value),
+    formatPercentage: (value: number) => `${value.toFixed(0)}%`,
+  }),
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
 // cmdk may call scrollIntoView when moving the highlighted item — not implemented in jsdom.
 beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn();
@@ -224,6 +240,7 @@ describe("CommandPalette — invoice search", () => {
 describe("CommandPalette — navigation commands", () => {
   const PAGE_LABELS = [
     "Marketplace",
+    "Secondary Market",
     "Investor Dashboard",
     "My Invoices",
     "Create Invoice",
@@ -256,12 +273,38 @@ describe("CommandPalette — navigation commands", () => {
     expect(pushMock).toHaveBeenCalledWith("/transactions");
   });
 
+  it("surfaces Secondary Market from search and navigates with Enter", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CommandPalette />);
+
+    await typeQuery(user, "secondary");
+
+    expect(screen.getByTestId("nav-page-secondary")).toBeInTheDocument();
+    expect(screen.queryByTestId("nav-page-marketplace")).not.toBeInTheDocument();
+
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(pushMock).toHaveBeenCalledWith("/secondary");
+    expect(pushRecentMock).toHaveBeenCalledWith({
+      id: "/secondary",
+      label: "Secondary Market",
+      href: "/secondary",
+      type: "page",
+    });
+  });
+
   it("navigates to /analytics when Analytics is selected", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     render(<CommandPalette />);
 
     await user.click(screen.getByText("Analytics"));
     expect(pushMock).toHaveBeenCalledWith("/analytics");
+    expect(pushRecentMock).toHaveBeenCalledWith({
+      id: "/analytics",
+      label: "Analytics",
+      href: "/analytics",
+      type: "page",
+    });
   });
 
   it("filters page commands by search query", async () => {

--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -53,6 +53,7 @@ test.describe("Command Palette", () => {
 
     const expectedLabels = [
       "Marketplace",
+      "Secondary Market",
       "Investor Dashboard",
       "My Invoices",
       "Create Invoice",
@@ -94,6 +95,31 @@ test.describe("Command Palette", () => {
 
     await palette.getByText("Transaction History").click();
     await expect(page).toHaveURL(/\/transactions/, { timeout: 10_000 });
+  });
+
+  test("searching Secondary Market and pressing Enter navigates and records it", async ({
+    page,
+  }) => {
+    await page.keyboard.press("Control+k");
+    const palette = page.getByRole("dialog", { name: /command palette/i });
+    await expect(palette).toBeVisible({ timeout: 5_000 });
+
+    const input = palette.getByLabel("Command palette search");
+    await input.fill("secondary");
+    await expect(palette.getByText("Secondary Market")).toBeVisible();
+
+    await input.press("ArrowDown");
+    await input.press("Enter");
+
+    await expect(page).toHaveURL(/\/secondary/, { timeout: 10_000 });
+    const recent = await page.evaluate(() =>
+      JSON.parse(localStorage.getItem("kora-cmd-recent") ?? "[]")
+    );
+    expect(recent[0]).toMatchObject({
+      label: "Secondary Market",
+      href: "/secondary",
+      type: "page",
+    });
   });
 
   // ── Keyboard navigation ───────────────────────────────────────────────────────


### PR DESCRIPTION
## PR Description

### Summary

Adds the missing Secondary Market route to the command palette and extends navigation coverage for both Secondary Market and Analytics.

### Changes

* Added the **Secondary Market** command with an appropriate icon.
* Enabled searching for and navigating to `/secondary`.
* Confirmed page navigation is recorded in command-palette recents.
* Added unit tests for Secondary Market search, navigation, and recent-item tracking.
* Added recent-item coverage for the existing Analytics command.
* Extended the command-palette E2E tests.

### Validation

* [x] Changed-file ESLint passes.
* [x] Focused command-palette tests pass — 35/35.
* [ ] Full repository checks remain blocked by unrelated pre-existing lint, TypeScript, test, and build failures.
* [ ] Playwright execution is unavailable because `@playwright/test` is not currently installed.

Closes #645
