### PR TITLE
feat(pwa,data): wire InstallPrompt analytics and investor StaleDataBadge

### DIFF
--- a/__tests__/install-prompt-analytics.test.ts
+++ b/__tests__/install-prompt-analytics.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for the PWA InstallPrompt analytics wiring (Issue #708).
+ *
+ * InstallPrompt now calls the helpers in lib/installPromptAnalytics.ts on show,
+ * install acceptance, and dismiss. These cover the local event log the helper
+ * always writes (so the metric survives when no analytics SDK is loaded) and
+ * assert that no PII leaks into the payload.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  trackInstallPromptShown,
+  trackInstallPromptAccepted,
+  trackInstallPromptDismissed,
+  getLocalInstallPromptEvents,
+  detectInstallCohort,
+} from "@/lib/installPromptAnalytics";
+
+const EVENTS_KEY = "kora-install-prompt-events";
+
+describe("installPromptAnalytics", () => {
+  beforeEach(() => {
+    localStorage.removeItem(EVENTS_KEY);
+  });
+
+  it("records a shown event", () => {
+    trackInstallPromptShown(1);
+    const events = getLocalInstallPromptEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].name).toBe("install_prompt_shown");
+    expect(events[0].visitCount).toBe(1);
+  });
+
+  it("records install and dismiss outcomes", () => {
+    trackInstallPromptAccepted(2);
+    trackInstallPromptDismissed(3);
+    expect(getLocalInstallPromptEvents().map((e) => e.name)).toEqual([
+      "install_prompt_accepted",
+      "install_prompt_dismissed",
+    ]);
+  });
+
+  it("carries no PII — only cohort, visit count and timestamp", () => {
+    trackInstallPromptAccepted(1);
+    const [event] = getLocalInstallPromptEvents();
+    expect(Object.keys(event).sort()).toEqual([
+      "cohort",
+      "name",
+      "timestamp",
+      "visitCount",
+    ]);
+  });
+
+  it("segments cohort by route", () => {
+    expect(detectInstallCohort("/dashboard/sme")).toBe("sme");
+    expect(detectInstallCohort("/marketplace")).toBe("investor");
+    expect(detectInstallCohort("/about")).toBe("unknown");
+  });
+});

--- a/app/dashboard/investor/page.tsx
+++ b/app/dashboard/investor/page.tsx
@@ -37,6 +37,7 @@ import { computeImpliedDiscount } from "@/types/invoice";
 import type { ColumnDef, DataTableProps } from "@/types/table";
 import { InvestorDashboardSkeleton } from "@/components/ui/skeleton";
 import { KycStatusCard } from "@/components/dashboard/KycStatusCard";
+import { StaleDataBadge } from "@/components/layout/StaleDataBadge";
 import { SellerAnalyticsDashboard } from "@/components/analytics/SellerAnalyticsDashboard";
 
 const DataTable = dynamic<DataTableProps<InvestorPosition>>(
@@ -480,6 +481,10 @@ export default function InvestorDashboardPage() {
           <p className="mt-1 text-sm text-muted-foreground">
             {t("subtitle")}
           </p>
+          <StaleDataBadge
+            updatedAt={positionsQuery.dataUpdatedAt || null}
+            className="mt-2"
+          />
         </div>
         <Link href="/marketplace">
           <Button variant="outline">

--- a/components/pwa/InstallPrompt.tsx
+++ b/components/pwa/InstallPrompt.tsx
@@ -24,6 +24,11 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { X, Download } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTranslations } from "next-intl";
+import {
+  trackInstallPromptShown,
+  trackInstallPromptAccepted,
+  trackInstallPromptDismissed,
+} from "@/lib/installPromptAnalytics";
 
 // ─── LocalStorage keys ────────────────────────────────────────────────────────
 
@@ -88,6 +93,7 @@ export function InstallPrompt() {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [visible, setVisible] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const visitCountRef = useRef(0);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -105,6 +111,7 @@ export function InstallPrompt() {
 
     // Increment visit count for this session
     const visitCount = incrementVisitCount();
+    visitCountRef.current = visitCount;
 
     const handler = (e: Event) => {
       e.preventDefault();
@@ -114,10 +121,12 @@ export function InstallPrompt() {
       if (visitCount >= 2) {
         // 2nd+ visit: show immediately when the event fires
         setVisible(true);
+        trackInstallPromptShown(visitCount);
       } else {
         // 1st visit: wait 30 seconds before showing
         timerRef.current = setTimeout(() => {
           setVisible(true);
+          trackInstallPromptShown(visitCount);
         }, FIRST_VISIT_DELAY_MS);
       }
     };
@@ -136,6 +145,9 @@ export function InstallPrompt() {
     if (outcome === "accepted") {
       // Permanent dismiss — user installed the app
       suppressForDays(365 * 10);
+      trackInstallPromptAccepted(visitCountRef.current);
+    } else {
+      trackInstallPromptDismissed(visitCountRef.current);
     }
     setDeferredPrompt(null);
     setVisible(false);
@@ -143,6 +155,7 @@ export function InstallPrompt() {
 
   const handleDismiss = useCallback(() => {
     suppressForDays(SUPPRESS_DAYS);
+    trackInstallPromptDismissed(visitCountRef.current);
     setVisible(false);
     setDeferredPrompt(null);
     if (timerRef.current !== null) {

--- a/docs/analytics-events.md
+++ b/docs/analytics-events.md
@@ -156,3 +156,18 @@ trackMarketplaceFundCta(searchParams, filterCount, sortBy);
 | `hooks/useInvoices.ts`            | No change required                                |
 | `middleware.ts`                   | No change required                                |
 | `lib/installPromptAnalytics.ts`   | Same transport pattern (reference implementation) |
+
+---
+
+## PWA Install Prompt (Issue #708)
+
+`components/pwa/InstallPrompt.tsx` emits these via `lib/installPromptAnalytics.ts`:
+
+| Event                       | Fired when                                        |
+|-----------------------------|---------------------------------------------------|
+| `install_prompt_shown`      | Banner becomes visible (immediately on 2nd+ visit, after the 30s delay on first visit) |
+| `install_prompt_accepted`   | `userChoice` resolves with `accepted`             |
+| `install_prompt_dismissed`  | "Not now"/× pressed, or `userChoice` resolves with `dismissed` |
+
+Payload is `{ name, cohort, visitCount, timestamp }` — cohort is derived from the
+current route (`sme` / `investor` / `unknown`). No PII is included.


### PR DESCRIPTION
- InstallPrompt now emits install_prompt_shown/accepted/dismissed via lib/installPromptAnalytics.ts (Closes #708)
- Investor dashboard renders StaleDataBadge from the positions query dataUpdatedAt, matching the marketplace header (Closes #711)
- Document the install prompt events in docs/analytics-events.md
- Add a unit test for the install prompt analytics helper

## Summary

- 

## Linked Issue

Closes #

## What Changed

- 
- 

## Testing Steps

1.
2.
3.

## Screenshots or Recordings

Add before/after screenshots for UI changes, especially invoice, SME dashboard, investor marketplace, position, and wallet states.

## Checklist

- [ ] Tests added or updated
- [ ] Docs updated, if needed
- [ ] Accessibility checked
- [ ] Wallet and network behavior considered
- [ ] SME, investor, invoice, or position terminology is accurate
- [ ] No secrets, private keys, real wallet seed phrases, or live credentials added

## Notes for Reviewers

Call out any migration steps, mocked data, incomplete contract wiring, or areas that need focused review.
Closes #708
Closes #712
Closes #713
Closes #711 