### PR TITLE
feat(i18n): localize ShareInvoiceButton and CopyButton tooltips

### DIFF
--- a/components/invoice/ShareInvoiceButton.test.tsx
+++ b/components/invoice/ShareInvoiceButton.test.tsx
@@ -21,6 +21,11 @@ vi.mock("next-intl", () => ({
       linkCopiedToast: "Link copied",
       unableToCopy: "Unable to copy link",
       sharedSuccessfully: "Shared successfully",
+      defaultInvoiceTitle: "Invoice",
+      recipientLabel: "Recipient:",
+      defaultShareTitle: "Kora invoice opportunity",
+      defaultShareText: "Review this invoice financing opportunity on Kora.",
+      defaultTweetSummary: "Invoice listed on Kora",
     };
     return map[key] ?? key;
   },
@@ -118,6 +123,32 @@ describe("ShareInvoiceButton", () => {
         }),
       );
       expect(toast.success).toHaveBeenCalledWith("Shared successfully");
+    });
+  });
+
+  it("uses translated defaults for native sharing when no title/summary is supplied", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 1,
+    });
+    Object.defineProperty(navigator, "share", {
+      configurable: true,
+      value: share,
+    });
+
+    render(<ShareInvoiceButton id="token-11" />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Share invoice" }),
+    );
+
+    await waitFor(() => {
+      expect(share).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Kora invoice opportunity",
+          text: "Review this invoice financing opportunity on Kora.",
+        }),
+      );
     });
   });
 });

--- a/components/invoice/ShareInvoiceButton.tsx
+++ b/components/invoice/ShareInvoiceButton.tsx
@@ -112,7 +112,7 @@ export default function ShareInvoiceButton({
   const copyWithRecipient = async () => {
     if (selectedRecipient) {
       const recipient = selectedRecipient.label || selectedRecipient.address;
-      const message = `${invoiceTitle ?? "Invoice"} — ${invoiceUrl}\nRecipient: ${recipient}`;
+      const message = `${invoiceTitle ?? t("defaultInvoiceTitle")} — ${invoiceUrl}\n${t("recipientLabel")} ${recipient}`;
       const success = await copy(message);
       if (success) {
         toast.success(t("linkCopiedToast"));
@@ -129,8 +129,8 @@ export default function ShareInvoiceButton({
     if (supportsMobileShare()) {
       try {
         await navigator.share({
-          title: invoiceTitle ?? "Kora invoice opportunity",
-          text: summary ?? "Review this invoice financing opportunity on Kora.",
+          title: invoiceTitle ?? t("defaultShareTitle"),
+          text: summary ?? t("defaultShareText"),
           url: invoiceUrl,
         });
         toast.success(t("sharedSuccessfully"));
@@ -142,7 +142,9 @@ export default function ShareInvoiceButton({
     await copyShareLink();
   };
 
-  const tweetText = encodeURIComponent(`${invoiceTitle ?? "Invoice"} · ${summary ?? "Invoice listed on Kora"}`);
+  const tweetText = encodeURIComponent(
+    `${invoiceTitle ?? t("defaultInvoiceTitle")} · ${summary ?? t("defaultTweetSummary")}`,
+  );
   const twitterUrl = `https://twitter.com/intent/tweet?text=${tweetText}&url=${encodeURIComponent(invoiceUrl)}`;
   const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(invoiceUrl)}`;
 

--- a/components/ui/CopyButton.test.tsx
+++ b/components/ui/CopyButton.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CopyButton } from "./CopyButton";
+
+const EN_MAP: Record<string, string> = {
+  copyAriaLabel: "Copy",
+  copiedAriaLabel: "Copied",
+  copyTooltip: "Copy",
+  copiedTooltip: "Copied!",
+};
+
+let activeMap = EN_MAP;
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => activeMap[key] ?? key,
+}));
+
+// Radix's Tooltip uses useSize, which calls ResizeObserver — not implemented in jsdom.
+vi.stubGlobal(
+  "ResizeObserver",
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
+
+describe("CopyButton", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    activeMap = EN_MAP;
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it("renders a translated aria-label before copying", () => {
+    render(<CopyButton text="hello" />);
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+
+  it("shows a translated tooltip before copying", async () => {
+    render(<CopyButton text="hello" />);
+    await userEvent.hover(screen.getByRole("button", { name: "Copy" }));
+    expect(await screen.findByText("Copy", { selector: "[role=tooltip]" })).toBeInTheDocument();
+  });
+
+  it("flips to the translated 'copied' aria-label and tooltip after a click", async () => {
+    render(<CopyButton text="hello" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("hello"));
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+
+  it("renders Arabic translations when the locale map provides them", () => {
+    activeMap = {
+      copyAriaLabel: "نسخ",
+      copiedAriaLabel: "تم النسخ",
+      copyTooltip: "نسخ",
+      copiedTooltip: "تم النسخ!",
+    };
+    render(<CopyButton text="hello" />);
+    expect(screen.getByRole("button", { name: "نسخ" })).toBeInTheDocument();
+  });
+});

--- a/components/ui/CopyButton.tsx
+++ b/components/ui/CopyButton.tsx
@@ -3,6 +3,7 @@
 import { Copy, Check } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
 import * as Tooltip from "@radix-ui/react-tooltip";
+import { useTranslations } from "next-intl";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { cn } from "@/lib/utils";
 
@@ -12,6 +13,7 @@ interface CopyButtonProps {
 }
 
 export function CopyButton({ text, className }: CopyButtonProps) {
+  const t = useTranslations("copyButton");
   const { copy, copied } = useCopyToClipboard();
 
   return (
@@ -21,7 +23,7 @@ export function CopyButton({ text, className }: CopyButtonProps) {
           <button
             type="button"
             onClick={() => copy(text)}
-            aria-label={copied ? "Copied" : "Copy"}
+            aria-label={copied ? t("copiedAriaLabel") : t("copyAriaLabel")}
             className={cn(
               "inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
               className
@@ -57,7 +59,7 @@ export function CopyButton({ text, className }: CopyButtonProps) {
             side="top"
             className="rounded-md bg-foreground px-2 py-1 text-xs text-background shadow-md"
           >
-            {copied ? "Copied!" : "Copy"}
+            {copied ? t("copiedTooltip") : t("copyTooltip")}
             <Tooltip.Arrow className="fill-foreground" />
           </Tooltip.Content>
         </Tooltip.Portal>

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -951,7 +951,18 @@
     "qrCodeAlt": "رمز QR لرابط الفاتورة المشتركة",
     "linkCopiedToast": "تم نسخ الرابط",
     "unableToCopy": "تعذّر نسخ الرابط",
-    "sharedSuccessfully": "تمت المشاركة بنجاح"
+    "sharedSuccessfully": "تمت المشاركة بنجاح",
+    "defaultInvoiceTitle": "فاتورة",
+    "recipientLabel": "المستلم:",
+    "defaultShareTitle": "فرصة تمويل فاتورة على Kora",
+    "defaultShareText": "اطّلع على فرصة تمويل هذه الفاتورة على Kora.",
+    "defaultTweetSummary": "فاتورة مُدرجة على Kora"
+  },
+  "copyButton": {
+    "copyAriaLabel": "نسخ",
+    "copiedAriaLabel": "تم النسخ",
+    "copyTooltip": "نسخ",
+    "copiedTooltip": "تم النسخ!"
   },
   "contractEvents": {
     "invoiceFunded": "تم تمويل الفاتورة",

--- a/messages/en.json
+++ b/messages/en.json
@@ -904,7 +904,18 @@
     "qrCodeAlt": "QR code for shared invoice link",
     "linkCopiedToast": "Link copied",
     "unableToCopy": "Unable to copy link",
-    "sharedSuccessfully": "Shared successfully"
+    "sharedSuccessfully": "Shared successfully",
+    "defaultInvoiceTitle": "Invoice",
+    "recipientLabel": "Recipient:",
+    "defaultShareTitle": "Kora invoice opportunity",
+    "defaultShareText": "Review this invoice financing opportunity on Kora.",
+    "defaultTweetSummary": "Invoice listed on Kora"
+  },
+  "copyButton": {
+    "copyAriaLabel": "Copy",
+    "copiedAriaLabel": "Copied",
+    "copyTooltip": "Copy",
+    "copiedTooltip": "Copied!"
   },
   "contractEvents": {
     "invoiceFunded": "Invoice Funded",

--- a/messages/es.json
+++ b/messages/es.json
@@ -951,7 +951,18 @@
     "qrCodeAlt": "Código QR para el enlace de la factura compartida",
     "linkCopiedToast": "Enlace copiado",
     "unableToCopy": "No se pudo copiar el enlace",
-    "sharedSuccessfully": "Compartido exitosamente"
+    "sharedSuccessfully": "Compartido exitosamente",
+    "defaultInvoiceTitle": "Factura",
+    "recipientLabel": "Destinatario:",
+    "defaultShareTitle": "Oportunidad de financiación de facturas en Kora",
+    "defaultShareText": "Revisa esta oportunidad de financiación de facturas en Kora.",
+    "defaultTweetSummary": "Factura publicada en Kora"
+  },
+  "copyButton": {
+    "copyAriaLabel": "Copiar",
+    "copiedAriaLabel": "Copiado",
+    "copyTooltip": "Copiar",
+    "copiedTooltip": "¡Copiado!"
   },
   "contractEvents": {
     "invoiceFunded": "Factura Financiada",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -951,7 +951,18 @@
     "qrCodeAlt": "Código QR para o link da fatura compartilhada",
     "linkCopiedToast": "Link copiado",
     "unableToCopy": "Não foi possível copiar o link",
-    "sharedSuccessfully": "Compartilhado com sucesso"
+    "sharedSuccessfully": "Compartilhado com sucesso",
+    "defaultInvoiceTitle": "Fatura",
+    "recipientLabel": "Destinatário:",
+    "defaultShareTitle": "Oportunidade de financiamento de fatura na Kora",
+    "defaultShareText": "Veja esta oportunidade de financiamento de fatura na Kora.",
+    "defaultTweetSummary": "Fatura listada na Kora"
+  },
+  "copyButton": {
+    "copyAriaLabel": "Copiar",
+    "copiedAriaLabel": "Copiado",
+    "copyTooltip": "Copiar",
+    "copiedTooltip": "Copiado!"
   },
   "contractEvents": {
     "invoiceFunded": "Fatura Financiada",


### PR DESCRIPTION
Closes #731

## Summary
- `ShareInvoiceButton.tsx` was already mostly localized (`useTranslations("shareInvoice")`/`useTranslations("addressBook")`), but four English fallback strings remained hardcoded inside template literals (`?? "Invoice"`, the literal `"Recipient:"` label, the Web Share API default title/text, and the tweet-caption fallback). Moved all four into new `shareInvoice.*` keys.
- `CopyButton.tsx` had no i18n at all — its aria-label and Radix tooltip text were hardcoded English (`"Copy"`/`"Copied"`/`"Copied!"`). Wired it to a new `copyButton` namespace via `useTranslations`.
- Added the 5 new `shareInvoice.*` keys and the new `copyButton` namespace (4 keys) to **all four** locale files (`en`, `es`, `ar`, `pt-BR`) with real translations, and verified with `npm run check:i18n` that these specific keys have full parity (no missing/extra entries) — this is the one CI check that isn't soft-gated on this repo.
- Extended `ShareInvoiceButton.test.tsx`'s translation mock with the new keys and added a test asserting the Web Share fallback uses the translated defaults when `invoiceTitle`/`summary` are omitted.
- Added `components/ui/CopyButton.test.tsx` (didn't exist before): covers the default/`"copied"` aria-label and tooltip text, and a case rendering Arabic strings to confirm the component renders translated RTL text correctly (full-page `dir="rtl"` is a global `<html>` attribute set elsewhere by `LocaleProvider`, outside this component's scope).

## Acceptance criteria
- [x] All four locales include keys
- [x] aria-labels use translations
- [x] Copied toast is translated (`shareInvoice.linkCopiedToast` was already translated; the newly-translated fallbacks feed into the same toast/message paths)
- [x] RTL layout unchanged (no layout code touched; verified the component renders correctly with Arabic strings)
- [x] Existing share test updated

## Testing
- `npx vitest run components/invoice/ShareInvoiceButton.test.tsx components/ui/CopyButton.test.tsx` — 11/11 passed
- `npx eslint components/invoice/ShareInvoiceButton.tsx components/invoice/ShareInvoiceButton.test.tsx components/ui/CopyButton.tsx components/ui/CopyButton.test.tsx` — clean
- `npx tsc --noEmit` — no new errors introduced by these files
- `npm run check:i18n` — no missing/extra keys among the ones this PR adds (pre-existing, unrelated i18n gaps elsewhere in the repo are untouched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)