### PR TITLE
feat(keyboard): open ShortcutReferenceModal from palette and footer

### DIFF
--- a/components/command/CommandPalette.tsx
+++ b/components/command/CommandPalette.tsx
@@ -17,6 +17,7 @@ import {
   Zap,
   X,
   LogOut,
+  Keyboard,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCommandPalette } from "@/hooks/useCommandPalette";
@@ -264,7 +265,7 @@ export function CommandPalette() {
 
               {/* Actions */}
               {(showEmpty ||
-                ["connect wallet", "create invoice", "disconnect wallet"].some((a) =>
+                ["connect wallet", "create invoice", "disconnect wallet", "shortcuts", "keyboard shortcuts"].some((a) =>
                   a.includes(query.toLowerCase())
                 )) && (
                 <Command.Group
@@ -297,6 +298,17 @@ export function CommandPalette() {
                       onSelect={handleDisconnect}
                     />
                   )}
+                  <PaletteItem
+                    icon={<Keyboard className="h-4 w-4" />}
+                    label="Shortcuts"
+                    query={query}
+                    testId="action-shortcuts"
+                    onSelect={() =>
+                      runAction(() =>
+                        window.dispatchEvent(new CustomEvent("kora:open-shortcut-modal"))
+                      )
+                    }
+                  />
                 </Command.Group>
               )}
             </Command.List>

--- a/components/command/__tests__/CommandPalette.test.tsx
+++ b/components/command/__tests__/CommandPalette.test.tsx
@@ -409,3 +409,31 @@ describe("CommandPalette — recent items", () => {
     expect(setOpenMock).toHaveBeenCalledWith(false);
   });
 });
+
+// ── Shortcuts action (issue #709) ───────────────────────────────────────────
+
+describe("CommandPalette — shortcuts action", () => {
+  it("dispatches the global shortcut-modal event and closes the palette", async () => {
+    const listener = vi.fn();
+    window.addEventListener("kora:open-shortcut-modal", listener);
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CommandPalette />);
+
+    await user.click(screen.getByText("Shortcuts"));
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(setOpenMock).toHaveBeenCalledWith(false);
+
+    window.removeEventListener("kora:open-shortcut-modal", listener);
+  });
+
+  it("surfaces the Shortcuts action when searching", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CommandPalette />);
+
+    await typeQuery(user, "shortcut");
+
+    expect(screen.getByTestId("action-shortcuts")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #709

## Summary
- Adds a "Shortcuts" command to the command palette's Actions group. Selecting it (or finding it via search — "shortcuts"/"keyboard shortcuts") dispatches the same `kora:open-shortcut-modal` `window` event the footer's "Keyboard Shortcuts" link already uses.
- No changes needed to `Footer.tsx` or `KeyboardShortcutsProvider.tsx` — both were already correctly wired to that event; `ShortcutReferenceModal` stays mounted exactly once (inside `KeyboardShortcutsProvider`), so neither entry point creates a duplicate instance.
- Esc-to-close and focus return were already implemented/tested inside `ShortcutReferenceModal` itself and are unaffected by this change.

## Acceptance criteria
- [x] Command palette lists a Shortcuts command
- [x] Footer button opens the same modal (pre-existing, verified unchanged)
- [x] Modal is keyboard accessible (pre-existing, verified unchanged)
- [x] CommandPalette test updated
- [x] No duplicate modal instances mount (both entry points funnel through the same window event into the same singleton)

## Testing
- `npx vitest run components/command/__tests__/CommandPalette.test.tsx` — 23/23 passed (21 existing + 2 new)
- `npx eslint components/command/CommandPalette.tsx components/command/__tests__/CommandPalette.test.tsx` — clean
- `npx tsc --noEmit` — no new errors introduced by these two files (repo-wide `type-check`/`build`/`lint` are already soft-gated in CI due to a large pre-existing, unrelated error backlog on `main`, confirmed before starting this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)