### PR TITLE
feat(analytics): add portfolio digest mailto share action

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -18,7 +18,7 @@ import { StatCard } from "@/components/ui/stat-card";
 import { useWallet } from "@/hooks/useWallet";
 import { useFormatters } from "@/hooks/useFormatters";
 import { usePositions } from "@/hooks/usePositions";
-import { buildDigestDocument, digestFilename } from "@/lib/portfolioDigest";
+import { buildDigestDocument, buildDigestMailto, digestFilename } from "@/lib/portfolioDigest";
 import { renderDigestPdf } from "@/lib/portfolioDigestPdf";
 import {
   useUIStore,
@@ -157,25 +157,39 @@ function PortfolioAnalyticsInner() {
   // ── PDF digest (#602) ─────────────────────────────────────────────────────
   const [isGeneratingDigest, setIsGeneratingDigest] = useState(false);
 
-  const handleDownloadDigest = useCallback(async () => {
-    setIsGeneratingDigest(true);
-    try {
-      // Composed from the *unfiltered* list plus the active filters:
-      // `buildDigestDocument` re-applies them, so the PDF provably reflects
-      // the same rows the page is showing.
-      const doc = buildDigestDocument({
+  // Composed from the *unfiltered* list plus the active filters:
+  // `buildDigestDocument` re-applies them, so the digest provably reflects
+  // the same rows the page is showing. Shared by the PDF and mailto actions
+  // so both read from one source of truth.
+  const buildDigest = useCallback(
+    () =>
+      buildDigestDocument({
         positions: positionsData,
         filters,
         formatCurrency: (value) => formatCurrency(value, "USDC"),
         formatPercent: (value) => formatPercentage(value, 2),
-      });
-      await renderDigestPdf(doc, { filename: digestFilename() });
+      }),
+    [positionsData, filters, formatCurrency, formatPercentage]
+  );
+
+  const handleDownloadDigest = useCallback(async () => {
+    setIsGeneratingDigest(true);
+    try {
+      await renderDigestPdf(buildDigest(), { filename: digestFilename() });
     } catch (error) {
       console.error("[analytics] digest generation failed", error);
     } finally {
       setIsGeneratingDigest(false);
     }
-  }, [positionsData, filters, formatCurrency, formatPercentage]);
+  }, [buildDigest]);
+
+  // Issue #710: mailto share for advisors/forwarding — summary stats only,
+  // no position-level rows (see buildDigestMailto's doc comment for why).
+  const handleShareDigest = useCallback(() => {
+    window.location.href = buildDigestMailto(buildDigest(), (value) =>
+      formatCurrency(value, "USDC")
+    );
+  }, [buildDigest, formatCurrency]);
 
   // The same filtered live positions drive the charts, table, and exports.
   // Explicit mock mode is handled by usePositions; an empty live portfolio
@@ -336,6 +350,21 @@ function PortfolioAnalyticsInner() {
                 onClick={handleDownloadDigest}
               >
                 {isGeneratingDigest ? "Generating…" : "PDF Digest"}
+              </button>
+              {/*
+                Issue #710: one-click mailto for forwarding the digest summary
+                to an advisor — the PDF itself stays on-device, this only
+                opens the user's mail client with the summary pre-filled.
+              */}
+              <button
+                type="button"
+                disabled={!hasExportData}
+                aria-disabled={!hasExportData}
+                aria-label="Share portfolio digest via email"
+                className="rounded-md bg-zinc-800 px-3 py-1.5 text-sm text-zinc-200 transition-colors hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-zinc-800"
+                onClick={handleShareDigest}
+              >
+                Share via Email
               </button>
               <PrintButton />
             </div>


### PR DESCRIPTION
Closes #710

## Summary
- Adds a "Share via Email" button to the analytics toolbar, next to the existing Export CSV / Export PDF / PDF Digest buttons, using the same raw-button markup/classes for visual consistency (this page's toolbar buttons are plain text, no icons).
- Wires it to the existing `buildDigestMailto` helper in `lib/portfolioDigest.ts` (already implemented, already unit-tested — no changes needed there).
- Factored the `buildDigestDocument(...)` call out of `handleDownloadDigest` into a small `buildDigest()` `useCallback` so the PDF-download and new mailto handlers share one source of truth instead of duplicating the call.
- Disabled under the same `hasExportData` (empty-portfolio) gate the other three export buttons already use.
- No position-level rows go into the email body — `buildDigestMailto` only ever emits summary stats, by design (see its doc comment), which is exactly what "no position-level rows in mailto body" requires.

## Acceptance criteria
- [x] Button opens mailto with subject and summary body (via `buildDigestMailto`, already covered by unit tests: dated subject, no position rows, optional recipient)
- [x] No position-level rows in mailto body
- [x] Disabled when zero positions (`disabled={!hasExportData}`, same gate as the sibling export buttons)
- [x] PDF download still works (`handleDownloadDigest` behavior unchanged, just reads from the factored-out `buildDigest()`)
- [x] Unit test covers mailto encoding (pre-existing 3 tests in `lib/__tests__/portfolioDigest.test.ts` already cover `buildDigestMailto`'s shape; no lib-level behavior changed by this PR)

## Testing
- `npx vitest run lib/__tests__/portfolioDigest.test.ts` — 23/23 passed
- `npx eslint app/analytics/page.tsx` — clean
- `npx tsc --noEmit` — no new errors introduced by this file
- Manual in-browser verification wasn't possible in this environment: `main` currently 500s on every route in `npm run dev` due to pre-existing, unrelated breakage in the app shell (`components/layout/Navbar.tsx` references an undefined `tSettings`/`Settings` icon, which cascades into `components/wallet/WalletButton.tsx` referencing an undefined `useKycStatusSync`). Confirmed via `npx tsc --noEmit` that none of this pre-existing breakage touches `app/analytics/page.tsx`. Verified this change by reading the rendered JSX/handler wiring directly against the existing, working sibling buttons (Export CSV/PDF/PDF Digest) it mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)