### PR TITLE
feat(secondary): add buyer accept-position transfer dialog

### DIFF
--- a/app/secondary/page.tsx
+++ b/app/secondary/page.tsx
@@ -23,10 +23,12 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import EmptyState from "@/components/ui/EmptyState";
+import { toast } from "sonner";
 import { TxSimulationPreview } from "@/components/invoice/TxSimulationPreview";
 import { AcquirePositionDialog } from "@/components/invoice/AcquirePositionDialog";
+import { AcceptTransferDialog } from "@/components/invoice/AcceptTransferDialog";
 import { FeeDisclosure } from "@/components/secondary/FeeDisclosure";
-import { useAcquirePositionFlow } from "@/hooks/useTransaction";
+import { useAcquirePositionFlow, useTransferPositionFlow } from "@/hooks/useTransaction";
 import { useWallet } from "@/hooks/useWallet";
 import { env } from "@/lib/env";
 import { computeAcquisitionFees, getFeeSchedule } from "@/lib/secondaryFees";
@@ -35,7 +37,7 @@ import { useInvoiceStore } from "@/store/invoiceStore";
 import { MOCK_INVOICES } from "@/services/mockData";
 import { RISK_TIER_COLORS, cn } from "@/lib/utils";
 import { computeImpliedDiscount } from "@/types/invoice";
-import type { Invoice } from "@/types/invoice";
+import type { Invoice, PositionListing } from "@/types/invoice";
 import { TENOR_OPTIONS, YIELD_OPTIONS } from "@/components/marketplace/filters";
 import { useTranslations } from "next-intl";
 import { useFormatters } from "@/hooks/useFormatters";
@@ -47,6 +49,13 @@ import {
   secondaryFiltersToQueryString,
   DEFAULT_SECONDARY_FILTERS,
 } from "@/lib/secondaryUrlFilters";
+import {
+  SECONDARY_SORT_OPTIONS,
+  DEFAULT_SECONDARY_SORT,
+  parseSecondarySort,
+  sortSecondaryItems,
+  type SecondarySortBy,
+} from "@/lib/secondarySort";
 
 interface SecondaryMarketItem {
   listing: PositionListing;
@@ -241,8 +250,20 @@ const MOCK_SECONDARY_LISTINGS: SecondaryMarketItem[] = [
 ];
 
 function SecondaryMarketplaceContent() {
+  const t = useTranslations("secondaryMarket");
+  const { formatCurrency, formatPercentage } = useFormatters();
+
   // Issue #594: acquire runs through the same simulation gate as fund/transfer.
   const { acquirePosition, simulationDialogProps } = useAcquirePositionFlow();
+  // Issue #732: buyer accept-position transfer — same simulation-gate pattern,
+  // its own TxSimulationPreview instance since useTxSimulation state is local
+  // to whichever flow hook renders it.
+  const {
+    acceptTransfer,
+    status: acceptStatus,
+    error: acceptError,
+    simulationDialogProps: acceptSimulationDialogProps,
+  } = useTransferPositionFlow();
   const { publicKey } = useWallet();
 
   // Issue #597: one schedule, read from validated env, shared by every figure
@@ -271,6 +292,8 @@ function SecondaryMarketplaceContent() {
   const [mobileFilterOpen, setMobileFilterOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [acquireItem, setAcquireItem] = useState<SecondaryMarketItem | null>(null);
+  const [acceptItem, setAcceptItem] = useState<SecondaryMarketItem | null>(null);
+  const [sortBy, setSortBy] = useState<SecondarySortBy>(DEFAULT_SECONDARY_SORT);
 
   // Debounce free-text inputs (seller + search) before committing to the URL.
   const debouncedSearch = useDebounce(searchQuery, 350);
@@ -311,7 +334,7 @@ function SecondaryMarketplaceContent() {
 
   // Combine store position listings with mock defaults
   const allItems: SecondaryMarketItem[] = useMemo(() => {
-    const combined = [...buildMockListings()];
+    const combined = [...MOCK_SECONDARY_LISTINGS];
 
     Object.values(storeListings).forEach((listing) => {
       if (combined.some((item) => item.positionId === listing.positionId)) return;
@@ -645,7 +668,7 @@ function SecondaryMarketplaceContent() {
                         fees={computeAcquisitionFees(item.listing.askPrice, feeSchedule)}
                       />
 
-                      {/* Action Button */}
+                      {/* Action Buttons */}
                       <Button
                         className="w-full mt-3 bg-primary text-primary-foreground hover:bg-primary/90 font-medium text-xs h-9"
                         onClick={() => {
@@ -661,6 +684,23 @@ function SecondaryMarketplaceContent() {
                         {publicKey ? t("acquirePosition") : t("connectWalletToAcquire")}
                         <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
                       </Button>
+
+                      {/* Issue #732: buyer accept-position transfer dialog shell */}
+                      <Button
+                        variant="outline"
+                        className="w-full mt-2 border-zinc-700 bg-zinc-950/60 text-xs text-zinc-300 hover:text-white h-9"
+                        onClick={() => {
+                          if (!publicKey) {
+                            toast.info(t("connectWalletToAcquire"), {
+                              description: "Please connect your wallet first.",
+                            });
+                            return;
+                          }
+                          setAcceptItem(item);
+                        }}
+                      >
+                        {t("acceptTransfer")}
+                      </Button>
                     </div>
                   </CardContent>
                 </Card>
@@ -672,6 +712,7 @@ function SecondaryMarketplaceContent() {
         {/* Issue #594: preview before signing; the dialog blocks proceed when
             the simulation fails. */}
         <TxSimulationPreview {...simulationDialogProps} />
+        <TxSimulationPreview {...acceptSimulationDialogProps} />
 
         {/* Issue #642: accessible acquire position dialog shell */}
         <AcquirePositionDialog
@@ -689,6 +730,22 @@ function SecondaryMarketplaceContent() {
               );
             }
           }}
+        />
+
+        {/* Issue #732: buyer accept-position transfer dialog shell */}
+        <AcceptTransferDialog
+          item={acceptItem}
+          open={acceptItem !== null}
+          onOpenChange={(open) => {
+            if (!open) setAcceptItem(null);
+          }}
+          onConfirm={() => {
+            if (acceptItem && publicKey) {
+              void acceptTransfer(acceptItem.positionId, publicKey);
+            }
+          }}
+          status={acceptStatus}
+          error={acceptError}
         />
 
         {/* Mobile Filter Bottom Sheet */}

--- a/components/invoice/AcceptTransferDialog.tsx
+++ b/components/invoice/AcceptTransferDialog.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertCircle, ArrowRight, Clock, Handshake, User } from "lucide-react";
+import { cn, RISK_TIER_COLORS } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useTranslations } from "next-intl";
+import type { TxLifecycleStatus } from "@/hooks/useTransaction";
+import type { Invoice } from "@/types/invoice";
+
+interface AcceptTransferDialogProps {
+  item: {
+    positionId: string;
+    invoice: Invoice | any;
+    expectedReturn: number;
+    sellerAddress: string;
+    remainingTenor: number;
+  } | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  /** Current lifecycle status of the accept-transfer transaction, if any. */
+  status?: TxLifecycleStatus;
+  /** Error surfaced by the flow (e.g. the NOT_IMPLEMENTED buyer-acceptance stub). */
+  error?: string;
+}
+
+const PENDING_STATUSES: TxLifecycleStatus[] = [
+  "building",
+  "simulating",
+  "signing",
+  "submitting",
+  "retrying",
+  "polling",
+];
+
+export function AcceptTransferDialog({
+  item,
+  open,
+  onOpenChange,
+  onConfirm,
+  status,
+  error,
+}: AcceptTransferDialogProps) {
+  const t = useTranslations("secondaryMarket.acceptDialog");
+
+  // Close automatically once the transfer confirms on-chain — kept open on
+  // failure so the inline NOT_IMPLEMENTED banner below stays visible.
+  useEffect(() => {
+    if (open && status === "confirmed") onOpenChange(false);
+  }, [open, status, onOpenChange]);
+
+  if (!item) return null;
+
+  const currency = item.invoice?.metadata?.currency ?? "USDC";
+  const isPending = status !== undefined && PENDING_STATUSES.includes(status);
+  const isFailed = status === "failed" && Boolean(error);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Handshake className="h-4 w-4 text-primary" aria-hidden />
+            {t("title")}
+          </DialogTitle>
+          <DialogDescription>{t("description")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Position Summary */}
+          <div className="rounded-lg border border-border bg-muted/30 p-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  {t("positionLabel")}
+                </p>
+                <p
+                  className="font-mono text-sm font-medium text-white"
+                  data-testid="accept-transfer-invoice-number"
+                >
+                  {item.invoice?.metadata?.invoiceNumber ?? `Invoice ${item.positionId}`}
+                </p>
+              </div>
+              <Badge
+                variant="outline"
+                className={cn(
+                  "text-[10px] uppercase",
+                  RISK_TIER_COLORS[item.invoice?.riskTier] ?? "text-zinc-400 border-zinc-700"
+                )}
+              >
+                {item.invoice?.riskTier}
+              </Badge>
+            </div>
+            <div className="mt-3 text-xs">
+              <span className="text-zinc-400 block text-[10px] uppercase tracking-wider">
+                {t("expectedReturn")}
+              </span>
+              <span className="font-semibold text-white text-sm">
+                {currency} {item.expectedReturn}
+              </span>
+            </div>
+          </div>
+
+          {/* Position Details */}
+          <div className="rounded-lg border border-border bg-muted/30 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+              {t("positionDetails")}
+            </p>
+            <div className="space-y-1.5 text-xs">
+              <div className="flex items-center justify-between text-zinc-400">
+                <span className="flex items-center gap-1.5">
+                  <Clock className="h-3.5 w-3.5 text-primary/80" />
+                  {t("remainingTenor")}
+                </span>
+                <span className="font-medium text-white">{item.remainingTenor} days remaining</span>
+              </div>
+
+              <div className="flex items-center justify-between text-zinc-400">
+                <span className="flex items-center gap-1.5">
+                  <User className="h-3.5 w-3.5 text-zinc-400" />
+                  {t("fromAddress")}
+                </span>
+                <span className="font-mono text-[11px] text-zinc-300">
+                  {item.sellerAddress.slice(0, 4)}...{item.sellerAddress.slice(-4)}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Graceful, actionable NOT_IMPLEMENTED / failure copy — no alert() */}
+          {isFailed && (
+            <div
+              className="rounded-lg border border-warning/30 bg-warning/5 p-3"
+              data-testid="accept-transfer-error-banner"
+              role="alert"
+            >
+              <div className="flex items-start gap-2">
+                <AlertCircle className="h-4 w-4 text-warning mt-0.5 flex-shrink-0" />
+                <div className="flex-1">
+                  <p className="text-xs font-semibold text-warning uppercase tracking-wider">
+                    {t("notImplementedTitle")}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">{error}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">{t("notImplementedHint")}</p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} data-testid="accept-transfer-cancel">
+            {t("cancel")}
+          </Button>
+          <Button
+            onClick={() => {
+              onConfirm();
+            }}
+            disabled={isPending}
+            data-testid="accept-transfer-confirm"
+          >
+            {isPending ? t("pending") : t("confirmAccept")}
+            <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/invoice/AcquirePositionDialog.tsx
+++ b/components/invoice/AcquirePositionDialog.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useFormatters } from "@/hooks/useFormatters";
 import { useTranslations } from "next-intl";
+import type { Invoice } from "@/types/invoice";
 
 interface AcquirePositionDialogProps {
   item: {
@@ -50,7 +51,7 @@ export function AcquirePositionDialog({
   onConfirm,
 }: AcquirePositionDialogProps) {
   const { formatCurrency, formatPercentage } = useFormatters();
-  useTranslations("secondaryMarket.acquireDialog");
+  const t = useTranslations("secondaryMarket.acquireDialog");
 
   if (!item) return null;
 
@@ -246,7 +247,10 @@ export function AcquirePositionDialog({
             {t("cancel")}
           </Button>
           <Button
-            onClick={handleConfirm}
+            onClick={() => {
+              onConfirm();
+              onOpenChange(false);
+            }}
             className={cn(
               isExtremeAlert && "border-destructive/30 hover:bg-destructive/10"
             )}

--- a/components/invoice/__tests__/AcceptTransferDialog.test.tsx
+++ b/components/invoice/__tests__/AcceptTransferDialog.test.tsx
@@ -1,0 +1,180 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { AcceptTransferDialog } from "../AcceptTransferDialog";
+import type { Invoice } from "@/types/invoice";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, any>) => {
+    const map: Record<string, string> = {
+      title: "Accept Position Transfer",
+      description: "Review the position details before accepting this transfer on the secondary market.",
+      positionLabel: "Position",
+      expectedReturn: "Expected Return",
+      positionDetails: "Position Details",
+      remainingTenor: "Remaining Tenor",
+      fromAddress: "From Address",
+      notImplementedTitle: "Not Yet Available",
+      notImplementedHint: "Buyer acceptance isn't available on-chain yet — check back once this contract path ships.",
+      cancel: "Cancel",
+      confirmAccept: "Accept Transfer",
+      pending: "Processing…",
+    };
+    return map[key] ?? key;
+  },
+}));
+
+const mockInvoice = {
+  metadata: { invoiceNumber: "INV-2026-001", currency: "USDC" },
+  riskTier: "AA",
+} as unknown as Invoice;
+
+const mockItem = {
+  positionId: "pos_101",
+  invoice: mockInvoice,
+  expectedReturn: 5000,
+  sellerAddress: "GSELLER1111111111111111111111111111111111111111111",
+  remainingTenor: 45,
+};
+
+describe("AcceptTransferDialog", () => {
+  const onConfirm = vi.fn();
+  const onOpenChange = vi.fn();
+  let alertSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  function getTestElement(testId: string) {
+    return document.querySelector(`[data-testid="${testId}"]`) as HTMLElement;
+  }
+
+  it("renders nothing when there is no item", () => {
+    const { container } = render(
+      <AcceptTransferDialog
+        item={null}
+        open={false}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+      />,
+    );
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+  });
+
+  it("renders the position summary and details", () => {
+    render(
+      <AcceptTransferDialog
+        item={mockItem}
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(getTestElement("accept-transfer-invoice-number").textContent).toBe("INV-2026-001");
+    expect(getTestElement("accept-transfer-confirm")).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when the Accept Transfer button is clicked", () => {
+    render(
+      <AcceptTransferDialog
+        item={mockItem}
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.click(getTestElement("accept-transfer-confirm"));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onOpenChange(false) when Cancel is clicked", () => {
+    render(
+      <AcceptTransferDialog
+        item={mockItem}
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.click(getTestElement("accept-transfer-cancel"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("disables the confirm button while the transaction is pending", () => {
+    render(
+      <AcceptTransferDialog
+        item={mockItem}
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        status="signing"
+      />,
+    );
+
+    expect(getTestElement("accept-transfer-confirm")).toBeDisabled();
+  });
+
+  it("shows an actionable NOT_IMPLEMENTED banner instead of alert() when the stub fails", () => {
+    render(
+      <AcceptTransferDialog
+        item={mockItem}
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        status="failed"
+        error="Buyer acceptance for transfer_position is not yet implemented"
+      />,
+    );
+
+    const banner = getTestElement("accept-transfer-error-banner");
+    expect(banner).toBeInTheDocument();
+    expect(banner.textContent).toContain("Buyer acceptance for transfer_position is not yet implemented");
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  it("does not show the error banner when there is no failure", () => {
+    render(
+      <AcceptTransferDialog
+        item={mockItem}
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(getTestElement("accept-transfer-error-banner")).not.toBeInTheDocument();
+  });
+
+  it("closes automatically once the status reaches confirmed", () => {
+    const { rerender } = render(
+      <AcceptTransferDialog
+        item={mockItem}
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        status="polling"
+      />,
+    );
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    rerender(
+      <AcceptTransferDialog
+        item={mockItem}
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        status="confirmed"
+      />,
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1101,8 +1101,23 @@
     "sellerAddress": "عنوان البائع",
     "acquirePosition": "الاستحواذ على المركز",
     "connectWalletToAcquire": "اتصل بالمحفظة للاستحواذ",
+    "acceptTransfer": "قبول النقل",
     "listingAria": "عرض ثانوي للفاتورة {invoiceNumber}",
     "listingAriaStale": "عرض ثانوي للفاتورة {invoiceNumber} — غير متاح، تم نقل المركز",
+    "acceptDialog": {
+      "title": "قبول نقل المركز",
+      "description": "راجع تفاصيل المركز قبل قبول هذا النقل في السوق الثانوية.",
+      "positionLabel": "المركز",
+      "expectedReturn": "العائد المتوقع",
+      "positionDetails": "تفاصيل المركز",
+      "remainingTenor": "المدة المتبقية",
+      "fromAddress": "عنوان المُرسِل",
+      "notImplementedTitle": "غير متاح بعد",
+      "notImplementedHint": "قبول المشتري غير متاح بعد على السلسلة — يُرجى المحاولة مرة أخرى بعد تفعيل هذا المسار في العقد.",
+      "cancel": "إلغاء",
+      "confirmAccept": "قبول النقل",
+      "pending": "جارٍ المعالجة…"
+    },
     "acquireDialog": {
       "title": "تأكيد الاستحواذ",
       "description": "راجع تفاصيل المركز قبل الاستحواذ عليه من السوق الثانوي.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1054,8 +1054,23 @@
     "sellerAddress": "Seller Address",
     "acquirePosition": "Acquire Position",
     "connectWalletToAcquire": "Connect Wallet to Acquire",
+    "acceptTransfer": "Accept Transfer",
     "listingAria": "Secondary listing for {invoiceNumber}",
     "listingAriaStale": "Secondary listing for {invoiceNumber} — stale, position transferred",
+    "acceptDialog": {
+      "title": "Accept Position Transfer",
+      "description": "Review the position details before accepting this transfer on the secondary market.",
+      "positionLabel": "Position",
+      "expectedReturn": "Expected Return",
+      "positionDetails": "Position Details",
+      "remainingTenor": "Remaining Tenor",
+      "fromAddress": "From Address",
+      "notImplementedTitle": "Not Yet Available",
+      "notImplementedHint": "Buyer acceptance isn't available on-chain yet — check back once this contract path ships.",
+      "cancel": "Cancel",
+      "confirmAccept": "Accept Transfer",
+      "pending": "Processing…"
+    },
     "acquireDialog": {
       "title": "Confirm Acquisition",
       "description": "Review the position details before acquiring this position on the secondary market.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1101,8 +1101,23 @@
     "sellerAddress": "Dirección del Vendedor",
     "acquirePosition": "Adquirir Posición",
     "connectWalletToAcquire": "Conectar Billetera para Adquirir",
+    "acceptTransfer": "Aceptar Transferencia",
     "listingAria": "Listado secundario para {invoiceNumber}",
     "listingAriaStale": "Listado secundario para {invoiceNumber} — no disponible, posición transferida",
+    "acceptDialog": {
+      "title": "Aceptar Transferencia de Posición",
+      "description": "Revisa los detalles de la posición antes de aceptar esta transferencia en el mercado secundario.",
+      "positionLabel": "Posición",
+      "expectedReturn": "Retorno Esperado",
+      "positionDetails": "Detalles de la Posición",
+      "remainingTenor": "Plazo Restante",
+      "fromAddress": "Dirección de Origen",
+      "notImplementedTitle": "Aún No Disponible",
+      "notImplementedHint": "La aceptación por parte del comprador aún no está disponible on-chain — vuelve a intentarlo cuando esta ruta del contrato esté habilitada.",
+      "cancel": "Cancelar",
+      "confirmAccept": "Aceptar Transferencia",
+      "pending": "Procesando…"
+    },
     "acquireDialog": {
       "title": "Confirmar Adquisición",
       "description": "Revisa los detalles de la posición antes de adquirirla en el mercado secundario.",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1101,8 +1101,23 @@
     "sellerAddress": "Endereço do Vendedor",
     "acquirePosition": "Adquirir Posição",
     "connectWalletToAcquire": "Conectar Carteira para Adquirir",
+    "acceptTransfer": "Aceitar Transferência",
     "listingAria": "Oferta secundária para {invoiceNumber}",
     "listingAriaStale": "Oferta secundária para {invoiceNumber} — indisponível, posição transferida",
+    "acceptDialog": {
+      "title": "Aceitar Transferência de Posição",
+      "description": "Revise os detalhes da posição antes de aceitar esta transferência no mercado secundário.",
+      "positionLabel": "Posição",
+      "expectedReturn": "Retorno Esperado",
+      "positionDetails": "Detalhes da Posição",
+      "remainingTenor": "Prazo Restante",
+      "fromAddress": "Endereço de Origem",
+      "notImplementedTitle": "Ainda Não Disponível",
+      "notImplementedHint": "A aceitação pelo comprador ainda não está disponível on-chain — volte a tentar quando esse caminho do contrato estiver disponível.",
+      "cancel": "Cancelar",
+      "confirmAccept": "Aceitar Transferência",
+      "pending": "Processando…"
+    },
     "acquireDialog": {
       "title": "Confirmar Aquisição",
       "description": "Revise os detalhes da posição antes de adquiri-la no mercado secundário.",


### PR DESCRIPTION
Closes #732

## Summary
- Adds `AcceptTransferDialog` (`components/invoice/AcceptTransferDialog.tsx`), structural parity with `AcquirePositionDialog` (same `Dialog`/`DialogHeader`/`DialogFooter` composition, same `Badge`/`RISK_TIER_COLORS` usage), minus the price-discount-specific alert blocks — accepting a P2P transfer isn't a priced purchase.
- Wired to `useTransferPositionFlow().acceptTransfer` (already existed, unchanged) — no changes needed to `hooks/useTransaction.ts` or `hooks/useTxSimulation.ts`.
- Simulation preview: mounts a second, independent `<TxSimulationPreview {...acceptSimulationDialogProps} />` instance on the secondary market page (each `useTxSimulation()` call owns its own dialog state, so this can't share Acquire's instance).
- `NOT_IMPLEMENTED` handling: `acceptTransfer` calls the documented stub `prepareAcceptPositionTransfer`, which throws — `useTransaction`'s existing `execute()` catch path already surfaces that gracefully via the app-wide `toast.error(...)` convention used by every other tx flow (fund/repay/claim/cancel/transfer/acquire), so no new error-plumbing was needed for that. On top of that toast, the dialog itself now shows an inline, actionable banner (`role="alert"`, not `window.alert()`) whenever `status === "failed"` — see the `accept-transfer-error-banner` test.
- Wallet-connect gating on the new "Accept Transfer" CTA mirrors the existing "Acquire Position" CTA's gate exactly (`if (!publicKey) { toast.info(...); return; }`).
- There's no data model distinguishing "positions pending my acceptance" from any other listing (checked `store/`/`types/` — nothing wires a listing to an intended buyer), so — matching how Acquire already works — the CTA lives on every secondary listing card, not a separate filtered list.

## Pre-existing bugs fixed (both files this feature depends on)
Both of these were **already broken on `main`**, unrelated to this issue, confirmed by running `npx tsc --noEmit`/`npm run type-check` on an unmodified checkout before starting:
- `components/invoice/AcquirePositionDialog.tsx`: `useTranslations(...)`'s return value was never assigned to `t`, and the Confirm button's `onClick` referenced an undefined `handleConfirm`. Fixed both (2-line fix) since this is the direct parity source `AcceptTransferDialog` mirrors, and it was failing to compile.
- `app/secondary/page.tsx`: `useTranslations()`/`useFormatters()` were imported but never invoked (`t(...)` calls referenced a `t` that didn't exist), `toast`/`sonner` was called without being imported, the sort controls referenced an undeclared `sortBy` state and unimported `SECONDARY_SORT_OPTIONS`/`parseSecondarySort`/`sortSecondaryItems` from `lib/secondarySort.ts`, and the listings memo called an undefined `buildMockListings()` (only a `MOCK_SECONDARY_LISTINGS` const exists). This is the exact file the new feature needs to compile in, so these were fixed as a direct prerequisite — not a broader unrelated cleanup. Every `t("...")` key already existed in `messages/en.json`'s `secondaryMarket` namespace, so this was pure wiring, no new copy needed for the fix itself.

I did **not** touch the large body of other pre-existing, unrelated TypeScript/lint/test failures elsewhere in the repo (`components/wallet/AddressBook.tsx`, `WalletButton.tsx`, `store/walletStore.ts`, etc.) — those are out of scope for this issue and are already soft-gated in CI (see workflow comments referencing commit `64ce34e2`).

## Acceptance criteria
- [x] Dialog opens from secondary listing CTA
- [x] Simulation preview shown before sign (via `useTxSimulation`/`TxSimulationPreview`, same gate as every other tx flow)
- [x] NOT_IMPLEMENTED shows actionable copy not alert() (inline banner + test asserting `window.alert` is never called)
- [x] Wallet connect gating works (same gate as Acquire Position)
- [x] Component or integration test added (`components/invoice/__tests__/AcceptTransferDialog.test.tsx`, 8 tests)

## i18n
Added a new `secondaryMarket.acceptDialog` namespace (sibling of the existing `acquireDialog`) plus `secondaryMarket.acceptTransfer`, to **all four** locale files (`en`, `es`, `ar`, `pt-BR`) with real translations — verified with `npm run check:i18n` that these specific keys have full parity.

## Testing
- `npx vitest run components/invoice/__tests__/AcceptTransferDialog.test.tsx` — 8/8 passed
- `npx eslint components/invoice/AcquirePositionDialog.tsx components/invoice/AcceptTransferDialog.tsx components/invoice/__tests__/AcceptTransferDialog.test.tsx app/secondary/page.tsx` — clean
- `npx tsc --noEmit` — no errors in any of the files this PR touches (confirmed both pre-existing bugs above are actually fixed, and no new errors introduced)
- `npm run check:i18n` — no missing/extra keys among the ones this PR adds
- Manual in-browser verification wasn't possible in this environment: unrelated pre-existing breakage in the app shell (`components/layout/Navbar.tsx` / `components/wallet/WalletButton.tsx`, see the sibling #710 PR for details) currently 500s every route in `npm run dev` on `main`. Verified this change by direct code review against the working `AquirePositionDialog`/`TxSimulationPreview` patterns it mirrors, plus the automated test coverage above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)